### PR TITLE
Simplify cq

### DIFF
--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -5,9 +5,9 @@ use crate::util;
 use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::pairing::Pairing;
 use ark_ff::Field;
-use ark_poly::{evaluations::univariate::Evaluations, univariate::DensePolynomial, EvaluationDomain, GeneralEvaluationDomain, Polynomial};
+use ark_poly::{evaluations::univariate::Evaluations, univariate::DensePolynomial, EvaluationDomain, GeneralEvaluationDomain};
 use ark_std::{
-  ops::{Div, Mul, Sub},
+  ops::{Mul, Sub},
   One, UniformRand, Zero,
 };
 use rand::Rng;
@@ -65,7 +65,7 @@ impl BasicBlock for CQBasicBlock {
       table_dict.insert(model.raw[i], i);
     }
 
-    // Round 1
+    // Calculate m
     let mut m_i = HashMap::new();
     for i in 0..n {
       m_i.entry(table_dict.get(&inputs[0].raw[i]).unwrap()).and_modify(|x| *x += 1).or_insert(1);
@@ -73,68 +73,34 @@ impl BasicBlock for CQBasicBlock {
     let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.iter().map(|(i, y)| (L_i_x_1[**i], Fr::from(*y as u32))).unzip();
     let m_x_1 = util::msm::<G1Projective>(&temp, &temp2).into();
 
-    //Round 2
     let beta = Fr::rand(rng);
+
+    // Calculate A
     let A_i: HashMap<usize, Fr> = m_i.iter().map(|(i, y)| (**i, Fr::from(*y as u32) * (model.raw[**i] + beta).inverse().unwrap())).collect();
     let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_x_1[*i], *y)).unzip();
     let A_x_1 = util::msm::<G1Projective>(&temp, &temp2).into();
     let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (Q_i_x_1[*i], *y)).unzip();
     let Q_A_x_1 = util::msm::<G1Projective>(&temp, &temp2).into();
+    let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_0_x_1[*i], *y)).unzip();
+    let A_0_x_1 = util::msm::<G1Projective>(&temp, &temp2).into();
+    let A_0 = Fr::from(N as u32).inverse().unwrap() * A_i.iter().map(|(_, y)| *y).sum::<Fr>();
+    let A_0_1 = (srs.0[0] * A_0).into();
+
+    // Calculate B
     let B_i: Vec<Fr> = (0..n).map(|i| (inputs[0].raw[i] + beta).inverse().unwrap()).collect();
     let B = Evaluations::from_vec_and_domain(B_i.clone(), domain_n).interpolate();
-    let B_0 = DensePolynomial {
-      coeffs: B.coeffs[1..].to_vec(),
-    };
-    let B_0_x_1 = util::msm::<G1Projective>(&srs.0[0..n - 1], &B_0).into();
+    let B_x_1 = util::msm::<G1Projective>(&srs.0, &B.coeffs).into();
     let mut Q_B = B.mul(&(inputs[0].poly.clone() + (DensePolynomial { coeffs: vec![beta] })));
     Q_B = Q_B.sub(&DensePolynomial { coeffs: vec![Fr::one()] }).divide_by_vanishing_poly(domain_n).unwrap().0;
-    let Q_B_x_1 = util::msm::<G1Projective>(&srs.0[0..n - 1], &Q_B).into();
-    let P_x_1 = util::msm::<G1Projective>(&srs.0[N - n + 1..N], &B_0).into();
+    let Q_B_x_1 = util::msm::<G1Projective>(&srs.0, &Q_B).into();
+    let B_0_x_1 = util::msm::<G1Projective>(&srs.0, &B.coeffs[1..]).into();
+    let B_DC = util::msm::<G1Projective>(&srs.0[N - n..N], &B.coeffs).into();
 
