### PR TITLE
zkcq + cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target
+Cargo.lock
+.DS_Store
+*.swp

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+tab_spaces = 2
+max_width = 150
+chain_width = 130

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -1,3 +1,4 @@
+#![allow(unused_variables)]
 use ark_poly::univariate::DensePolynomial;
 use ark_poly::{GeneralEvaluationDomain, EvaluationDomain};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine};
@@ -38,23 +39,31 @@ impl DataEnc{
 pub trait BasicBlock{
   fn run(model: &Vec<Fr>,
          inputs: &Vec<Vec<Fr>>) ->
-         Vec<Fr>;
+         Vec<Fr>{
+    Vec::new()
+  }
   fn setup(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
            model: &Data) ->
-          (Vec<G1Affine>,Vec<G2Affine>);
+          (Vec<G1Affine>,Vec<G2Affine>){
+    (Vec::new(),Vec::new())
+  }
   fn prove<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
                    setup: (&Vec<G1Affine>,&Vec<G2Affine>),
                    model: &Data,
                    inputs: &Vec<Data>,
                    output: &Data,
                    rng: &mut R) ->
-                  (Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>);
+                  (Vec<G1Affine>,Vec<G2Affine>){
+    (Vec::new(), Vec::new())
+  }
   fn verify<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
                     model: &DataEnc,
                     inputs: &Vec<DataEnc>,
                     output: &DataEnc,
-                    proof: (&Vec<G1Affine>,&Vec<G2Affine>,&Vec<Fr>),
-                    rng: &mut R);
+                    proof: (&Vec<G1Affine>,&Vec<G2Affine>),
+                    rng: &mut R){
+    ()
+  }
 }
 
 

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -1,69 +1,73 @@
 #![allow(unused_variables)]
-use ark_poly::univariate::DensePolynomial;
-use ark_poly::{GeneralEvaluationDomain, EvaluationDomain};
-use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine};
-use rand::Rng;
 use crate::util;
+pub use add::AddBasicBlock;
+use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine};
+use ark_poly::univariate::DensePolynomial;
+use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 pub use cq::CQBasicBlock;
 pub use cqlin::CQLinBasicBlock;
 pub use mul::MulBasicBlock;
-pub use add::AddBasicBlock;
+use rand::Rng;
+pub mod add;
 pub mod cq;
 pub mod cqlin;
 pub mod mul;
-pub mod add;
 