-    //Round 3
-    let gamma = Fr::rand(rng);
-    let eta = Fr::rand(rng);
-    let B_0_gamma = B_0.evaluate(&gamma);
-    let f_gamma = inputs[0].poly.evaluate(&gamma);
-    let A_0 = Fr::from(N as u32).inverse().unwrap() * A_i.iter().map(|(_, y)| *y).sum::<Fr>();
-    let b_0 = Fr::from(N as u32) * A_0 * Fr::from(n as u32).inverse().unwrap();
-    let Z_H_gamma = domain_n.evaluate_vanishing_polynomial(gamma);
-    let b_gamma = B_0_gamma * gamma + b_0;
-    let Q_b_gamma = (b_gamma * (f_gamma + beta) - Fr::one()) * Z_H_gamma.inverse().unwrap();
-    let v = B_0_gamma + eta * f_gamma + eta * eta * Q_b_gamma;
-    let mut num = B_0 + inputs[0].poly.mul(eta) + Q_B.mul(eta * eta);
-    num -= &DensePolynomial { coeffs: vec![v] };
-    let h = num.div(&DensePolynomial {
-      coeffs: vec![-gamma, Fr::one()],
-    });
-    let pi_gamma = util::msm::<G1Projective>(&srs.0[..n - 1], &h).into();
-    let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_0_x_1[*i], *y)).unzip();
-    let A_0_x = util::msm::<G1Projective>(&temp, &temp2).into();
-
-    let B_0_gamma_1 = (srs.0[0] * B_0_gamma).into();
-    let b_gamma_1 = (srs.0[0] * b_gamma).into();
-    let f_gamma_1 = (srs.0[0] * f_gamma).into();
-    let f_gamma_2 = (srs.1[0] * f_gamma).into();
-    let A_0_1 = (srs.0[0] * A_0).into();
-    let b_gamma_f_gamma = (srs.0[0] * (b_gamma * (f_gamma + beta))).into();
+    let f_x_2 = util::msm::<G2Projective>(&srs.1[0..n], &inputs[0].poly.coeffs).into();
 
     return (
-      vec![
-        m_x_1,
-        A_x_1,
-        Q_A_x_1,
-        B_0_x_1,
-        Q_B_x_1,
-        P_x_1,
-        pi_gamma,
-        A_0_x,
-        B_0_gamma_1,
-        b_gamma_1,
-        f_gamma_1,
-        A_0_1,
-        b_gamma_f_gamma,
-      ],
-      vec![setup.1[0], f_gamma_2],
+      vec![m_x_1, A_x_1, Q_A_x_1, A_0_1, A_0_x_1, B_x_1, Q_B_x_1, B_0_x_1, B_DC],
+      vec![setup.1[0], f_x_2],
     );
   }
   fn verify<R: Rng>(
@@ -148,43 +114,49 @@ impl BasicBlock for CQBasicBlock {
     let N = model.len;
     let n = inputs[0].len;
     let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
-    let [m_x_1, A_x_1, Q_A_x_1, B_0_x_1, Q_B_x_1, P_x_1, pi_gamma, A_0_x, B_0_gamma_1, b_gamma_1, f_gamma_1, A_0_1, b_gamma_f_gamma] = proof.0[..]
-    else {
+    let [m_x_1, A_x_1, Q_A_x_1, A_0_1, A_0_x_1, B_x_1, Q_B_x_1, B_0_x_1, B_DC] = proof.0[..] else {
       panic!("Wrong proof format")
     };
-    let [T_x_2, f_gamma_2] = proof.1[..] else { panic!("Wrong proof format") };
+    let [T_x_2, f_x_2] = proof.1[..] else { panic!("Wrong proof format") };
 
-    // Round 2
     let beta = Fr::rand(rng);
-    let A_x_1: G1Projective = A_x_1.into();
-    let m_x_1: G1Projective = m_x_1.into();
-    let lhs = Bn254::pairing(A_x_1, T_x_2);
-    let rhs = Bn254::pairing(Q_A_x_1, srs.1[N] - srs.1[0]) + Bn254::pairing(m_x_1 - A_x_1 * beta, srs.1[0]);
-    assert!(lhs == rhs);
-    let lhs = Bn254::pairing(B_0_x_1, srs.1[N - 1 - (n - 2)]);
-    let rhs = Bn254::pairing(P_x_1, srs.1[0]);
+
+    // Check A_x_1 (A_i = m_i/(t_i+beta))
+    let lhs = Bn254::pairing(A_x_1, T_x_2) + Bn254::pairing(A_x_1 * beta - m_x_1, srs.1[0]);
+    let rhs = Bn254::pairing(Q_A_x_1, srs.1[N] - srs.1[0]);
     assert!(lhs == rhs);
 
-    // Check b_gamma_f_gamma
-    let lhs = Bn254::pairing(b_gamma_1, f_gamma_2 + srs.1[0] * beta);
-    let rhs = Bn254::pairing(b_gamma_f_gamma, srs.1[0]);
-    assert!(lhs == rhs);
-    let lhs = Bn254::pairing(f_gamma_1, srs.1[0]);
-    let rhs = Bn254::pairing(srs.0[0], f_gamma_2);
+    // Check T_x_2 is the G2 equivalent of T_x_1
+    let lhs = Bn254::pairing(model.g1, srs.1[0]);
+    let rhs = Bn254::pairing(srs.0[0], T_x_2);
     assert!(lhs == rhs);
 
-    // Round 3
-    let gamma = Fr::rand(rng);
-    let eta = Fr::rand(rng);
-    let Z_H_gamma = domain_n.evaluate_vanishing_polynomial(gamma);
-    let Q_b_gamma_1 = (b_gamma_f_gamma - srs.0[0]) * Z_H_gamma.inverse().unwrap();
-    let v = B_0_gamma_1 + f_gamma_1 * eta + Q_b_gamma_1 * eta * eta;
-    let c = B_0_x_1 + inputs[0].g1 * eta + Q_B_x_1 * eta * eta;
-    let lhs = Bn254::pairing(c - v + pi_gamma * gamma, srs.1[0]);
-    let rhs = Bn254::pairing(pi_gamma, srs.1[1]);
-    assert!(lhs == rhs);
+    // Check A(x) - A(0) is divisible by x
     let lhs = Bn254::pairing(A_x_1 - A_0_1, srs.1[0]);
-    let rhs = Bn254::pairing(A_0_x, srs.1[1]);
+    let rhs = Bn254::pairing(A_0_x_1, srs.1[1]);
+    assert!(lhs == rhs);
+
+    // Check B_x_1 (B_i = 1/(f_i+beta))
+    let lhs = Bn254::pairing(B_x_1, f_x_2) + Bn254::pairing(B_x_1 * beta - srs.0[0], srs.1[0]);
+    let rhs = Bn254::pairing(Q_B_x_1, srs.1[n] - srs.1[0]);
+    assert!(lhs == rhs);
+
+    // Check f_x_2 is the G2 equivalent of f_x_1
+    let lhs = Bn254::pairing(inputs[0].g1, srs.1[0]);
+    let rhs = Bn254::pairing(srs.0[0], f_x_2);
+    assert!(lhs == rhs);
+
+    // Assume B(0) = A(0)*N/n (which assumes ∑A=∑B)
+    let B_0_1: G1Affine = (A_0_1 * (Fr::from(N as u32) * Fr::from(n as u32).inverse().unwrap())).into();
+
+    // Check B(x) - B(0) is divisible by x
+    let lhs = Bn254::pairing(B_x_1 - B_0_1, srs.1[0]);
+    let rhs = Bn254::pairing(B_0_x_1, srs.1[1]);
+
+    // Degree check B
+    let lhs = Bn254::pairing(B_x_1, srs.1[N - n]);
+    let rhs = Bn254::pairing(B_DC, srs.1[0]);
+
     assert!(lhs == rhs);
   }
 }


### PR DESCRIPTION
Simplifies the cq protocol by sending `B(x)` instead of `B_0(gamma)`. This makes the protocol much easier to reason about, and easier to convert to zero knowledge in the future.

#### Proof of Soundness
1. `A_x_1` corresponds to the vector `A_i = m_i/(t_i+beta)` by checks 1,2
2. `A_0_1 = A(0)` by check 3
3. `B_x_1` corresponds to the vector `B_i = 1/(f_i+beta)` by checks 4,5,7
4. `B_0_1 = B(0)` by check 6
5. `∑A = A_0_1/N = B_0_1/n = ∑B` by construction of `B_0_1` and cq lemma 2.1
6. `f_i` is contained in `t_i` by cq lemma 2.4