-pub struct Data{
-  pub raw : Vec<Fr>,
+pub struct Data {
+  pub raw: Vec<Fr>,
   pub poly: DensePolynomial<Fr>,
-  pub g1: G1Affine
+  pub g1: G1Affine,
 }
-impl Data{
-  pub fn new(srs:(&Vec<G1Affine>,&Vec<G2Affine>), raw:&Vec<Fr>) -> Data{
+impl Data {
+  pub fn new(srs: (&Vec<G1Affine>, &Vec<G2Affine>), raw: &Vec<Fr>) -> Data {
     let N = (*raw).len();
-    let domain  = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
-    let f = DensePolynomial{coeffs: domain.ifft(raw)};
+    let domain = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
+    let f = DensePolynomial { coeffs: domain.ifft(raw) };
     let fx: G1Affine = util::msm::<G1Projective>(&srs.0[..N], &f.coeffs).into();
-    return Data{raw: raw.to_vec(), poly: f, g1: fx};
+    return Data {
+      raw: raw.to_vec(),
+      poly: f,
+      g1: fx,
+    };
   }
 }
-pub struct DataEnc{
-  pub len : usize,
-  pub g1: G1Affine
+pub struct DataEnc {
+  pub len: usize,
+  pub g1: G1Affine,
 }
-impl DataEnc{
-  pub fn new(data:&Data) -> DataEnc{
-    return DataEnc{len: data.raw.len(), g1: data.g1};
+impl DataEnc {
+  pub fn new(data: &Data) -> DataEnc {
+    return DataEnc {
+      len: data.raw.len(),
+      g1: data.g1,
+    };
   }
 }
-pub trait BasicBlock{
-  fn run(model: &Vec<Fr>,
-         inputs: &Vec<Vec<Fr>>) ->
-         Vec<Fr>{
+pub trait BasicBlock {
+  fn run(model: &Vec<Fr>, inputs: &Vec<Vec<Fr>>) -> Vec<Fr> {
     Vec::new()
   }
-  fn setup(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-           model: &Data) ->
-          (Vec<G1Affine>,Vec<G2Affine>){
-    (Vec::new(),Vec::new())
-  }
-  fn prove<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-                   setup: (&Vec<G1Affine>,&Vec<G2Affine>),
-                   model: &Data,
-                   inputs: &Vec<Data>,
-                   output: &Data,
-                   rng: &mut R) ->
-                  (Vec<G1Affine>,Vec<G2Affine>){
+  fn setup(srs: (&Vec<G1Affine>, &Vec<G2Affine>), model: &Data) -> (Vec<G1Affine>, Vec<G2Affine>) {
     (Vec::new(), Vec::new())
   }
-  fn verify<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-                    model: &DataEnc,
-                    inputs: &Vec<DataEnc>,
-                    output: &DataEnc,
-                    proof: (&Vec<G1Affine>,&Vec<G2Affine>),
-                    rng: &mut R){
+  fn prove<R: Rng>(
+    srs: (&Vec<G1Affine>, &Vec<G2Affine>),
+    setup: (&Vec<G1Affine>, &Vec<G2Affine>),
+    model: &Data,
+    inputs: &Vec<Data>,
+    output: &Data,
+    rng: &mut R,
+  ) -> (Vec<G1Affine>, Vec<G2Affine>) {
+    (Vec::new(), Vec::new())
+  }
+  fn verify<R: Rng>(
+    srs: (&Vec<G1Affine>, &Vec<G2Affine>),
+    model: &DataEnc,
+    inputs: &Vec<DataEnc>,
+    output: &DataEnc,
+    proof: (&Vec<G1Affine>, &Vec<G2Affine>),
+    rng: &mut R,
+  ) {
     ()
   }
 }
-
-

--- a/src/basic_block/add.rs
+++ b/src/basic_block/add.rs
@@ -1,28 +1,27 @@
+use super::{BasicBlock, DataEnc};
 use ark_bn254::{Fr, G1Affine, G2Affine};
 use rand::Rng;
-use super::{BasicBlock,DataEnc};
 
 pub struct AddBasicBlock;
-impl BasicBlock for AddBasicBlock{
-  fn run(_model: &Vec<Fr>,
-         inputs: &Vec<Vec<Fr>>) ->
-         Vec<Fr>{
+impl BasicBlock for AddBasicBlock {
+  fn run(_model: &Vec<Fr>, inputs: &Vec<Vec<Fr>>) -> Vec<Fr> {
     let mut r = Vec::new();
-    for i in 0..inputs[0].len(){
-      r.push(inputs[0][i]+inputs[1][i]);
+    for i in 0..inputs[0].len() {
+      r.push(inputs[0][i] + inputs[1][i]);
     }
     return r;
   }
-  fn verify<R: Rng>(_srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-                    _model: &DataEnc,
-                    inputs: &Vec<DataEnc>,
-                    output: &DataEnc,
-                    _proof: (&Vec<G1Affine>,&Vec<G2Affine>),
-                    _rng: &mut R){
+  fn verify<R: Rng>(
+    _srs: (&Vec<G1Affine>, &Vec<G2Affine>),
+    _model: &DataEnc,
+    inputs: &Vec<DataEnc>,
+    output: &DataEnc,
+    _proof: (&Vec<G1Affine>, &Vec<G2Affine>),
+    _rng: &mut R,
+  ) {
     // Verify f(x)+g(x)=h(x)
-    let lhs = inputs[0].g1+inputs[1].g1;
+    let lhs = inputs[0].g1 + inputs[1].g1;
     let rhs = output.g1;
-    assert!(lhs==rhs);
+    assert!(lhs == rhs);
   }
 }
-

--- a/src/basic_block/add.rs
+++ b/src/basic_block/add.rs
@@ -1,6 +1,6 @@
 use ark_bn254::{Fr, G1Affine, G2Affine};
 use rand::Rng;
-use super::{BasicBlock,Data,DataEnc};
+use super::{BasicBlock,DataEnc};
 
 pub struct AddBasicBlock;
 impl BasicBlock for AddBasicBlock{
@@ -13,25 +13,11 @@ impl BasicBlock for AddBasicBlock{
     }
     return r;
   }
-  fn setup(_srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-           _model: &Data) ->
-          (Vec<G1Affine>,Vec<G2Affine>){
-    return (Vec::new(), Vec::new());
-  }
-  fn prove<R: Rng>(_srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-                   _setup: (&Vec<G1Affine>,&Vec<G2Affine>),
-                   _model: &Data,
-                   _inputs: &Vec<Data>,
-                   _output: &Data,
-                   _rng: &mut R) ->
-                  (Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>){
-    return (Vec::new(), Vec::new(), Vec::new());
-  }
   fn verify<R: Rng>(_srs: (&Vec<G1Affine>,&Vec<G2Affine>),
                     _model: &DataEnc,
                     inputs: &Vec<DataEnc>,
                     output: &DataEnc,
-                    _proof: (&Vec<G1Affine>,&Vec<G2Affine>,&Vec<Fr>),
+                    _proof: (&Vec<G1Affine>,&Vec<G2Affine>),
                     _rng: &mut R){
     // Verify f(x)+g(x)=h(x)
     let lhs = inputs[0].g1+inputs[1].g1;

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use ark_ec::{AffineRepr, pairing::Pairing};
+use ark_ec::pairing::Pairing;
 use ark_ff::Field;
 use ark_poly::{evaluations::univariate::Evaluations, GeneralEvaluationDomain, EvaluationDomain,univariate::DensePolynomial, Polynomial};
 use ark_bn254::{Fr, G1Projective, G2Projective, G1Affine, G2Affine, Bn254};
@@ -13,11 +13,6 @@ use crate::util;
 
 pub struct CQBasicBlock;
 impl BasicBlock for CQBasicBlock{
-  fn run(_model: &Vec<Fr>,
-         _inputs: &Vec<Vec<Fr>>) ->
-         Vec<Fr>{
-    return Vec::new();
-  }
   fn setup(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
            model: &Data) ->
           (Vec<G1Affine>,Vec<G2Affine>){
@@ -40,9 +35,9 @@ impl BasicBlock for CQBasicBlock{
     let mut L_i_0_x_1 = L_i_x_1.clone();
     let temp = srs.0[N-1] * Fr::from(N as u64).inverse().unwrap();
     L_i_0_x_1.par_iter_mut().enumerate().for_each(|(i,x)| *x = *x * domain_N.group_gen_inv().pow(&[i as u64]) - temp);
-    let Q_i_x_1 : Vec<G1Affine> = Q_i_x_1.iter().map(|x| (*x).into()).collect();
-    let L_i_x_1 : Vec<G1Affine> = L_i_x_1.iter().map(|x| (*x).into()).collect();
-    let L_i_0_x_1 : Vec<G1Affine> = L_i_0_x_1.iter().map(|x| (*x).into()).collect();
+    let Q_i_x_1 : Vec<G1Affine> = Q_i_x_1.par_iter().map(|x| (*x).into()).collect();
+    let L_i_x_1 : Vec<G1Affine> = L_i_x_1.par_iter().map(|x| (*x).into()).collect();
+    let L_i_0_x_1 : Vec<G1Affine> = L_i_0_x_1.par_iter().map(|x| (*x).into()).collect();
     let mut setup = Q_i_x_1;
     setup.extend(L_i_x_1);
     setup.extend(L_i_0_x_1);
@@ -54,7 +49,7 @@ impl BasicBlock for CQBasicBlock{
                    inputs: &Vec<Data>,
                    _output: &Data,
                    rng: &mut R) ->
-                  (Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>){
+                  (Vec<G1Affine>,Vec<G2Affine>){
     let N = model.raw.len();
     let n = inputs[0].raw.len();
     let domain_n  = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
@@ -109,20 +104,30 @@ impl BasicBlock for CQBasicBlock{
     let pi_gamma = util::msm::<G1Projective>(&srs.0[..n-1],&h).into();
     let (temp, temp2) : (Vec<G1Affine>,Vec<Fr>)=A_i.iter().map(|(i,y)| (L_i_0_x_1[*i], *y)).unzip();
     let A_0_x = util::msm::<G1Projective>(&temp, &temp2).into();
-    return (vec![m_x_1,A_x_1,Q_A_x_1,B_0_x_1,Q_B_x_1,P_x_1,pi_gamma,A_0_x],vec![setup.1[0]],vec![B_0_gamma,f_gamma,A_0]);
+
+    let B_0_gamma_1 = (srs.0[0] * B_0_gamma).into();
+    let b_gamma_1 = (srs.0[0] * b_gamma).into();
+    let f_gamma_1 = (srs.0[0] * f_gamma).into();
+    let f_gamma_2 = (srs.1[0] * f_gamma).into();
+    let A_0_1 = (srs.0[0] * A_0).into();
+    let b_gamma_f_gamma = (srs.0[0] * (b_gamma * (f_gamma + beta))).into();
+
+    return (vec![m_x_1,A_x_1,Q_A_x_1,B_0_x_1,Q_B_x_1,P_x_1,pi_gamma,A_0_x,
+                 B_0_gamma_1,b_gamma_1,f_gamma_1,A_0_1,b_gamma_f_gamma],
+            vec![setup.1[0],f_gamma_2]);
   }
   fn verify<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
                     model: &DataEnc,
                     inputs: &Vec<DataEnc>,
                     _output: &DataEnc,
-                    proof: (&Vec<G1Affine>,&Vec<G2Affine>,&Vec<Fr>),
+                    proof: (&Vec<G1Affine>,&Vec<G2Affine>),
                     rng: &mut R){
     let N = model.len;
     let n = inputs[0].len;
     let domain_n  = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
-    let [m_x_1,A_x_1,Q_A_x_1,B_0_x_1,Q_B_x_1,P_x_1,pi_gamma,A_0_x] = proof.0[..] else{panic!("Wrong proof format")};
-    let [T_x_2] = proof.1[..] else{panic!("Wrong proof format")};
-    let [B_0_gamma,f_gamma,A_0] = proof.2[..] else{panic!("Wrong proof format")};
+    let [m_x_1,A_x_1,Q_A_x_1,B_0_x_1,Q_B_x_1,P_x_1,pi_gamma,A_0_x,
+         B_0_gamma_1,b_gamma_1,f_gamma_1,A_0_1,b_gamma_f_gamma] = proof.0[..] else{panic!("Wrong proof format")};
+    let [T_x_2,f_gamma_2] = proof.1[..] else{panic!("Wrong proof format")};
 
     // Round 2
     let beta = Fr::rand(rng);
@@ -135,19 +140,25 @@ impl BasicBlock for CQBasicBlock{
     let rhs = Bn254::pairing(P_x_1,srs.1[0]);
     assert!(lhs==rhs);
 
+    // Check b_gamma_f_gamma
+    let lhs = Bn254::pairing(b_gamma_1,f_gamma_2 + srs.1[0] * beta);
+    let rhs = Bn254::pairing(b_gamma_f_gamma, srs.1[0]);
+    assert!(lhs==rhs);
+    let lhs = Bn254::pairing(f_gamma_1,srs.1[0]);
+    let rhs = Bn254::pairing(srs.0[0],f_gamma_2);
+    assert!(lhs==rhs);
+
     // Round 3
     let gamma = Fr::rand(rng);
     let eta = Fr::rand(rng);
-    let b_0 = Fr::from(N as u32) * A_0 * Fr::from(n as u32).inverse().unwrap();
     let Z_H_gamma = domain_n.evaluate_vanishing_polynomial(gamma);
-    let b_gamma = B_0_gamma * gamma + b_0;
-    let Q_b_gamma = (b_gamma * (f_gamma + beta) - Fr::one()) * Z_H_gamma.inverse().unwrap();
-    let v = B_0_gamma + eta * f_gamma + eta * eta * Q_b_gamma;
+    let Q_b_gamma_1 = (b_gamma_f_gamma - srs.0[0]) * Z_H_gamma.inverse().unwrap();
+    let v = B_0_gamma_1 + f_gamma_1 * eta + Q_b_gamma_1 * eta * eta;
     let c = B_0_x_1 + inputs[0].g1 * eta + Q_B_x_1 * eta * eta;
-    let lhs = Bn254::pairing(c - G1Affine::generator() * v + pi_gamma * gamma, srs.1[0]);
+    let lhs = Bn254::pairing(c - v + pi_gamma * gamma, srs.1[0]);
     let rhs = Bn254::pairing(pi_gamma, srs.1[1]);
     assert!(lhs==rhs);
-    let lhs = Bn254::pairing(A_x_1 -  G1Affine::generator() * A_0, srs.1[0]);
+    let lhs = Bn254::pairing(A_x_1 -  A_0_1, srs.1[0]);
     let rhs = Bn254::pairing(A_0_x, srs.1[1]);
     assert!(lhs==rhs);
   }

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -1,108 +1,114 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
+use super::{BasicBlock, Data, DataEnc};
+use crate::util;
+use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::pairing::Pairing;
 use ark_ff::Field;
-use ark_poly::{evaluations::univariate::Evaluations, GeneralEvaluationDomain, EvaluationDomain,univariate::DensePolynomial, Polynomial};
-use ark_bn254::{Fr, G1Projective, G2Projective, G1Affine, G2Affine, Bn254};
-use ark_std::{Zero, One, ops::{Mul,Div,Sub}, UniformRand};
-use std::collections::HashMap;
+use ark_poly::{evaluations::univariate::Evaluations, univariate::DensePolynomial, EvaluationDomain, GeneralEvaluationDomain, Polynomial};
+use ark_std::{
+  ops::{Div, Mul, Sub},
+  One, UniformRand, Zero,
+};
 use rand::Rng;
 use rayon::prelude::*;
-use super::{BasicBlock,Data,DataEnc};
-use crate::util;
+use std::collections::HashMap;
 
 pub struct CQBasicBlock;
-impl BasicBlock for CQBasicBlock{
-  fn setup(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-           model: &Data) ->
-          (Vec<G1Affine>,Vec<G2Affine>){
+impl BasicBlock for CQBasicBlock {
+  fn setup(srs: (&Vec<G1Affine>, &Vec<G2Affine>), model: &Data) -> (Vec<G1Affine>, Vec<G2Affine>) {
     let N = model.raw.len();
-    let domain_2N  = GeneralEvaluationDomain::<Fr>::new(2*N).unwrap();
-    let domain_N  = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
-    let srs_p : Vec<G1Projective> = srs.0[..N].iter().map(|x| (*x).into()).collect();
+    let domain_2N = GeneralEvaluationDomain::<Fr>::new(2 * N).unwrap();
+    let domain_N = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
+    let srs_p: Vec<G1Projective> = srs.0[..N].iter().map(|x| (*x).into()).collect();
     let T_x_2 = util::msm::<G2Projective>(&srs.1[..N], &model.poly.coeffs).into();
     let mut temp = model.poly.coeffs[1..].to_vec();
-    temp.resize(N*2-1,Fr::zero());
+    temp.resize(N * 2 - 1, Fr::zero());
     let mut temp2 = srs_p.to_vec();
     temp2.reverse();
     let mut Q_i_x_1 = util::toeplitz_mul(domain_2N, &temp, &temp2);
     util::fft_in_place(domain_N, &mut Q_i_x_1);
     let temp = Fr::from(N as u32).inverse().unwrap();
-    let temp2 = domain_N.group_gen_inv().pow(&[(N-1) as u64]);
-    Q_i_x_1.par_iter_mut().enumerate().for_each(|(i,x)| *x *= temp * temp2.pow(&[i as u64]));
+    let temp2 = domain_N.group_gen_inv().pow(&[(N - 1) as u64]);
+    Q_i_x_1.par_iter_mut().enumerate().for_each(|(i, x)| *x *= temp * temp2.pow(&[i as u64]));
     let mut L_i_x_1 = srs_p;
     util::ifft_in_place(domain_N, &mut L_i_x_1);
     let mut L_i_0_x_1 = L_i_x_1.clone();
-    let temp = srs.0[N-1] * Fr::from(N as u64).inverse().unwrap();
-    L_i_0_x_1.par_iter_mut().enumerate().for_each(|(i,x)| *x = *x * domain_N.group_gen_inv().pow(&[i as u64]) - temp);
-    let Q_i_x_1 : Vec<G1Affine> = Q_i_x_1.par_iter().map(|x| (*x).into()).collect();
-    let L_i_x_1 : Vec<G1Affine> = L_i_x_1.par_iter().map(|x| (*x).into()).collect();
-    let L_i_0_x_1 : Vec<G1Affine> = L_i_0_x_1.par_iter().map(|x| (*x).into()).collect();
+    let temp = srs.0[N - 1] * Fr::from(N as u64).inverse().unwrap();
+    L_i_0_x_1.par_iter_mut().enumerate().for_each(|(i, x)| *x = *x * domain_N.group_gen_inv().pow(&[i as u64]) - temp);
+    let Q_i_x_1: Vec<G1Affine> = Q_i_x_1.par_iter().map(|x| (*x).into()).collect();
+    let L_i_x_1: Vec<G1Affine> = L_i_x_1.par_iter().map(|x| (*x).into()).collect();
+    let L_i_0_x_1: Vec<G1Affine> = L_i_0_x_1.par_iter().map(|x| (*x).into()).collect();
     let mut setup = Q_i_x_1;
     setup.extend(L_i_x_1);
     setup.extend(L_i_0_x_1);
-    return (setup,vec![T_x_2]);
+    return (setup, vec![T_x_2]);
   }
-  fn prove<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-                   setup: (&Vec<G1Affine>,&Vec<G2Affine>),
-                   model: &Data,
-                   inputs: &Vec<Data>,
-                   _output: &Data,
-                   rng: &mut R) ->
-                  (Vec<G1Affine>,Vec<G2Affine>){
+  fn prove<R: Rng>(
+    srs: (&Vec<G1Affine>, &Vec<G2Affine>),
+    setup: (&Vec<G1Affine>, &Vec<G2Affine>),
+    model: &Data,
+    inputs: &Vec<Data>,
+    _output: &Data,
+    rng: &mut R,
+  ) -> (Vec<G1Affine>, Vec<G2Affine>) {
     let N = model.raw.len();
     let n = inputs[0].raw.len();
-    let domain_n  = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
+    let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
 
     // gen(N, t):
     let Q_i_x_1 = &setup.0[..N];
-    let L_i_x_1 = &setup.0[N..2*N];
-    let L_i_0_x_1 = &setup.0[2*N..];
+    let L_i_x_1 = &setup.0[N..2 * N];
+    let L_i_0_x_1 = &setup.0[2 * N..];
     let mut table_dict = HashMap::new();
-    for i in 0..N{
-      table_dict.insert(model.raw[i],i);
+    for i in 0..N {
+      table_dict.insert(model.raw[i], i);
     }
 
     // Round 1
     let mut m_i = HashMap::new();
-    for i in 0..n{
-      m_i.entry(table_dict.get(&inputs[0].raw[i]).unwrap()).and_modify(|x| *x+=1).or_insert(1);
+    for i in 0..n {
+      m_i.entry(table_dict.get(&inputs[0].raw[i]).unwrap()).and_modify(|x| *x += 1).or_insert(1);
     }
-    let (temp, temp2) : (Vec<G1Affine>,Vec<Fr>)=m_i.iter().map(|(i,y)| (L_i_x_1[**i], Fr::from(*y as u32))).unzip();
+    let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.iter().map(|(i, y)| (L_i_x_1[**i], Fr::from(*y as u32))).unzip();
     let m_x_1 = util::msm::<G1Projective>(&temp, &temp2).into();
 
     //Round 2
     let beta = Fr::rand(rng);
-    let A_i : HashMap<usize,Fr>= m_i.iter().map(|(i,y)| (**i,Fr::from(*y as u32) * (model.raw[**i]+beta).inverse().unwrap())).collect();
-    let (temp, temp2) : (Vec<G1Affine>,Vec<Fr>)=A_i.iter().map(|(i,y)| (L_i_x_1[*i], *y)).unzip();
+    let A_i: HashMap<usize, Fr> = m_i.iter().map(|(i, y)| (**i, Fr::from(*y as u32) * (model.raw[**i] + beta).inverse().unwrap())).collect();
+    let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_x_1[*i], *y)).unzip();
     let A_x_1 = util::msm::<G1Projective>(&temp, &temp2).into();
-    let (temp, temp2) : (Vec<G1Affine>,Vec<Fr>)=A_i.iter().map(|(i,y)| (Q_i_x_1[*i], *y)).unzip();
+    let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (Q_i_x_1[*i], *y)).unzip();
     let Q_A_x_1 = util::msm::<G1Projective>(&temp, &temp2).into();
-    let B_i : Vec<Fr>= (0..n).map(|i| (inputs[0].raw[i]+beta).inverse().unwrap()).collect();
+    let B_i: Vec<Fr> = (0..n).map(|i| (inputs[0].raw[i] + beta).inverse().unwrap()).collect();
     let B = Evaluations::from_vec_and_domain(B_i.clone(), domain_n).interpolate();
-    let B_0 = DensePolynomial{coeffs : B.coeffs[1..].to_vec()};
-    let B_0_x_1 = util::msm::<G1Projective>(&srs.0[0..n-1], &B_0).into();
-    let mut Q_B = B.mul(&(inputs[0].poly.clone() + (DensePolynomial{coeffs:vec![beta]})));
-    Q_B = Q_B.sub(&DensePolynomial{coeffs:vec![Fr::one()]}).divide_by_vanishing_poly(domain_n).unwrap().0;
-    let Q_B_x_1 = util::msm::<G1Projective>(&srs.0[0..n-1], &Q_B).into();
-    let P_x_1 = util::msm::<G1Projective>(&srs.0[N-n+1..N], &B_0).into();
+    let B_0 = DensePolynomial {
+      coeffs: B.coeffs[1..].to_vec(),
+    };
+    let B_0_x_1 = util::msm::<G1Projective>(&srs.0[0..n - 1], &B_0).into();
+    let mut Q_B = B.mul(&(inputs[0].poly.clone() + (DensePolynomial { coeffs: vec![beta] })));
+    Q_B = Q_B.sub(&DensePolynomial { coeffs: vec![Fr::one()] }).divide_by_vanishing_poly(domain_n).unwrap().0;
+    let Q_B_x_1 = util::msm::<G1Projective>(&srs.0[0..n - 1], &Q_B).into();
+    let P_x_1 = util::msm::<G1Projective>(&srs.0[N - n + 1..N], &B_0).into();
 
     //Round 3
     let gamma = Fr::rand(rng);
     let eta = Fr::rand(rng);
     let B_0_gamma = B_0.evaluate(&gamma);
     let f_gamma = inputs[0].poly.evaluate(&gamma);
-    let A_0 = Fr::from(N as u32).inverse().unwrap() * A_i.iter().map(|(_,y)| *y).sum::<Fr>();
+    let A_0 = Fr::from(N as u32).inverse().unwrap() * A_i.iter().map(|(_, y)| *y).sum::<Fr>();
     let b_0 = Fr::from(N as u32) * A_0 * Fr::from(n as u32).inverse().unwrap();
     let Z_H_gamma = domain_n.evaluate_vanishing_polynomial(gamma);
     let b_gamma = B_0_gamma * gamma + b_0;
     let Q_b_gamma = (b_gamma * (f_gamma + beta) - Fr::one()) * Z_H_gamma.inverse().unwrap();
     let v = B_0_gamma + eta * f_gamma + eta * eta * Q_b_gamma;
-    let mut num = B_0 + inputs[0].poly.mul(eta)+ Q_B.mul(eta * eta);
-    num -= &DensePolynomial{coeffs:vec![v]};
-    let h = num.div(&DensePolynomial{coeffs:vec![-gamma,Fr::one()]});
-    let pi_gamma = util::msm::<G1Projective>(&srs.0[..n-1],&h).into();
-    let (temp, temp2) : (Vec<G1Affine>,Vec<Fr>)=A_i.iter().map(|(i,y)| (L_i_0_x_1[*i], *y)).unzip();
+    let mut num = B_0 + inputs[0].poly.mul(eta) + Q_B.mul(eta * eta);
+    num -= &DensePolynomial { coeffs: vec![v] };
+    let h = num.div(&DensePolynomial {
+      coeffs: vec![-gamma, Fr::one()],
+    });
+    let pi_gamma = util::msm::<G1Projective>(&srs.0[..n - 1], &h).into();
+    let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_0_x_1[*i], *y)).unzip();
     let A_0_x = util::msm::<G1Projective>(&temp, &temp2).into();
 
     let B_0_gamma_1 = (srs.0[0] * B_0_gamma).into();
@@ -112,41 +118,60 @@ impl BasicBlock for CQBasicBlock{
     let A_0_1 = (srs.0[0] * A_0).into();
     let b_gamma_f_gamma = (srs.0[0] * (b_gamma * (f_gamma + beta))).into();
 
-    return (vec![m_x_1,A_x_1,Q_A_x_1,B_0_x_1,Q_B_x_1,P_x_1,pi_gamma,A_0_x,
-                 B_0_gamma_1,b_gamma_1,f_gamma_1,A_0_1,b_gamma_f_gamma],
-            vec![setup.1[0],f_gamma_2]);
+    return (
+      vec![
+        m_x_1,
+        A_x_1,
+        Q_A_x_1,
+        B_0_x_1,
+        Q_B_x_1,
+        P_x_1,
+        pi_gamma,
+        A_0_x,
+        B_0_gamma_1,
+        b_gamma_1,
+        f_gamma_1,
+        A_0_1,
+        b_gamma_f_gamma,
+      ],
+      vec![setup.1[0], f_gamma_2],
+    );
   }
-  fn verify<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-                    model: &DataEnc,
-                    inputs: &Vec<DataEnc>,
-                    _output: &DataEnc,
-                    proof: (&Vec<G1Affine>,&Vec<G2Affine>),
-                    rng: &mut R){
+  fn verify<R: Rng>(
+    srs: (&Vec<G1Affine>, &Vec<G2Affine>),
+    model: &DataEnc,
+    inputs: &Vec<DataEnc>,
+    _output: &DataEnc,
+    proof: (&Vec<G1Affine>, &Vec<G2Affine>),
+    rng: &mut R,
+  ) {
     let N = model.len;
     let n = inputs[0].len;
-    let domain_n  = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
-    let [m_x_1,A_x_1,Q_A_x_1,B_0_x_1,Q_B_x_1,P_x_1,pi_gamma,A_0_x,
-         B_0_gamma_1,b_gamma_1,f_gamma_1,A_0_1,b_gamma_f_gamma] = proof.0[..] else{panic!("Wrong proof format")};
-    let [T_x_2,f_gamma_2] = proof.1[..] else{panic!("Wrong proof format")};
+    let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
+    let [m_x_1, A_x_1, Q_A_x_1, B_0_x_1, Q_B_x_1, P_x_1, pi_gamma, A_0_x, B_0_gamma_1, b_gamma_1, f_gamma_1, A_0_1, b_gamma_f_gamma] = proof.0[..]
+    else {
+      panic!("Wrong proof format")
+    };
+    let [T_x_2, f_gamma_2] = proof.1[..] else { panic!("Wrong proof format") };
 
     // Round 2
     let beta = Fr::rand(rng);
-    let A_x_1 : G1Projective = A_x_1.into();
-    let m_x_1 : G1Projective = m_x_1.into();
-    let lhs = Bn254::pairing(A_x_1,T_x_2);
-    let rhs = Bn254::pairing(Q_A_x_1,srs.1[N] - srs.1[0]) + Bn254::pairing(m_x_1 - A_x_1 * beta, srs.1[0]);
-    assert!(lhs==rhs);
-    let lhs = Bn254::pairing(B_0_x_1,srs.1[N-1-(n-2)]);
-    let rhs = Bn254::pairing(P_x_1,srs.1[0]);
-    assert!(lhs==rhs);
+    let A_x_1: G1Projective = A_x_1.into();
+    let m_x_1: G1Projective = m_x_1.into();
+    let lhs = Bn254::pairing(A_x_1, T_x_2);
+    let rhs = Bn254::pairing(Q_A_x_1, srs.1[N] - srs.1[0]) + Bn254::pairing(m_x_1 - A_x_1 * beta, srs.1[0]);
+    assert!(lhs == rhs);
+    let lhs = Bn254::pairing(B_0_x_1, srs.1[N - 1 - (n - 2)]);
+    let rhs = Bn254::pairing(P_x_1, srs.1[0]);
+    assert!(lhs == rhs);
 
     // Check b_gamma_f_gamma
-    let lhs = Bn254::pairing(b_gamma_1,f_gamma_2 + srs.1[0] * beta);
+    let lhs = Bn254::pairing(b_gamma_1, f_gamma_2 + srs.1[0] * beta);
     let rhs = Bn254::pairing(b_gamma_f_gamma, srs.1[0]);
-    assert!(lhs==rhs);
-    let lhs = Bn254::pairing(f_gamma_1,srs.1[0]);
-    let rhs = Bn254::pairing(srs.0[0],f_gamma_2);
-    assert!(lhs==rhs);
+    assert!(lhs == rhs);
+    let lhs = Bn254::pairing(f_gamma_1, srs.1[0]);
+    let rhs = Bn254::pairing(srs.0[0], f_gamma_2);
+    assert!(lhs == rhs);
 
     // Round 3
     let gamma = Fr::rand(rng);
@@ -157,11 +182,9 @@ impl BasicBlock for CQBasicBlock{
     let c = B_0_x_1 + inputs[0].g1 * eta + Q_B_x_1 * eta * eta;
     let lhs = Bn254::pairing(c - v + pi_gamma * gamma, srs.1[0]);
     let rhs = Bn254::pairing(pi_gamma, srs.1[1]);
-    assert!(lhs==rhs);
-    let lhs = Bn254::pairing(A_x_1 -  A_0_1, srs.1[0]);
+    assert!(lhs == rhs);
+    let lhs = Bn254::pairing(A_x_1 - A_0_1, srs.1[0]);
     let rhs = Bn254::pairing(A_0_x, srs.1[1]);
-    assert!(lhs==rhs);
+    assert!(lhs == rhs);
   }
 }
-
-

--- a/src/basic_block/cqlin.rs
+++ b/src/basic_block/cqlin.rs
@@ -96,7 +96,7 @@ impl BasicBlock for CQLinBasicBlock{
                    inputs: &Vec<Data>,
                    output: &Data,
                    rng: &mut R) ->
-                  (Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>){
+                  (Vec<G1Affine>,Vec<G2Affine>){
     let n = inputs[0].raw.len();
     let domain_n  = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
     let R = &setup.0[..n];
@@ -120,13 +120,13 @@ impl BasicBlock for CQLinBasicBlock{
     let pi = util::msm::<G1Projective>(&L_i_x, &h_i).into();
     let pi_1 = util::msm::<G1Projective>(&L_i_x_n, &h_i).into();
 
-    return (vec![R_x,Q_x,A_x,S_x,P_x,z,pi,pi_1],vec![setup.1[0]],Vec::new());
+    return (vec![R_x,Q_x,A_x,S_x,P_x,z,pi,pi_1],vec![setup.1[0]]);
   }
   fn verify<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
                     _model: &DataEnc,
                     inputs: &Vec<DataEnc>,
                     output: &DataEnc,
-                    proof: (&Vec<G1Affine>,&Vec<G2Affine>,&Vec<Fr>),
+                    proof: (&Vec<G1Affine>,&Vec<G2Affine>),
                     rng: &mut R){
     let n = inputs[0].len;
     let [R_x,Q_x,A_x,S_x,P_x,z,pi,pi_1] = proof.0[..] else{panic!("Wrong proof format")};

--- a/src/basic_block/cqlin.rs
+++ b/src/basic_block/cqlin.rs
@@ -1,158 +1,160 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
+use super::{BasicBlock, Data, DataEnc};
+use crate::util;
+use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::pairing::Pairing;
 use ark_ff::Field;
-use ark_poly::{GeneralEvaluationDomain, EvaluationDomain, Polynomial};
-use ark_bn254::{Fr, G1Projective, G2Projective, G1Affine, G2Affine, Bn254};
-use ark_std::{Zero, One, UniformRand};
-use rayon::prelude::*;
+use ark_poly::{EvaluationDomain, GeneralEvaluationDomain, Polynomial};
+use ark_std::{One, UniformRand, Zero};
 use rand::Rng;
-use super::{BasicBlock,Data,DataEnc};
-use crate::util;
+use rayon::prelude::*;
 
 pub struct CQLinBasicBlock;
-impl BasicBlock for CQLinBasicBlock{
-  fn run(model: &Vec<Fr>,
-         inputs: &Vec<Vec<Fr>>) ->
-         Vec<Fr>{
+impl BasicBlock for CQLinBasicBlock {
+  fn run(model: &Vec<Fr>, inputs: &Vec<Vec<Fr>>) -> Vec<Fr> {
     let n = inputs[0].len();
-    let mut r = vec![Fr::zero() ; n];
-    for i in 0..n{
-      for j in 0..n{
-        r[i]+=model[j*n+i] * inputs[0][j];
+    let mut r = vec![Fr::zero(); n];
+    for i in 0..n {
+      for j in 0..n {
+        r[i] += model[j * n + i] * inputs[0][j];
       }
     }
     return r;
   }
-  fn setup(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-           model: &Data) ->
-          (Vec<G1Affine>,Vec<G2Affine>){
+  fn setup(srs: (&Vec<G1Affine>, &Vec<G2Affine>), model: &Data) -> (Vec<G1Affine>, Vec<G2Affine>) {
     let N = model.raw.len();
     let n: usize = (N as f64).sqrt() as usize;
     let n_inv = Fr::from(n as u64).inverse().unwrap();
-    let domain_n  = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
-    let domain_2n  = GeneralEvaluationDomain::<Fr>::new(2*n).unwrap();
+    let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
+    let domain_2n = GeneralEvaluationDomain::<Fr>::new(2 * n).unwrap();
     let srs_p: Vec<G1Projective> = srs.0[..N].par_iter().map(|x| (*x).into()).collect();
     let mut L_i_x = srs_p[..n].to_vec();
     util::ifft_in_place(domain_n, &mut L_i_x);
-    let mut L_i_x_n: Vec<_> = (0..n).into_par_iter().map(|i| srs_p[n*i]).collect();
+    let mut L_i_x_n: Vec<_> = (0..n).into_par_iter().map(|i| srs_p[n * i]).collect();
     util::ifft_in_place(domain_n, &mut L_i_x_n);
 
-    let mut temp: Vec<Vec<_>>= (0..n).into_par_iter().map(|i|(0..n).map(|j|srs_p[i+n*j]).collect()).collect();
+    let mut temp: Vec<Vec<_>> = (0..n).into_par_iter().map(|i| (0..n).map(|j| srs_p[i + n * j]).collect()).collect();
     temp.par_iter_mut().for_each(|x| util::ifft_in_place(domain_n, x));
-    let mut U: Vec<Vec<_>> = (0..n).into_par_iter().map(|j|(0..n).map(|i|temp[i][j]).collect()).collect();
+    let mut U: Vec<Vec<_>> = (0..n).into_par_iter().map(|j| (0..n).map(|i| temp[i][j]).collect()).collect();
     U.par_iter_mut().for_each(|x| util::ifft_in_place(domain_n, x));
-    let mut temp: Vec<Vec<G2Projective>> = (0..n).into_par_iter().map(|i|(0..n).map(|j|srs.1[i+n*j].into()).collect()).collect();
+    let mut temp: Vec<Vec<G2Projective>> = (0..n).into_par_iter().map(|i| (0..n).map(|j| srs.1[i + n * j].into()).collect()).collect();
     temp.par_iter_mut().for_each(|x| util::ifft_in_place(domain_n, x));
-    let mut U2: Vec<Vec<_>> = (0..n).into_par_iter().map(|i|(0..n).map(|j|temp[j][i]).collect()).collect();
+    let mut U2: Vec<Vec<_>> = (0..n).into_par_iter().map(|i| (0..n).map(|j| temp[j][i]).collect()).collect();
     U2.par_iter_mut().for_each(|x| util::ifft_in_place(domain_n, x));
-    let mut V = srs_p[N-n..N].to_vec();
+    let mut V = srs_p[N - n..N].to_vec();
     util::ifft_in_place(domain_n, &mut V);
     V.par_iter_mut().for_each(|x| *x *= n_inv);
 
-    let mut srs_star: Vec<Vec<_>>= (0..n).into_par_iter().map(|i|srs_p[n*i..n*i+n].to_vec()).collect();
+    let mut srs_star: Vec<Vec<_>> = (0..n).into_par_iter().map(|i| srs_p[n * i..n * i + n].to_vec()).collect();
     srs_star.par_iter_mut().for_each(|x| util::ifft_in_place(domain_n, x));
-    srs_star = (0..n).into_par_iter().map(|i|(0..n).map(|j|srs_star[n-1-j][i]).collect()).collect();
+    srs_star = (0..n).into_par_iter().map(|i| (0..n).map(|j| srs_star[n - 1 - j][i]).collect()).collect();
     srs_star.par_iter_mut().for_each(|x| x.append(&mut vec![G1Projective::zero(); n]));
     srs_star.par_iter_mut().for_each(|x| util::fft_in_place(domain_2n, x));
 
-    let mut Ls = vec![vec![Fr::zero() ; n] ; n];
-    Ls.par_iter_mut().enumerate().for_each(|(i, x)| x[i]=Fr::one());
+    let mut Ls = vec![vec![Fr::zero(); n]; n];
+    Ls.par_iter_mut().enumerate().for_each(|(i, x)| x[i] = Fr::one());
     Ls.par_iter_mut().for_each(|x| domain_n.ifft_in_place(x));
-    let S: Vec<Vec<_>>= (0..n).into_par_iter().map(|i|(0..n).map(|j|(U[i][j]*domain_n.element(i).inverse().unwrap()-V[j]) * model.raw[i*n+j]).collect()).collect();
-    let S: Vec<_> = S.par_iter().map(|x|x.iter().sum::<G1Projective>()).collect();
-    let R: Vec<Vec<_>>= (0..n).into_par_iter().map(|i|(0..n).map(|j|U[i][j] * model.raw[i*n+j]).collect()).collect();
-    let R: Vec<_> = R.par_iter().map(|x|x.iter().sum::<G1Projective>()).collect();
+    let S: Vec<Vec<_>> = (0..n)
+      .into_par_iter()
+      .map(|i| (0..n).map(|j| (U[i][j] * domain_n.element(i).inverse().unwrap() - V[j]) * model.raw[i * n + j]).collect())
+      .collect();
+    let S: Vec<_> = S.par_iter().map(|x| x.iter().sum::<G1Projective>()).collect();
+    let R: Vec<Vec<_>> = (0..n).into_par_iter().map(|i| (0..n).map(|j| U[i][j] * model.raw[i * n + j]).collect()).collect();
+    let R: Vec<_> = R.par_iter().map(|x| x.iter().sum::<G1Projective>()).collect();
 
-    let mut C: Vec<Vec<_>>= (0..n).into_par_iter().map(|i|(0..n).map(|j|model.raw[j*n+i]).collect()).collect();
+    let mut C: Vec<Vec<_>> = (0..n).into_par_iter().map(|i| (0..n).map(|j| model.raw[j * n + i]).collect()).collect();
     C.par_iter_mut().for_each(|x| domain_n.ifft_in_place(x));
 
     let mut temp = C;
     temp.par_iter_mut().for_each(|x| x.append(&mut vec![Fr::zero(); n]));
     temp.par_iter_mut().for_each(|x| domain_2n.fft_in_place(x));
-    let temp: Vec<Vec<_>> = (0..2*n).into_par_iter().map(|i|(0..n).map(|j|srs_star[j][i]*temp[j][i]).collect()).collect();
-    let mut temp: Vec<_> = temp.par_iter().map(|x|x.iter().sum::<G1Projective>()).collect();
+    let temp: Vec<Vec<_>> = (0..2 * n).into_par_iter().map(|i| (0..n).map(|j| srs_star[j][i] * temp[j][i]).collect()).collect();
+    let mut temp: Vec<_> = temp.par_iter().map(|x| x.iter().sum::<G1Projective>()).collect();
     util::ifft_in_place(domain_2n, &mut temp);
     let mut temp = temp[n..].to_vec();
     util::fft_in_place(domain_n, &mut temp);
-    let Q: Vec<_> = (0..n).into_par_iter().map(|i|temp[i]*domain_n.element(i)*n_inv).collect();
-    let M_x = (0..n).into_par_iter().map(|i|(0..n).map(|j|U2[i][j]*model.raw[i*n+j]).sum::<G2Projective>()).sum::<G2Projective>(); //TODO: Change to msm
+    let Q: Vec<_> = (0..n).into_par_iter().map(|i| temp[i] * domain_n.element(i) * n_inv).collect();
+    let M_x = (0..n).into_par_iter().map(|i| (0..n).map(|j| U2[i][j] * model.raw[i * n + j]).sum::<G2Projective>()).sum::<G2Projective>(); //TODO: Change to msm
 
-    let R: Vec<G1Affine> = R.par_iter().map(|x|(*x).into()).collect();
-    let mut Q: Vec<G1Affine> = Q.par_iter().map(|x|(*x).into()).collect();
-    let mut S: Vec<G1Affine> = S.par_iter().map(|x|(*x).into()).collect();
-    let mut L_i_x: Vec<G1Affine> = L_i_x.par_iter().map(|x|(*x).into()).collect();
-    let mut L_i_x_n: Vec<G1Affine> = L_i_x_n.par_iter().map(|x|(*x).into()).collect();
+    let R: Vec<G1Affine> = R.par_iter().map(|x| (*x).into()).collect();
+    let mut Q: Vec<G1Affine> = Q.par_iter().map(|x| (*x).into()).collect();
+    let mut S: Vec<G1Affine> = S.par_iter().map(|x| (*x).into()).collect();
+    let mut L_i_x: Vec<G1Affine> = L_i_x.par_iter().map(|x| (*x).into()).collect();
+    let mut L_i_x_n: Vec<G1Affine> = L_i_x_n.par_iter().map(|x| (*x).into()).collect();
     let mut setup = R;
     setup.append(&mut Q);
     setup.append(&mut S);
     setup.append(&mut L_i_x);
     setup.append(&mut L_i_x_n);
-    return (setup,vec![M_x.into()]);
+    return (setup, vec![M_x.into()]);
   }
-  fn prove<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-                   setup: (&Vec<G1Affine>,&Vec<G2Affine>),
-                   _model: &Data,
-                   inputs: &Vec<Data>,
-                   output: &Data,
-                   rng: &mut R) ->
-                  (Vec<G1Affine>,Vec<G2Affine>){
+  fn prove<R: Rng>(
+    srs: (&Vec<G1Affine>, &Vec<G2Affine>),
+    setup: (&Vec<G1Affine>, &Vec<G2Affine>),
+    _model: &Data,
+    inputs: &Vec<Data>,
+    output: &Data,
+    rng: &mut R,
+  ) -> (Vec<G1Affine>, Vec<G2Affine>) {
     let n = inputs[0].raw.len();
-    let domain_n  = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
+    let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
     let R = &setup.0[..n];
-    let Q = &setup.0[n..2*n];
-    let S = &setup.0[2*n..3*n];
-    let L_i_x = &setup.0[3*n..4*n];
-    let L_i_x_n = &setup.0[4*n..];
+    let Q = &setup.0[n..2 * n];
+    let S = &setup.0[2 * n..3 * n];
+    let L_i_x = &setup.0[3 * n..4 * n];
+    let L_i_x_n = &setup.0[4 * n..];
 
     let R_x = util::msm::<G1Projective>(R, &inputs[0].raw).into();
     let Q_x = util::msm::<G1Projective>(Q, &inputs[0].raw).into();
-    let temp: Vec<_> = (0..n).into_par_iter().map(|i|srs.0[n*i]).collect();
+    let temp: Vec<_> = (0..n).into_par_iter().map(|i| srs.0[n * i]).collect();
     let A_x = util::msm::<G1Projective>(&temp, &inputs[0].poly.coeffs).into();
     let S_x = util::msm::<G1Projective>(S, &inputs[0].raw).into();
-    let P_x = util::msm::<G1Projective>(&srs.0[n*n-n..n*n], &output.poly.coeffs).into();
+    let P_x = util::msm::<G1Projective>(&srs.0[n * n - n..n * n], &output.poly.coeffs).into();
 
     let gamma = Fr::rand(rng);
     let gamma_n = gamma.pow(&[n as u64]);
     let z = inputs[0].poly.evaluate(&gamma_n);
-    let h_i: Vec<_> = (0..n).into_par_iter().map(|i|(inputs[0].raw[i] - z) * (domain_n.element(i) - gamma_n).inverse().unwrap()).collect();
-    let z = (srs.0[0]*z).into();
+    let h_i: Vec<_> = (0..n).into_par_iter().map(|i| (inputs[0].raw[i] - z) * (domain_n.element(i) - gamma_n).inverse().unwrap()).collect();
+    let z = (srs.0[0] * z).into();
     let pi = util::msm::<G1Projective>(&L_i_x, &h_i).into();
     let pi_1 = util::msm::<G1Projective>(&L_i_x_n, &h_i).into();
 
-    return (vec![R_x,Q_x,A_x,S_x,P_x,z,pi,pi_1],vec![setup.1[0]]);
+    return (vec![R_x, Q_x, A_x, S_x, P_x, z, pi, pi_1], vec![setup.1[0]]);
   }
-  fn verify<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-                    _model: &DataEnc,
-                    inputs: &Vec<DataEnc>,
-                    output: &DataEnc,
-                    proof: (&Vec<G1Affine>,&Vec<G2Affine>),
-                    rng: &mut R){
+  fn verify<R: Rng>(
+    srs: (&Vec<G1Affine>, &Vec<G2Affine>),
+    _model: &DataEnc,
+    inputs: &Vec<DataEnc>,
+    output: &DataEnc,
+    proof: (&Vec<G1Affine>, &Vec<G2Affine>),
+    rng: &mut R,
+  ) {
     let n = inputs[0].len;
-    let [R_x,Q_x,A_x,S_x,P_x,z,pi,pi_1] = proof.0[..] else{panic!("Wrong proof format")};
-    let lhs = Bn254::pairing(A_x,proof.1[0]);
-    let rhs = Bn254::pairing(Q_x,srs.1[n*n]-srs.1[0]) + Bn254::pairing(R_x, srs.1[0]);
-    assert!(lhs==rhs);
+    let [R_x, Q_x, A_x, S_x, P_x, z, pi, pi_1] = proof.0[..] else {
+      panic!("Wrong proof format")
+    };
+    let lhs = Bn254::pairing(A_x, proof.1[0]);
+    let rhs = Bn254::pairing(Q_x, srs.1[n * n] - srs.1[0]) + Bn254::pairing(R_x, srs.1[0]);
+    assert!(lhs == rhs);
 
     let temp: G1Affine = (output.g1 * Fr::from(n as u64).inverse().unwrap()).into();
     let lhs = Bn254::pairing(R_x - temp, srs.1[0]);
     let rhs = Bn254::pairing(S_x, srs.1[n]);
-    assert!(lhs==rhs);
+    assert!(lhs == rhs);
 
-    let lhs = Bn254::pairing(output.g1, srs.1[n*n-n]);
+    let lhs = Bn254::pairing(output.g1, srs.1[n * n - n]);
     let rhs = Bn254::pairing(P_x, srs.1[0]);
-    assert!(lhs==rhs);
+    assert!(lhs == rhs);
 
     let gamma = Fr::rand(rng);
     let gamma_n = gamma.pow(&[n as u64]);
-    let lhs = Bn254::pairing(inputs[0].g1 - z + pi*gamma_n, srs.1[0]);
-    let rhs = Bn254::pairing(pi,srs.1[1]);
-    assert!(lhs==rhs);
+    let lhs = Bn254::pairing(inputs[0].g1 - z + pi * gamma_n, srs.1[0]);
+    let rhs = Bn254::pairing(pi, srs.1[1]);
+    assert!(lhs == rhs);
 
-    let lhs = Bn254::pairing(A_x - z + pi_1*gamma_n, srs.1[0]);
-    let rhs = Bn254::pairing(pi_1,srs.1[n]);
-    assert!(lhs==rhs);
+    let lhs = Bn254::pairing(A_x - z + pi_1 * gamma_n, srs.1[0]);
+    let rhs = Bn254::pairing(pi_1, srs.1[n]);
+    assert!(lhs == rhs);
   }
 }
-
-

--- a/src/basic_block/mul.rs
+++ b/src/basic_block/mul.rs
@@ -1,50 +1,50 @@
-use ark_ec::pairing::Pairing;
-use ark_poly::{GeneralEvaluationDomain, EvaluationDomain};
-use ark_bn254::{Fr, G1Projective, G1Affine, G2Projective, G2Affine, Bn254};
-use ark_std::{ops::Mul, ops::Sub};
+use super::{BasicBlock, Data, DataEnc};
 use crate::util;
+use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
+use ark_ec::pairing::Pairing;
+use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
+use ark_std::{ops::Mul, ops::Sub};
 use rand::Rng;
-use super::{BasicBlock,Data,DataEnc};
 
 pub struct MulBasicBlock;
-impl BasicBlock for MulBasicBlock{
-  fn run(_model: &Vec<Fr>,
-         inputs: &Vec<Vec<Fr>>) ->
-         Vec<Fr>{
+impl BasicBlock for MulBasicBlock {
+  fn run(_model: &Vec<Fr>, inputs: &Vec<Vec<Fr>>) -> Vec<Fr> {
     let mut r = Vec::new();
-    for i in 0..inputs[0].len(){
-      r.push(inputs[0][i]*inputs[1][i]);
+    for i in 0..inputs[0].len() {
+      r.push(inputs[0][i] * inputs[1][i]);
     }
     return r;
   }
-  fn prove<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-                   _setup: (&Vec<G1Affine>,&Vec<G2Affine>),
-                   _model: &Data,
-                   inputs: &Vec<Data>,
-                   output: &Data,
-                   _rng: &mut R) ->
-                  (Vec<G1Affine>,Vec<G2Affine>){
+  fn prove<R: Rng>(
+    srs: (&Vec<G1Affine>, &Vec<G2Affine>),
+    _setup: (&Vec<G1Affine>, &Vec<G2Affine>),
+    _model: &Data,
+    inputs: &Vec<Data>,
+    output: &Data,
+    _rng: &mut R,
+  ) -> (Vec<G1Affine>, Vec<G2Affine>) {
     let N = inputs[0].raw.len();
-    let domain  = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
+    let domain = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
     let gx2 = util::msm::<G2Projective>(&srs.1[..N], &inputs[1].poly.coeffs).into();
     let t = inputs[0].poly.mul(&inputs[1].poly).sub(&output.poly).divide_by_vanishing_poly(domain).unwrap().0;
-    let tx = util::msm::<G1Projective>(&srs.0[..N-1], &t.coeffs).into();
-    return (vec![tx],vec![gx2]);
+    let tx = util::msm::<G1Projective>(&srs.0[..N - 1], &t.coeffs).into();
+    return (vec![tx], vec![gx2]);
   }
-  fn verify<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-                    _model: &DataEnc,
-                    inputs: &Vec<DataEnc>,
-                    output: &DataEnc,
-                    proof: (&Vec<G1Affine>,&Vec<G2Affine>),
-                    _rng: &mut R){
+  fn verify<R: Rng>(
+    srs: (&Vec<G1Affine>, &Vec<G2Affine>),
+    _model: &DataEnc,
+    inputs: &Vec<DataEnc>,
+    output: &DataEnc,
+    proof: (&Vec<G1Affine>, &Vec<G2Affine>),
+    _rng: &mut R,
+  ) {
     // Verify f(x)*g(x)-h(x)=z(x)t(x)
-    let lhs = Bn254::pairing(inputs[0].g1,proof.1[0]) - Bn254::pairing(output.g1,srs.1[0]);
-    let rhs = Bn254::pairing(proof.0[0],srs.1[inputs[0].len]-srs.1[0]);
-    assert!(lhs==rhs);
+    let lhs = Bn254::pairing(inputs[0].g1, proof.1[0]) - Bn254::pairing(output.g1, srs.1[0]);
+    let rhs = Bn254::pairing(proof.0[0], srs.1[inputs[0].len] - srs.1[0]);
+    assert!(lhs == rhs);
     // Verify gx2
-    let lhs = Bn254::pairing(inputs[1].g1,srs.1[0]);
-    let rhs = Bn254::pairing(srs.0[0],proof.1[0]);
-    assert!(lhs==rhs);
+    let lhs = Bn254::pairing(inputs[1].g1, srs.1[0]);
+    let rhs = Bn254::pairing(srs.0[0], proof.1[0]);
+    assert!(lhs == rhs);
   }
 }
-

--- a/src/basic_block/mul.rs
+++ b/src/basic_block/mul.rs
@@ -1,7 +1,8 @@
-use ark_ec::{VariableBaseMSM, pairing::Pairing};
+use ark_ec::pairing::Pairing;
 use ark_poly::{GeneralEvaluationDomain, EvaluationDomain};
 use ark_bn254::{Fr, G1Projective, G1Affine, G2Projective, G2Affine, Bn254};
 use ark_std::{ops::Mul, ops::Sub};
+use crate::util;
 use rand::Rng;
 use super::{BasicBlock,Data,DataEnc};
 
@@ -16,30 +17,25 @@ impl BasicBlock for MulBasicBlock{
     }
     return r;
   }
-  fn setup(_srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-           _model: &Data) ->
-          (Vec<G1Affine>,Vec<G2Affine>){
-    return (Vec::new(), Vec::new());
-  }
   fn prove<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
                    _setup: (&Vec<G1Affine>,&Vec<G2Affine>),
                    _model: &Data,
                    inputs: &Vec<Data>,
                    output: &Data,
                    _rng: &mut R) ->
-                  (Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>){
+                  (Vec<G1Affine>,Vec<G2Affine>){
     let N = inputs[0].raw.len();
     let domain  = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
-    let gx2 = G2Projective::msm(&srs.1[..N], &inputs[1].poly.coeffs).unwrap().into();
+    let gx2 = util::msm::<G2Projective>(&srs.1[..N], &inputs[1].poly.coeffs).into();
     let t = inputs[0].poly.mul(&inputs[1].poly).sub(&output.poly).divide_by_vanishing_poly(domain).unwrap().0;
-    let tx = G1Projective::msm(&srs.0[..N-1], &t.coeffs).unwrap().into();
-    return (vec![tx],vec![gx2],Vec::new());
+    let tx = util::msm::<G1Projective>(&srs.0[..N-1], &t.coeffs).into();
+    return (vec![tx],vec![gx2]);
   }
   fn verify<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
                     _model: &DataEnc,
                     inputs: &Vec<DataEnc>,
                     output: &DataEnc,
-                    proof: (&Vec<G1Affine>,&Vec<G2Affine>,&Vec<Fr>),
+                    proof: (&Vec<G1Affine>,&Vec<G2Affine>),
                     _rng: &mut R){
     // Verify f(x)*g(x)-h(x)=z(x)t(x)
     let lhs = Bn254::pairing(inputs[0].g1,proof.1[0]) - Bn254::pairing(output.g1,srs.1[0]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,36 +2,36 @@
 #![allow(non_upper_case_globals)]
 use ark_bn254::{Fr, G1Affine, G2Affine};
 use ark_std::UniformRand;
-use rand::{rngs::StdRng,SeedableRng};
-use rayon::prelude::*;
 use basic_block::*;
+use rand::{rngs::StdRng, SeedableRng};
+use rayon::prelude::*;
 mod basic_block;
-mod util;
 mod ptau;
+mod util;
 
-fn test_basic_block<BB: BasicBlock>(srs: (&Vec<G1Affine>,&Vec<G2Affine>), model: &Vec<Fr>, inputs: &Vec<Vec<Fr>>){
+fn test_basic_block<BB: BasicBlock>(srs: (&Vec<G1Affine>, &Vec<G2Affine>), model: &Vec<Fr>, inputs: &Vec<Vec<Fr>>) {
   let mut rng = StdRng::from_entropy();
-  let output = BB::run(model,inputs);
+  let output = BB::run(model, inputs);
   let model = Data::new(srs, model);
-  let setup = BB::setup(srs,&model);
-  let inputs = inputs.iter().map(|x| Data::new(srs,x)).collect();
-  let output = Data::new(srs,&output);
+  let setup = BB::setup(srs, &model);
+  let inputs = inputs.iter().map(|x| Data::new(srs, x)).collect();
+  let output = Data::new(srs, &output);
   let mut rng2 = rng.clone();
-  let proof = BB::prove(srs,(&(setup.0),&(setup.1)),&model,&inputs,&output,&mut rng);
+  let proof = BB::prove(srs, (&(setup.0), &(setup.1)), &model, &inputs, &output, &mut rng);
   let model = DataEnc::new(&model);
   let inputs = inputs.iter().map(|x| DataEnc::new(x)).collect();
   let output = DataEnc::new(&output);
-  BB::verify(srs,&model,&inputs,&output,(&(proof.0),&(proof.1)),&mut rng2);
+  BB::verify(srs, &model, &inputs, &output, (&(proof.0), &(proof.1)), &mut rng2);
 }
 fn main() {
-  let srs = ptau::load_file("challenge",7);
-  let srs = (&srs.0,&srs.1);
-  const N:usize = 1<<6;
-  const n:usize = 1<<3;
+  let srs = ptau::load_file("challenge", 7);
+  let srs = (&srs.0, &srs.1);
+  const N: usize = 1 << 6;
+  const n: usize = 1 << 3;
   let a: Vec<_> = (0..N).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::rand(rng)).collect();
   let b: Vec<_> = (0..N).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::rand(rng)).collect();
-  test_basic_block::<AddBasicBlock>(srs,&Vec::new(),&vec![a.clone(),b.clone()]);
-  test_basic_block::<MulBasicBlock>(srs,&Vec::new(),&vec![a.clone(),b.clone()]);
-  test_basic_block::<CQBasicBlock>(srs,&a,&vec![a[..n].to_vec()]);
-  test_basic_block::<CQLinBasicBlock>(srs,&a,&vec![b[..n].to_vec()]);
+  test_basic_block::<AddBasicBlock>(srs, &Vec::new(), &vec![a.clone(), b.clone()]);
+  test_basic_block::<MulBasicBlock>(srs, &Vec::new(), &vec![a.clone(), b.clone()]);
+  test_basic_block::<CQBasicBlock>(srs, &a, &vec![a[..n].to_vec()]);
+  test_basic_block::<CQLinBasicBlock>(srs, &a, &vec![b[..n].to_vec()]);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn test_basic_block<BB: BasicBlock>(srs: (&Vec<G1Affine>,&Vec<G2Affine>), model:
   let model = DataEnc::new(&model);
   let inputs = inputs.iter().map(|x| DataEnc::new(x)).collect();
   let output = DataEnc::new(&output);
-  BB::verify(srs,&model,&inputs,&output,(&(proof.0),&(proof.1),&(proof.2)),&mut rng2);
+  BB::verify(srs,&model,&inputs,&output,(&(proof.0),&(proof.1)),&mut rng2);
 }
 fn main() {
   let srs = ptau::load_file("challenge",7);

--- a/src/ptau.rs
+++ b/src/ptau.rs
@@ -1,29 +1,35 @@
 use ark_bn254::{Fq, Fq2, G1Affine, G2Affine};
 use ark_ff::PrimeField;
-use std::fs;
 use rayon::prelude::*;
+use std::fs;
 
-pub fn load_file(filename: &str, n: usize) -> (Vec<G1Affine>,Vec<G2Affine>){
+pub fn load_file(filename: &str, n: usize) -> (Vec<G1Affine>, Vec<G2Affine>) {
   let bytes = fs::read(filename).unwrap();
 
-  let powers_length=1<<n;
-  let powers_g1_length=(powers_length<<1)-1;
+  let powers_length = 1 << n;
+  let powers_g1_length = (powers_length << 1) - 1;
 
-  let g1 = (0..powers_g1_length).into_par_iter().map(|i|{
-    let start = 64 + i*64;
-    let x = Fq::from_be_bytes_mod_order(&bytes[start..start+32]);
-    let y = Fq::from_be_bytes_mod_order(&bytes[start+32..start+64]);
-    G1Affine::new_unchecked(x,y)
-  }).collect();
+  let g1 = (0..powers_g1_length)
+    .into_par_iter()
+    .map(|i| {
+      let start = 64 + i * 64;
+      let x = Fq::from_be_bytes_mod_order(&bytes[start..start + 32]);
+      let y = Fq::from_be_bytes_mod_order(&bytes[start + 32..start + 64]);
+      G1Affine::new_unchecked(x, y)
+    })
+    .collect();
 
-  let g2 = (0..powers_length).into_par_iter().map(|i|{
-    let start = 64 + 64*powers_g1_length + 128*i;
-    let a = Fq::from_be_bytes_mod_order(&bytes[start..start+32]);
-    let b = Fq::from_be_bytes_mod_order(&bytes[start+32..start+64]);
-    let c = Fq::from_be_bytes_mod_order(&bytes[start+64..start+96]);
-    let d = Fq::from_be_bytes_mod_order(&bytes[start+96..start+128]);
-    G2Affine::new_unchecked(Fq2{c0:b, c1:a}, Fq2{c0:d, c1:c})
-  }).collect();
+  let g2 = (0..powers_length)
+    .into_par_iter()
+    .map(|i| {
+      let start = 64 + 64 * powers_g1_length + 128 * i;
+      let a = Fq::from_be_bytes_mod_order(&bytes[start..start + 32]);
+      let b = Fq::from_be_bytes_mod_order(&bytes[start + 32..start + 64]);
+      let c = Fq::from_be_bytes_mod_order(&bytes[start + 64..start + 96]);
+      let d = Fq::from_be_bytes_mod_order(&bytes[start + 96..start + 128]);
+      G2Affine::new_unchecked(Fq2 { c0: b, c1: a }, Fq2 { c0: d, c1: c })
+    })
+    .collect();
 
-  return (g1,g2);
+  return (g1, g2);
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use ark_poly::{GeneralEvaluationDomain, EvaluationDomain};
 use ark_bn254::Fr;
 use ark_std::Zero;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
-use ark_poly::{GeneralEvaluationDomain, EvaluationDomain};
 use ark_bn254::Fr;
-use ark_std::Zero;
 use ark_ec::{ScalarMul, VariableBaseMSM};
+use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
+use ark_std::Zero;
 use rayon::prelude::*;
 
 fn bitreverse(mut n: u32, l: u64) -> u32 {
@@ -13,88 +13,87 @@ fn bitreverse(mut n: u32, l: u64) -> u32 {
   }
   r
 }
-pub fn fft_helper<G:ScalarMul+std::ops::MulAssign<Fr>>(a: &mut Vec<G>, domain: GeneralEvaluationDomain<Fr>, inv: bool){
+pub fn fft_helper<G: ScalarMul + std::ops::MulAssign<Fr>>(a: &mut Vec<G>, domain: GeneralEvaluationDomain<Fr>, inv: bool) {
   let n = a.len();
   let log_size = domain.log_size_of_group();
 
   let swap = &mut Vec::new();
-  (0..n).into_par_iter().map(|i|{
-    a[bitreverse(i as u32, log_size) as usize]
-  }).collect_into_vec(swap);
+  (0..n).into_par_iter().map(|i| a[bitreverse(i as u32, log_size) as usize]).collect_into_vec(swap);
 
   let mut curr = (swap, a);
 
   let mut m = 1;
   for _ in 0..log_size {
-    (0..n).into_par_iter().map(|i|{
-      let left = i % (2*m) < m;
-      let k = i / (2*m) * (2*m);
-      let j = i % m;
-      let w = match inv{
-        false  => domain.element(n / (2*m) * j),
-        true => domain.element(n - n / (2*m) * j)
-      };
-      let mut t = curr.0[(k+m)+j];
-      t *= w;
-      if left{
-        return curr.0[k+j]+t;
-      }else{
-        return curr.0[k+j]-t;
-      }
-    }).collect_into_vec(curr.1);
-    curr = (curr.1,curr.0);
+    (0..n)
+      .into_par_iter()
+      .map(|i| {
+        let left = i % (2 * m) < m;
+        let k = i / (2 * m) * (2 * m);
+        let j = i % m;
+        let w = match inv {
+          false => domain.element(n / (2 * m) * j),
+          true => domain.element(n - n / (2 * m) * j),
+        };
+        let mut t = curr.0[(k + m) + j];
+        t *= w;
+        if left {
+          return curr.0[k + j] + t;
+        } else {
+          return curr.0[k + j] - t;
+        }
+      })
+      .collect_into_vec(curr.1);
+    curr = (curr.1, curr.0);
     m *= 2;
   }
-  if log_size%2==0{
-    (0..n).into_par_iter().map(|i|{
-      curr.0[i]
-    }).collect_into_vec(curr.1);
+  if log_size % 2 == 0 {
+    (0..n).into_par_iter().map(|i| curr.0[i]).collect_into_vec(curr.1);
   }
 }
-pub fn fft<G:ScalarMul+std::ops::MulAssign<Fr>>(domain: GeneralEvaluationDomain<Fr>, a: &Vec<G>) -> Vec<G>{
+pub fn fft<G: ScalarMul + std::ops::MulAssign<Fr>>(domain: GeneralEvaluationDomain<Fr>, a: &Vec<G>) -> Vec<G> {
   let mut r = a.to_vec();
   fft_helper(&mut r, domain, false);
   r
 }
-pub fn ifft<G:ScalarMul+std::ops::MulAssign<Fr>>(domain: GeneralEvaluationDomain<Fr>, a: &Vec<G>) -> Vec<G>{
+pub fn ifft<G: ScalarMul + std::ops::MulAssign<Fr>>(domain: GeneralEvaluationDomain<Fr>, a: &Vec<G>) -> Vec<G> {
   let mut r = a.to_vec();
   fft_helper(&mut r, domain, true);
   r.par_iter_mut().for_each(|x| *x *= domain.size_inv());
   r
 }
-pub fn fft_in_place<G:ScalarMul+std::ops::MulAssign<Fr>>(domain: GeneralEvaluationDomain<Fr>, a: &mut Vec<G>){
+pub fn fft_in_place<G: ScalarMul + std::ops::MulAssign<Fr>>(domain: GeneralEvaluationDomain<Fr>, a: &mut Vec<G>) {
   fft_helper(a, domain, false);
 }
-pub fn ifft_in_place<G:ScalarMul+std::ops::MulAssign<Fr>>(domain: GeneralEvaluationDomain<Fr>, a: &mut Vec<G>){
+pub fn ifft_in_place<G: ScalarMul + std::ops::MulAssign<Fr>>(domain: GeneralEvaluationDomain<Fr>, a: &mut Vec<G>) {
   fft_helper(a, domain, true);
   a.par_iter_mut().for_each(|x| *x *= domain.size_inv());
 }
 
-pub fn circulant_mul<G:ScalarMul+std::ops::MulAssign<Fr>>(domain: GeneralEvaluationDomain<Fr>, c: &Vec<Fr>, a: &Vec<G>) -> Vec<G>{
+pub fn circulant_mul<G: ScalarMul + std::ops::MulAssign<Fr>>(domain: GeneralEvaluationDomain<Fr>, c: &Vec<Fr>, a: &Vec<G>) -> Vec<G> {
   let lambda = domain.fft(c);
-  let mut r = fft(domain,a);
-  r.par_iter_mut().enumerate().for_each(|(i,x)| *x *= lambda[i]);
-  ifft_in_place(domain,&mut r);
+  let mut r = fft(domain, a);
+  r.par_iter_mut().enumerate().for_each(|(i, x)| *x *= lambda[i]);
+  ifft_in_place(domain, &mut r);
   r
 }
 
-pub fn toeplitz_mul<G:ScalarMul+std::ops::MulAssign<Fr>>(domain: GeneralEvaluationDomain<Fr>, m: &Vec<Fr>, a: &Vec<G>) -> Vec<G>{
-  let n = (m.len()+1)/2;
+pub fn toeplitz_mul<G: ScalarMul + std::ops::MulAssign<Fr>>(domain: GeneralEvaluationDomain<Fr>, m: &Vec<Fr>, a: &Vec<G>) -> Vec<G> {
+  let n = (m.len() + 1) / 2;
   let mut temp = m.to_vec();
-  let mut m2 = temp.split_off(n-1);
+  let mut m2 = temp.split_off(n - 1);
   m2.push(Fr::zero());
   m2.append(&mut temp);
   let mut temp2 = a.to_vec();
-  temp2.resize(2*n, G::zero());
+  temp2.resize(2 * n, G::zero());
   let mut r = circulant_mul(domain, &m2, &temp2);
   r.resize(n, G::zero());
   r
 }
 
-pub fn msm<P: VariableBaseMSM>(a: &[P::MulBase], b: &[P::ScalarField]) -> P{
+pub fn msm<P: VariableBaseMSM>(a: &[P::MulBase], b: &[P::ScalarField]) -> P {
   let max_threads = rayon::current_num_threads();
   let size = ark_std::cmp::min(a.len(), b.len());
-  if max_threads > size{
+  if max_threads > size {
     return VariableBaseMSM::msm_unchecked(&a, &b);
   }
   let chunk_size = size / max_threads;
@@ -102,5 +101,5 @@ pub fn msm<P: VariableBaseMSM>(a: &[P::MulBase], b: &[P::ScalarField]) -> P{
   let b = &b[..size];
   let a_chunks = a.par_chunks(chunk_size);
   let b_chunks = b.par_chunks(chunk_size);
-  return a_chunks.zip(b_chunks).map(|(x,y)|->P{VariableBaseMSM::msm_unchecked(&x, &y)}).sum()
+  return a_chunks.zip(b_chunks).map(|(x, y)| -> P { VariableBaseMSM::msm_unchecked(&x, &y) }).sum();
 }


### PR DESCRIPTION
1. Strengthening the security of cq by having the prover send the elements `B_0_gamma, f_gamma, A_0` encoded as group elements rather than their plain values
2. Added default implementations to basic_block.rs to clean up the code. For example basic_block/add.rs doesn't need to implement the setup function as it has no setup.
3. Changed proof format to no longer include field elements as it is unsafe and no longer required
4. Added .gitignore
5. Ran rustfmt