### PR TITLE
NDArray, MatMult, ZeroMorph, and Bridge stuffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+debug/
+target/
+
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,10 @@ ark-ff = {version = "0.4", features = ["parallel"]}
 ark-ec = "0.4"
 ark-poly = {version = "0.4", features = ["parallel"]}
 ark-bn254 = "0.4"
+ark-poly-commit = "0.4"
 rand = "0.8.5"
 rayon = "1"
+ark-linear-sumcheck = {git= "https://github.com/arkworks-rs/sumcheck", version="0.3.0"}
+ark-serialize = { version = "^0.4.0", default-features = false, features = [ "derive" ] }
+ark-crypto-primitives = {version = "^0.4.0", default-features = false, features = ["sponge", "merkle_tree"] }
+ndarray = "0.15.6"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# zk-llm
+
+## To run the basic blocks
+```
+cargo run
+```

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -11,6 +11,7 @@ pub use add::AddBasicBlock;
 pub use rope::RopeBasicBlock;
 pub use transpose::TransposeBasicBlock;
 pub use matmult::MatMultBasicBlock;
+pub use bridge::BridgeBasicBlock;
 pub mod cq;
 pub mod cqlin;
 pub mod mul;
@@ -18,6 +19,7 @@ pub mod add;
 pub mod rope;
 pub mod transpose;
 pub mod matmult;
+pub mod bridge;
 
 pub struct Data{
   pub raw : Tensor<Fr>,

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -2,58 +2,71 @@ use ark_poly::univariate::DensePolynomial;
 use ark_poly::{GeneralEvaluationDomain, EvaluationDomain};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine};
 use rand::Rng;
+use ndarray::{Array, IxDyn};
 use crate::util;
 pub use cq::CQBasicBlock;
 pub use cqlin::CQLinBasicBlock;
 pub use mul::MulBasicBlock;
 pub use add::AddBasicBlock;
+pub use rope::RopeBasicBlock;
+pub use transpose::TransposeBasicBlock;
+pub use matmult::MatMultBasicBlock;
 pub mod cq;
 pub mod cqlin;
 pub mod mul;
 pub mod add;
+pub mod rope;
+pub mod transpose;
+pub mod matmult;
 
 pub struct Data{
-  pub raw : Vec<Fr>,
+  pub raw : Tensor<Fr>,
   pub poly: DensePolynomial<Fr>,
   pub g1: G1Affine
 }
 impl Data{
-  pub fn new(srs:(&Vec<G1Affine>,&Vec<G2Affine>), raw:&Vec<Fr>) -> Data{
-    let N = (*raw).len();
+  pub fn new(srs:(&Vec<G1Affine>,&Vec<G2Affine>), raw:&Tensor<Fr>) -> Data{
+    let raw_vec = raw.clone().into_raw_vec();
+    let N = (*raw_vec).len();
     let domain  = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
-    let f = DensePolynomial{coeffs: domain.ifft(raw)};
+    let f = DensePolynomial{coeffs: domain.ifft(&raw_vec)};
     let fx: G1Affine = util::msm::<G1Projective>(&srs.0[..N], &f.coeffs).into();
-    return Data{raw: raw.to_vec(), poly: f, g1: fx};
+    return Data{raw: raw.clone(), poly: f, g1: fx};
   }
 }
 pub struct DataEnc{
   pub len : usize,
-  pub g1: G1Affine
+  pub g1: G1Affine,
+  pub shape: Vec<usize>,
 }
 impl DataEnc{
   pub fn new(data:&Data) -> DataEnc{
-    return DataEnc{len: data.raw.len(), g1: data.g1};
+    return DataEnc{len: data.raw.len(), g1: data.g1, shape: data.raw.shape().to_owned()};
   }
 }
+
+pub type Tensor<F> = Array<F, IxDyn>;
 pub trait BasicBlock{
-  fn run(model: &Vec<Fr>,
-         inputs: &Vec<Vec<Fr>>) ->
-         Vec<Fr>;
+  type Setup;
+  type Proof;
+  fn run(model: &Vec<Tensor<Fr>>,
+         inputs: &Vec<Tensor<Fr>>) ->
+         Vec<Tensor<Fr>>;
   fn setup(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-           model: &Data) ->
-          (Vec<G1Affine>,Vec<G2Affine>);
+           model: &Data) -> Self::Setup;
+          //(Vec<G1Affine>,Vec<G2Affine>);
   fn prove<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-                   setup: (&Vec<G1Affine>,&Vec<G2Affine>),
+                   setup: &Self::Setup,
                    model: &Data,
                    inputs: &Vec<Data>,
                    output: &Data,
-                   rng: &mut R) ->
-                  (Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>);
+                   rng: &mut R) -> Self::Proof;
+                  //(Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>);
   fn verify<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
                     model: &DataEnc,
                     inputs: &Vec<DataEnc>,
                     output: &DataEnc,
-                    proof: (&Vec<G1Affine>,&Vec<G2Affine>,&Vec<Fr>),
+                    proof: &Self::Proof,
                     rng: &mut R);
 }
 

--- a/src/basic_block/add.rs
+++ b/src/basic_block/add.rs
@@ -1,17 +1,20 @@
 use ark_bn254::{Fr, G1Affine, G2Affine};
 use rand::Rng;
-use super::{BasicBlock,Data,DataEnc};
+use ndarray::{Array, IxDyn};
+use super::{BasicBlock,Data,DataEnc,Tensor};
 
 pub struct AddBasicBlock;
 impl BasicBlock for AddBasicBlock{
-  fn run(_model: &Vec<Fr>,
-         inputs: &Vec<Vec<Fr>>) ->
-         Vec<Fr>{
+  type Setup = (Vec<G1Affine>,Vec<G2Affine>);
+  type Proof = (Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>);
+  fn run(_model: &Vec<Tensor<Fr>>,
+         inputs: &Vec<Tensor<Fr>>) ->
+        Vec<Tensor<Fr>> {
     let mut r = Vec::new();
     for i in 0..inputs[0].len(){
       r.push(inputs[0][i]+inputs[1][i]);
     }
-    return r;
+    vec![Array::from_shape_vec(IxDyn(inputs[0].shape()), r).unwrap()]
   }
   fn setup(_srs: (&Vec<G1Affine>,&Vec<G2Affine>),
            _model: &Data) ->
@@ -19,7 +22,7 @@ impl BasicBlock for AddBasicBlock{
     return (Vec::new(), Vec::new());
   }
   fn prove<R: Rng>(_srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-                   _setup: (&Vec<G1Affine>,&Vec<G2Affine>),
+                   _setup: &Self::Setup,
                    _model: &Data,
                    _inputs: &Vec<Data>,
                    _output: &Data,
@@ -31,7 +34,7 @@ impl BasicBlock for AddBasicBlock{
                     _model: &DataEnc,
                     inputs: &Vec<DataEnc>,
                     output: &DataEnc,
-                    _proof: (&Vec<G1Affine>,&Vec<G2Affine>,&Vec<Fr>),
+                    _proof: &Self::Proof,
                     _rng: &mut R){
     // Verify f(x)+g(x)=h(x)
     let lhs = inputs[0].g1+inputs[1].g1;

--- a/src/basic_block/bridge.rs
+++ b/src/basic_block/bridge.rs
@@ -1,0 +1,127 @@
+use rand::Rng;
+use ark_ec::{VariableBaseMSM, pairing::Pairing};
+use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, Evaluations, GeneralEvaluationDomain, Polynomial};
+use ark_bn254::{Fr, G1Projective, G1Affine, G2Projective, G2Affine, Bn254};
+use ark_std::{ops::Mul, ops::Sub, ops::Div, One, Zero, UniformRand};
+use super::{BasicBlock,Data,DataEnc,Tensor};
+
+pub struct BridgeBasicBlock;
+impl BasicBlock for BridgeBasicBlock{
+  type Setup = (Vec<G1Affine>,Vec<G2Affine>);
+  type Proof = (Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>);
+  fn run(_model: &Vec<Tensor<Fr>>,
+         inputs: &Vec<Tensor<Fr>>) ->
+        Vec<Tensor<Fr>> {
+    inputs.to_vec()
+  }
+  fn setup(_srs: (&Vec<G1Affine>,&Vec<G2Affine>),
+           _model: &Data) ->
+          (Vec<G1Affine>,Vec<G2Affine>){
+    return (Vec::new(), Vec::new());
+  }
+  fn prove<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
+                   _setup: &Self::Setup,
+                   _model: &Data,
+                   inputs: &Vec<Data>,
+                   _output: &Data,
+                   rng: &mut R) ->
+                  (Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>){
+    let beta = Fr::rand(rng);
+    let beta2 = beta*beta;
+    let N = inputs[0].raw.len();
+    let domain  = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
+    let omega = domain.group_gen();
+
+    let coeff = &inputs[0].raw.clone().into_raw_vec();
+    let coeff_f: DensePolynomial<Fr> = DenseUVPolynomial::from_coefficients_vec(coeff.to_vec());
+    let open_value = coeff_f.evaluate(&omega);
+    let open_value_poly = DensePolynomial::from_coefficients_vec(vec![open_value]);
+    let coeff_com: G1Affine = G1Projective::msm(&srs.0[..coeff.len()], coeff).unwrap().into();
+    let evals_com = inputs[0].g1;
+    
+    let mut x_vec = vec![Fr::zero(); N];
+    x_vec[1] = Fr::one();
+    let x = DenseUVPolynomial::from_coefficients_vec(x_vec);
+
+    let mut l0_array: Vec<Fr> = Vec::new();
+    let mut ln_minus_one_array: Vec<Fr> = Vec::new();
+    let mut z_array: Vec<Fr> = Vec::new();
+    let mut z_omega_array: Vec<Fr> = Vec::new();
+    let mut z_tmp = Fr::zero();
+    let mut b = Fr::one();
+    for n in 0..N {
+      z_array.push(z_tmp);
+      if n == 0{
+        l0_array.push(Fr::one());
+        ln_minus_one_array.push(Fr::zero());
+      } else if n == N-1 {
+        l0_array.push(Fr::zero());
+        ln_minus_one_array.push(Fr::one());
+      } else {
+        l0_array.push(Fr::zero());
+        ln_minus_one_array.push(Fr::zero());
+      }
+      let a = inputs[0].raw[n];
+      z_tmp = z_tmp + a*b;
+      b *= omega;
+      z_omega_array.push(z_tmp);
+    }
+    assert!(z_omega_array[N-1]-open_value==Fr::zero());
+    assert!(ln_minus_one_array[N-1]==Fr::one());
+    assert!(ln_minus_one_array[N-2]==Fr::zero());
+
+    // heck L_0(X)*Z(X)=0    
+    // L_0(X)
+    let l0 = Evaluations::from_vec_and_domain(l0_array, domain).interpolate();
+    let ln_minus_one = Evaluations::from_vec_and_domain(ln_minus_one_array, domain).interpolate();
+    // Z(X)
+    let z = Evaluations::from_vec_and_domain(z_array, domain).interpolate();
+    // Z(wX)
+    let z_omega = Evaluations::from_vec_and_domain(z_omega_array, domain).interpolate();
+    //let mut z_omega = z.clone();
+    //GeneralEvaluationDomain::<Fr>::distribute_powers(&mut z_omega.coeffs, omega);
+    
+    let l0x2 = G2Projective::msm(&srs.1[..N], &l0.coeffs).unwrap().into();
+    let lnx2 = G2Projective::msm(&srs.1[..N], &ln_minus_one.coeffs).unwrap().into();
+    let zx = G1Projective::msm_unchecked(&srs.0[..N], &z.coeffs).into();
+    let z_omegax = G1Projective::msm_unchecked(&srs.0[..N], &z_omega.coeffs).into();
+    
+    // T(X) = [Z(wX)-Z(X)-Xf(X)+beta*L_0(X)*Z(X)+beta2*L_n(X)*(Z(wX)-v)]/[X^(N)-1]
+    let t = (z_omega.sub(&z).sub(&inputs[0].poly.mul(&x)) 
+    + (&l0.mul(&z)*beta)
+    + (&ln_minus_one.mul(&z_omega.sub(&open_value_poly))*beta2)).divide_by_vanishing_poly(domain).unwrap().0;
+    let tx = G1Projective::msm_unchecked(&srs.0[..N-1], &t.coeffs).into();
+
+    // Q(X) = [f'(X)-f'(w)]/ [X-w]
+    let x_minus_omega = DenseUVPolynomial::from_coefficients_vec(vec![-omega, Fr::one()]);
+    let mut f_prime_minus_f_prime_omega = coeff_f.clone();
+    f_prime_minus_f_prime_omega.coeffs[0] -= open_value;
+    let q = f_prime_minus_f_prime_omega.div(&x_minus_omega);
+    let qx = G1Projective::msm_unchecked(&srs.0[..N-1], &q.coeffs).into();
+
+    return (vec![tx, zx, z_omegax, coeff_com, evals_com, qx],vec![l0x2, lnx2],vec![open_value, omega]);
+  }
+  fn verify<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
+                    _model: &DataEnc,
+                    inputs: &Vec<DataEnc>,
+                    _output: &DataEnc,
+                    proof: &Self::Proof,
+                    rng: &mut R){
+    let beta = Fr::rand(rng);
+    let beta2 = beta*beta;
+    // Verify [Z(wX)-Z(X)-Xf(X)+beta*L_0(X)*Z(X)+beta2*L_n(X)*(Z(wX)-v)]=[X^(N)-1]T(X)
+    let N = inputs[0].shape[0];
+    let lhs = Bn254::pairing(proof.0[2],srs.1[0]) 
+    - Bn254::pairing(proof.0[1],srs.1[0])
+    - Bn254::pairing(proof.0[4],srs.1[1])
+    + Bn254::pairing(proof.0[1] * beta,proof.1[0])
+    + Bn254::pairing(proof.0[2] * beta2 - srs.0[0] * proof.2[0] * beta2,proof.1[1]);
+    let rhs = Bn254::pairing(proof.0[0],srs.1[N]-srs.1[0]);
+    assert!(lhs==rhs);
+    // Verify the opening f'(w) is valid
+    let lhs = Bn254::pairing(proof.0[5], srs.1[1]*Fr::one()-srs.1[0]*proof.2[1]);
+    let rhs = Bn254::pairing(proof.0[3]*Fr::one()-srs.0[0]*proof.2[0], srs.1[0]);
+    assert!(lhs==rhs);
+  }
+}
+

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -8,14 +8,16 @@ use ark_std::{Zero, One, ops::{Mul,Div,Sub}, UniformRand};
 use std::collections::HashMap;
 use rand::Rng;
 use rayon::prelude::*;
-use super::{BasicBlock,Data,DataEnc};
+use super::{BasicBlock,Data,DataEnc,Tensor};
 use crate::util;
 
 pub struct CQBasicBlock;
 impl BasicBlock for CQBasicBlock{
-  fn run(_model: &Vec<Fr>,
-         _inputs: &Vec<Vec<Fr>>) ->
-         Vec<Fr>{
+  type Proof = (Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>);
+  type Setup = (Vec<G1Affine>,Vec<G2Affine>);
+  fn run(_model: &Vec<Tensor<Fr>>,
+         _inputs: &Vec<Tensor<Fr>>) ->
+        Vec<Tensor<Fr>> {
     return Vec::new();
   }
   fn setup(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
@@ -49,7 +51,7 @@ impl BasicBlock for CQBasicBlock{
     return (setup,vec![T_x_2]);
   }
   fn prove<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-                   setup: (&Vec<G1Affine>,&Vec<G2Affine>),
+                   setup: &Self::Setup,
                    model: &Data,
                    inputs: &Vec<Data>,
                    _output: &Data,
@@ -115,7 +117,7 @@ impl BasicBlock for CQBasicBlock{
                     model: &DataEnc,
                     inputs: &Vec<DataEnc>,
                     _output: &DataEnc,
-                    proof: (&Vec<G1Affine>,&Vec<G2Affine>,&Vec<Fr>),
+                    proof: &Self::Proof,
                     rng: &mut R){
     let N = model.len;
     let n = inputs[0].len;

--- a/src/basic_block/cqlin.rs
+++ b/src/basic_block/cqlin.rs
@@ -7,22 +7,25 @@ use ark_bn254::{Fr, G1Projective, G2Projective, G1Affine, G2Affine, Bn254};
 use ark_std::{Zero, One, UniformRand};
 use rayon::prelude::*;
 use rand::Rng;
-use super::{BasicBlock,Data,DataEnc};
+use ndarray::{Array, IxDyn};
+use super::{BasicBlock,Data,DataEnc,Tensor};
 use crate::util;
 
 pub struct CQLinBasicBlock;
 impl BasicBlock for CQLinBasicBlock{
-  fn run(model: &Vec<Fr>,
-         inputs: &Vec<Vec<Fr>>) ->
-         Vec<Fr>{
+  type Proof = (Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>);
+  type Setup = (Vec<G1Affine>,Vec<G2Affine>);
+  fn run(model: &Vec<Tensor<Fr>>,
+         inputs: &Vec<Tensor<Fr>>) ->
+         Vec<Tensor<Fr>>{
     let n = inputs[0].len();
     let mut r = vec![Fr::zero() ; n];
     for i in 0..n{
       for j in 0..n{
-        r[i]+=model[j*n+i] * inputs[0][j];
+        r[i]+=model[0][[j*n+i]] * inputs[0][j];
       }
     }
-    return r;
+    vec![Array::from_shape_vec(IxDyn(&[n]), r).unwrap()]
   }
   fn setup(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
            model: &Data) ->
@@ -91,7 +94,7 @@ impl BasicBlock for CQLinBasicBlock{
     return (setup,vec![M_x.into()]);
   }
   fn prove<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-                   setup: (&Vec<G1Affine>,&Vec<G2Affine>),
+                   setup: &Self::Setup,
                    _model: &Data,
                    inputs: &Vec<Data>,
                    output: &Data,
@@ -105,11 +108,12 @@ impl BasicBlock for CQLinBasicBlock{
     let L_i_x = &setup.0[3*n..4*n];
     let L_i_x_n = &setup.0[4*n..];
 
-    let R_x = util::msm::<G1Projective>(R, &inputs[0].raw).into();
-    let Q_x = util::msm::<G1Projective>(Q, &inputs[0].raw).into();
+    let inputs_0_vec = inputs[0].raw.clone().into_iter().collect::<Vec<_>>();
+    let R_x = util::msm::<G1Projective>(R, &inputs_0_vec).into();
+    let Q_x = util::msm::<G1Projective>(Q, &inputs_0_vec).into();
     let temp: Vec<_> = (0..n).into_par_iter().map(|i|srs.0[n*i]).collect();
     let A_x = util::msm::<G1Projective>(&temp, &inputs[0].poly.coeffs).into();
-    let S_x = util::msm::<G1Projective>(S, &inputs[0].raw).into();
+    let S_x = util::msm::<G1Projective>(S, &inputs_0_vec).into();
     let P_x = util::msm::<G1Projective>(&srs.0[n*n-n..n*n], &output.poly.coeffs).into();
 
     let gamma = Fr::rand(rng);
@@ -126,7 +130,7 @@ impl BasicBlock for CQLinBasicBlock{
                     _model: &DataEnc,
                     inputs: &Vec<DataEnc>,
                     output: &DataEnc,
-                    proof: (&Vec<G1Affine>,&Vec<G2Affine>,&Vec<Fr>),
+                    proof: &Self::Proof,
                     rng: &mut R){
     let n = inputs[0].len;
     let [R_x,Q_x,A_x,S_x,P_x,z,pi,pi_1] = proof.0[..] else{panic!("Wrong proof format")};

--- a/src/basic_block/matmult.rs
+++ b/src/basic_block/matmult.rs
@@ -1,0 +1,157 @@
+use ark_ec::VariableBaseMSM;
+use ark_ff::Field;
+use ark_linear_sumcheck::ml_sumcheck::protocol::PolynomialInfo;
+use ark_poly::{DenseMultilinearExtension, MultilinearExtension};
+use ark_linear_sumcheck::ml_sumcheck::data_structures::ListOfProductsOfPolynomials;
+use ark_linear_sumcheck::ml_sumcheck::{MLSumcheck, Proof};
+use ark_std::{UniformRand, rand::Rng, Zero, One};
+use ark_std::rc::Rc;
+use ndarray::{Array, IxDyn};
+use ark_bn254::{Fr, G1Projective, G1Affine, G2Affine};
+use super::{BasicBlock,Data,DataEnc,Tensor};
+use crate::util;
+
+pub fn memoize<F: Field>(r: &Vec<F>, v: usize) -> Vec<F> {
+	match v {
+		1 => {
+			vec![chi_step(0, r[v - 1]), chi_step(1, r[v - 1])]
+		}
+		_ => memoize(r, v - 1)
+			.iter()
+			.flat_map(|val| {
+				[
+					*val * &chi_step(0, r[v - 1]),
+					*val * &chi_step(1, r[v - 1]),
+				]
+			})
+			.collect(),
+	}
+}
+
+pub fn chi_step<F: Field>(w: i128, x: F) -> F {
+    match w {
+        0 => F::one() - x,
+        1 => x,
+        _ => panic!("Invalid value for w"),
+    }
+}
+
+pub fn dynamic_mle<F: Field>(fw: &Vec<F>, r: &Vec<F>, n: usize) -> Vec<F> {
+	let chi_lookup = memoize(r, r.len());
+    let mut final_result = Vec::new();
+    for fw_chunk in fw.chunks(1<<n) {
+        let result: F = fw_chunk
+		.iter()
+		.zip(chi_lookup.iter())
+		.map(|(left, right)| *left * right)
+		.sum();
+        final_result.push(result);
+    }
+	
+	final_result
+}
+
+pub struct MatMultBasicBlock;
+impl BasicBlock for MatMultBasicBlock{
+  type Setup = Result<(),()>;
+  type Proof = (Proof<Fr>,PolynomialInfo,G1Affine,Fr,util::ZM_proof);
+  fn run(_model: &Vec<Tensor<Fr>>,
+         inputs: &Vec<Tensor<Fr>>) ->
+        Vec<Tensor<Fr>> {
+    let N = inputs[0].shape()[0];
+    let matrix_a = &inputs[0];
+    let matrix_b = &inputs[1];
+    let mut r = Vec::new();
+    for i in 0..N {
+      for j in 0..N {
+        let mut sum = Fr::zero();
+        for k in 0..N {
+          sum += matrix_a[[i,k]] * matrix_b[[k,j]];
+        }
+        r.push(sum);   
+      }
+    }
+    vec![Array::from_shape_vec(IxDyn(&[matrix_a.shape()[0], matrix_b.shape()[1]]), r).unwrap()]
+  }
+  fn setup(_srs: (&Vec<G1Affine>,&Vec<G2Affine>),
+           _model: &Data) ->
+           Result<(),()> {
+    // MatMult do nothing in setup
+    return Ok(());
+  }
+  fn prove<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
+                   _setup: &Self::Setup,
+                   _model: &Data,
+                   inputs: &Vec<Data>,
+                   output: &Data,
+                   rng: &mut R) ->
+                  Self::Proof{
+    let N = inputs[0].raw.shape()[0];
+    let n = (N as f64).log2() as usize;
+    let mut point_0 = Vec::new();
+    let mut point_1 = Vec::new();
+    for _ in 0..n {
+      point_0.push(Fr::rand(rng));
+      point_1.push(Fr::rand(rng));
+    }
+
+    // Tried to accerlate the prover by using dynamic MLE, but need some more works
+    //let f_b = DenseMultilinearExtension::from_evaluations_vec(n * 2, inputs[1].raw.clone());
+    //let f_b = f_b.relabel(0, n, n);
+    //let new_eval_b = dynamic_mle(&f_b.to_evaluations(), &point_1, n);
+    //let f_b = DenseMultilinearExtension::from_evaluations_vec(n, new_eval_b);
+    //let new_eval_a = dynamic_mle(&inputs[0].raw, &point_0, n);
+    //let f_a = DenseMultilinearExtension::from_evaluations_vec(n, new_eval_a);
+
+    let f_b = DenseMultilinearExtension::from_evaluations_vec(n * 2, inputs[1].raw.clone().into_raw_vec());
+    let f_b = f_b.relabel(0, n, n);
+    let f_b = f_b.fix_variables(&point_1);
+    let f_a = DenseMultilinearExtension::from_evaluations_vec(n * 2, inputs[0].raw.clone().into_raw_vec());
+    let f_a = f_a.fix_variables(&point_0);
+
+    let f_c = DenseMultilinearExtension::from_evaluations_vec(n * 2, output.raw.clone().into_raw_vec());
+    
+    let point = point_0.iter().chain(point_1.iter()).cloned().collect::<Vec<_>>();
+    let asserted_sum = f_c.evaluate(&point).unwrap();
+
+    let uni_f_c = util::univariazation(&f_c);
+    let uni_poly_coeff = &uni_f_c.coeffs;
+    let com: G1Affine = G1Projective::msm(&srs.0[..uni_poly_coeff.len()], uni_poly_coeff).unwrap().into();
+
+    let mut multiplicands = Vec::with_capacity(2);
+    multiplicands.push(Rc::new(f_a));
+    multiplicands.push(Rc::new(f_b));
+
+    let mut poly = ListOfProductsOfPolynomials::new(n);
+    poly.add_product(multiplicands.into_iter(), Fr::one());
+
+    let poly_info = poly.info();
+    let proof = MLSumcheck::prove(&poly).expect("fail to prove");
+    let zm_proof = util::zm_prove(srs, &f_c, &point, asserted_sum, rng, util::NV_MAX);
+    return (proof,poly_info,com,asserted_sum,zm_proof);
+  }
+  fn verify<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
+                    _model: &DataEnc,
+                    inputs: &Vec<DataEnc>,
+                    _output: &DataEnc,
+                    proof: &Self::Proof,
+                    rng: &mut R){
+    let N = inputs[0].shape[0];
+    let n = (N as f64).log2() as usize;
+    let mut point_0 = Vec::new();
+    let mut point_1 = Vec::new();
+    for _ in 0..n {
+      point_0.push(Fr::rand(rng));
+      point_1.push(Fr::rand(rng));
+    }
+    let point = point_0.iter().chain(point_1.iter()).cloned().collect::<Vec<_>>();
+    
+    let com = proof.2;
+    let asserted_sum = proof.3;
+    let zm_proof = &proof.4;
+
+    MLSumcheck::verify(&proof.1, asserted_sum, &proof.0).expect("fail to verify");
+    util::zm_verify(srs, util::NV_MAX, point.len(), com, zm_proof, asserted_sum, &point, rng);
+  }
+}
+

--- a/src/basic_block/matmult.rs
+++ b/src/basic_block/matmult.rs
@@ -1,77 +1,43 @@
 use ark_ec::VariableBaseMSM;
-use ark_ff::Field;
 use ark_linear_sumcheck::ml_sumcheck::protocol::PolynomialInfo;
 use ark_poly::{DenseMultilinearExtension, MultilinearExtension};
 use ark_linear_sumcheck::ml_sumcheck::data_structures::ListOfProductsOfPolynomials;
 use ark_linear_sumcheck::ml_sumcheck::{MLSumcheck, Proof};
+use ark_linear_sumcheck::rng::{Blake2s512Rng, FeedableRNG};
 use ark_std::{UniformRand, rand::Rng, Zero, One};
 use ark_std::rc::Rc;
+use rand::{rngs::StdRng,SeedableRng};
 use ndarray::{Array, IxDyn};
 use ark_bn254::{Fr, G1Projective, G1Affine, G2Affine};
 use super::{BasicBlock,Data,DataEnc,Tensor};
 use crate::util;
 
-pub fn memoize<F: Field>(r: &Vec<F>, v: usize) -> Vec<F> {
-	match v {
-		1 => {
-			vec![chi_step(0, r[v - 1]), chi_step(1, r[v - 1])]
-		}
-		_ => memoize(r, v - 1)
-			.iter()
-			.flat_map(|val| {
-				[
-					*val * &chi_step(0, r[v - 1]),
-					*val * &chi_step(1, r[v - 1]),
-				]
-			})
-			.collect(),
-	}
-}
-
-pub fn chi_step<F: Field>(w: i128, x: F) -> F {
-    match w {
-        0 => F::one() - x,
-        1 => x,
-        _ => panic!("Invalid value for w"),
-    }
-}
-
-pub fn dynamic_mle<F: Field>(fw: &Vec<F>, r: &Vec<F>, n: usize) -> Vec<F> {
-	let chi_lookup = memoize(r, r.len());
-    let mut final_result = Vec::new();
-    for fw_chunk in fw.chunks(1<<n) {
-        let result: F = fw_chunk
-		.iter()
-		.zip(chi_lookup.iter())
-		.map(|(left, right)| *left * right)
-		.sum();
-        final_result.push(result);
-    }
-	
-	final_result
-}
-
 pub struct MatMultBasicBlock;
 impl BasicBlock for MatMultBasicBlock{
   type Setup = Result<(),()>;
-  type Proof = (Proof<Fr>,PolynomialInfo,G1Affine,Fr,util::ZM_proof);
+  type Proof = (Proof<Fr>,PolynomialInfo,Fr,Fr,util::ZM_proof,util::ZM_proof,util::ZM_proof,util::ZM_proof,G1Affine,G1Affine,G1Affine,G1Affine,Fr);
   fn run(_model: &Vec<Tensor<Fr>>,
          inputs: &Vec<Tensor<Fr>>) ->
         Vec<Tensor<Fr>> {
-    let N = inputs[0].shape()[0];
+    // Matrix shapes: MxN * NxK = MxK
     let matrix_a = &inputs[0];
     let matrix_b = &inputs[1];
+    let (matrix_a, matrix_b) = (util::mat_padding(matrix_a), util::mat_padding(matrix_b));
+    let M = matrix_a.shape()[0];
+    let N = matrix_a.shape()[1];
+    let K = matrix_b.shape()[1];
     let mut r = Vec::new();
-    for i in 0..N {
-      for j in 0..N {
+    // matrix multiplication
+    for i in 0..M {
+      for j in 0..K {
         let mut sum = Fr::zero();
         for k in 0..N {
-          sum += matrix_a[[i,k]] * matrix_b[[k,j]];
+          sum += matrix_a[[i, k]] * matrix_b[[k, j]];
         }
-        r.push(sum);   
+        r.push(sum);
       }
     }
-    vec![Array::from_shape_vec(IxDyn(&[matrix_a.shape()[0], matrix_b.shape()[1]]), r).unwrap()]
+    vec![Array::from_shape_vec(IxDyn(&[M, K]), r).unwrap()]
   }
   fn setup(_srs: (&Vec<G1Affine>,&Vec<G2Affine>),
            _model: &Data) ->
@@ -86,49 +52,80 @@ impl BasicBlock for MatMultBasicBlock{
                    output: &Data,
                    rng: &mut R) ->
                   Self::Proof{
-    let N = inputs[0].raw.shape()[0];
+    // Matrix shapes: MxN * NxK = MxK
+    let matrix_a = &inputs[0].raw;
+    let matrix_b = &inputs[1].raw;
+    let (matrix_a, matrix_b) = (util::mat_padding(matrix_a), util::mat_padding(matrix_b));
+    let matrix_c = &output.raw;
+    let M = matrix_a.shape()[0];
+    let N = matrix_a.shape()[1];
+    let K = matrix_b.shape()[1];
+    let m = (M as f64).log2() as usize;
     let n = (N as f64).log2() as usize;
-    let mut point_0 = Vec::new();
-    let mut point_1 = Vec::new();
-    for _ in 0..n {
-      point_0.push(Fr::rand(rng));
-      point_1.push(Fr::rand(rng));
+    let k = (K as f64).log2() as usize;
+
+    // Verifier's random points
+    let mut point = Vec::new();
+    for _ in 0..(m+k) {
+      point.push(Fr::rand(rng));
     }
+    let tho = Fr::rand(rng);
 
-    // Tried to accerlate the prover by using dynamic MLE, but need some more works
-    //let f_b = DenseMultilinearExtension::from_evaluations_vec(n * 2, inputs[1].raw.clone());
-    //let f_b = f_b.relabel(0, n, n);
-    //let new_eval_b = dynamic_mle(&f_b.to_evaluations(), &point_1, n);
-    //let f_b = DenseMultilinearExtension::from_evaluations_vec(n, new_eval_b);
-    //let new_eval_a = dynamic_mle(&inputs[0].raw, &point_0, n);
-    //let f_a = DenseMultilinearExtension::from_evaluations_vec(n, new_eval_a);
-
-    let f_b = DenseMultilinearExtension::from_evaluations_vec(n * 2, inputs[1].raw.clone().into_raw_vec());
-    let f_b = f_b.relabel(0, n, n);
-    let f_b = f_b.fix_variables(&point_1);
-    let f_a = DenseMultilinearExtension::from_evaluations_vec(n * 2, inputs[0].raw.clone().into_raw_vec());
-    let f_a = f_a.fix_variables(&point_0);
-
-    let f_c = DenseMultilinearExtension::from_evaluations_vec(n * 2, output.raw.clone().into_raw_vec());
-    
-    let point = point_0.iter().chain(point_1.iter()).cloned().collect::<Vec<_>>();
-    let asserted_sum = f_c.evaluate(&point).unwrap();
+    // DenseMultilinearExtension is in little endian form so a matrix is stored in column major order (i.e., f(column, row))
+    let f_b = DenseMultilinearExtension::from_evaluations_vec(n + k, matrix_b.clone().into_raw_vec());
+    let f_b_fix = f_b.clone().fix_variables(&point[0..k]);
+    let f_a = DenseMultilinearExtension::from_evaluations_vec(m + n, matrix_a.clone().into_raw_vec());
+    let f_a_fix = util::fix_last_variables(&f_a, &point[k..m+k]);
+    let f_c = DenseMultilinearExtension::from_evaluations_vec(m + k, matrix_c.clone().into_raw_vec());
+    let f_c_value = f_c.evaluate(&point).unwrap();
+    let f_c_zm_proof = util::zm_prove(srs, &f_c, &point, f_c_value, rng, util::NV_MAX);
+    let mut rng1 = StdRng::from_entropy();
+    let (random_poly_rc, random_poly, random_poly_sum) = util::random_polynomial(n, &mut rng1);
 
     let uni_f_c = util::univariazation(&f_c);
-    let uni_poly_coeff = &uni_f_c.coeffs;
-    let com: G1Affine = G1Projective::msm(&srs.0[..uni_poly_coeff.len()], uni_poly_coeff).unwrap().into();
+    let uni_f_c_coeff = &uni_f_c.coeffs;
+    let com_f_c: G1Affine = G1Projective::msm(&srs.0[..uni_f_c_coeff.len()], uni_f_c_coeff).unwrap().into();
+    let uni_f_b = util::univariazation(&f_b);
+    let uni_f_b_coeff = &uni_f_b.coeffs;
+    let com_f_b: G1Affine = G1Projective::msm(&srs.0[..uni_f_b_coeff.len()], uni_f_b_coeff).unwrap().into();
+    let uni_f_a = util::univariazation(&f_a);
+    let uni_f_a_coeff = &uni_f_a.coeffs;
+    let com_f_a: G1Affine = G1Projective::msm(&srs.0[..uni_f_a_coeff.len()], uni_f_a_coeff).unwrap().into();
+    let uni_random_poly = util::univariazation(&random_poly[0]);
+    let uni_random_poly_coeff = &uni_random_poly.coeffs;
+    let com_random_poly: G1Affine = G1Projective::msm(&srs.0[..uni_random_poly_coeff.len()], uni_random_poly_coeff).unwrap().into();
 
     let mut multiplicands = Vec::with_capacity(2);
-    multiplicands.push(Rc::new(f_a));
-    multiplicands.push(Rc::new(f_b));
+    multiplicands.push(Rc::new(f_a_fix));
+    multiplicands.push(Rc::new(f_b_fix));
 
+    
     let mut poly = ListOfProductsOfPolynomials::new(n);
     poly.add_product(multiplicands.into_iter(), Fr::one());
+    poly.add_product(random_poly_rc.into_iter(), tho);
 
+    let asserted_sum = f_c_value + random_poly_sum * tho;
+
+    let mut fs_rng = Blake2s512Rng::setup();
     let poly_info = poly.info();
-    let proof = MLSumcheck::prove(&poly).expect("fail to prove");
-    let zm_proof = util::zm_prove(srs, &f_c, &point, asserted_sum, rng, util::NV_MAX);
-    return (proof,poly_info,com,asserted_sum,zm_proof);
+    let (sumcheck_proof, _prover_state) =
+        MLSumcheck::prove_as_subprotocol(&mut fs_rng, &poly).expect("fail to prove");
+
+    // In zkVPD, the prover will evaluate the polynomial at the random point for verifier since verifier has no ability to evaluate the polynomial
+    let mut fs_rng = Blake2s512Rng::setup();
+    let subclaim = MLSumcheck::verify_as_subprotocol(&mut fs_rng, &poly_info, asserted_sum, &sumcheck_proof).expect("fail to verify");
+    let verifier_random_point = subclaim.point;
+    // concat verifier's random point with prover's random point
+    let point_fb = point[..k].to_vec().iter().chain(verifier_random_point.iter()).cloned().collect::<Vec<_>>();
+    let point_fa = verifier_random_point.iter().chain(point[k..m+k].iter()).cloned().collect::<Vec<_>>();
+    let f_b_value = f_b.evaluate(&point_fb).unwrap();
+    let f_b_zm_proof = util::zm_prove(srs, &f_b, &point_fb, f_b_value, rng, util::NV_MAX);
+    let f_a_value = f_a.evaluate(&point_fa).unwrap();
+    let f_a_zm_proof = util::zm_prove(srs, &f_a, &point_fa, f_a_value, rng, util::NV_MAX);
+    let random_poly_value = random_poly[0].evaluate(&verifier_random_point).unwrap();
+    let random_poly_zm_proof = util::zm_prove(srs, &random_poly[0], &verifier_random_point, random_poly_value, rng, util::NV_MAX);
+    
+    return (sumcheck_proof,poly_info,asserted_sum,random_poly_sum, f_a_zm_proof, f_b_zm_proof, f_c_zm_proof, random_poly_zm_proof, com_f_a, com_f_b, com_f_c, com_random_poly, subclaim.expected_evaluation);
   }
   fn verify<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
                     _model: &DataEnc,
@@ -136,22 +133,41 @@ impl BasicBlock for MatMultBasicBlock{
                     _output: &DataEnc,
                     proof: &Self::Proof,
                     rng: &mut R){
-    let N = inputs[0].shape[0];
-    let n = (N as f64).log2() as usize;
-    let mut point_0 = Vec::new();
-    let mut point_1 = Vec::new();
-    for _ in 0..n {
-      point_0.push(Fr::rand(rng));
-      point_1.push(Fr::rand(rng));
-    }
-    let point = point_0.iter().chain(point_1.iter()).cloned().collect::<Vec<_>>();
-    
-    let com = proof.2;
-    let asserted_sum = proof.3;
-    let zm_proof = &proof.4;
+    let M = inputs[0].shape[0];
+    let K = inputs[1].shape[1];
+    let m = (M as f64).log2() as usize;
+    let k = (K as f64).log2() as usize;
 
-    MLSumcheck::verify(&proof.1, asserted_sum, &proof.0).expect("fail to verify");
-    util::zm_verify(srs, util::NV_MAX, point.len(), com, zm_proof, asserted_sum, &point, rng);
+    let mut point = Vec::new();
+    for _ in 0..(m+k) {
+      point.push(Fr::rand(rng));
+    }
+    let tho = Fr::rand(rng);
+    let sumcheck_proof = &proof.0;
+    let poly_info = &proof.1;
+    let mut asserted_sum = proof.2;
+    let random_poly_sum = proof.3;
+    let f_a_zm_proof = &proof.4;
+    let f_b_zm_proof = &proof.5;
+    let f_c_zm_proof = &proof.6;
+    let random_poly_zm_proof = &proof.7;
+    let com_f_a = proof.8;
+    let com_f_b = proof.9;
+    let com_f_c = proof.10;
+    let com_random_poly = proof.11;
+    let expected_evaluation = proof.12;
+
+    // Verifier can verify the sumcheck proof by herself
+    let mut fs_rng = Blake2s512Rng::setup();
+    MLSumcheck::verify_as_subprotocol(&mut fs_rng, &poly_info, asserted_sum, &sumcheck_proof).expect("fail to verify");
+    
+    // check four openings are correct
+    assert!(f_a_zm_proof.value*f_b_zm_proof.value+tho*random_poly_zm_proof.value == expected_evaluation, "wrong subclaim");
+    asserted_sum -= tho * random_poly_sum;
+    util::zm_verify(srs, util::NV_MAX, point.len(), com_f_c, f_c_zm_proof, rng);
+    util::zm_verify(srs, util::NV_MAX, f_b_zm_proof.point.len(), com_f_b, f_b_zm_proof, rng);
+    util::zm_verify(srs, util::NV_MAX, f_a_zm_proof.point.len(), com_f_a, f_a_zm_proof, rng);
+    util::zm_verify(srs, util::NV_MAX, random_poly_zm_proof.point.len(), com_random_poly, random_poly_zm_proof, rng);
   }
 }
 

--- a/src/basic_block/mul.rs
+++ b/src/basic_block/mul.rs
@@ -2,19 +2,22 @@ use ark_ec::{VariableBaseMSM, pairing::Pairing};
 use ark_poly::{GeneralEvaluationDomain, EvaluationDomain};
 use ark_bn254::{Fr, G1Projective, G1Affine, G2Projective, G2Affine, Bn254};
 use ark_std::{ops::Mul, ops::Sub};
+use ndarray::{Array, IxDyn};
 use rand::Rng;
-use super::{BasicBlock,Data,DataEnc};
+use super::{BasicBlock,Data,DataEnc,Tensor};
 
 pub struct MulBasicBlock;
 impl BasicBlock for MulBasicBlock{
-  fn run(_model: &Vec<Fr>,
-         inputs: &Vec<Vec<Fr>>) ->
-         Vec<Fr>{
+  type Proof = (Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>);
+  type Setup = (Vec<G1Affine>,Vec<G2Affine>);
+  fn run(_model: &Vec<Tensor<Fr>>,
+         inputs: &Vec<Tensor<Fr>>) ->
+        Vec<Tensor<Fr>> {
     let mut r = Vec::new();
     for i in 0..inputs[0].len(){
       r.push(inputs[0][i]*inputs[1][i]);
     }
-    return r;
+    vec![Array::from_shape_vec(IxDyn(inputs[0].shape()), r).unwrap()]
   }
   fn setup(_srs: (&Vec<G1Affine>,&Vec<G2Affine>),
            _model: &Data) ->
@@ -22,7 +25,7 @@ impl BasicBlock for MulBasicBlock{
     return (Vec::new(), Vec::new());
   }
   fn prove<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
-                   _setup: (&Vec<G1Affine>,&Vec<G2Affine>),
+                   _setup: &Self::Setup,
                    _model: &Data,
                    inputs: &Vec<Data>,
                    output: &Data,
@@ -39,7 +42,7 @@ impl BasicBlock for MulBasicBlock{
                     _model: &DataEnc,
                     inputs: &Vec<DataEnc>,
                     output: &DataEnc,
-                    proof: (&Vec<G1Affine>,&Vec<G2Affine>,&Vec<Fr>),
+                    proof: &Self::Proof,
                     _rng: &mut R){
     // Verify f(x)*g(x)-h(x)=z(x)t(x)
     let lhs = Bn254::pairing(inputs[0].g1,proof.1[0]) - Bn254::pairing(output.g1,srs.1[0]);

--- a/src/basic_block/rope.rs
+++ b/src/basic_block/rope.rs
@@ -1,0 +1,121 @@
+use ark_ec::{VariableBaseMSM, pairing::Pairing};
+use ark_poly::{GeneralEvaluationDomain, EvaluationDomain, Evaluations};
+use ark_bn254::{Fr, G1Projective, G1Affine, G2Projective, G2Affine, Bn254};
+use ark_std::{ops::Mul, ops::Sub};
+use ndarray::{Array, IxDyn};
+use rand::Rng;
+use super::{BasicBlock,Data,DataEnc,Tensor};
+use crate::util;
+
+
+// precompute freq_cis in llama
+fn compute_cos_sin(N: usize, D: usize) -> (Tensor<Fr>, Tensor<Fr>) {
+  let mut cos_vec = Vec::new();
+  let mut sin_vec = Vec::new();
+  for i in 0..N {
+    for j in 0..D {
+      let theta = i as f64 * (0.0001 as f64).powf(2. * (j as f64/2.).floor() as f64 / D as f64);
+      let cos = theta.cos();
+      let sin = theta.sin();
+      cos_vec.push(Fr::from((cos*util::SCALE_FACTOR as f64).floor() as i64));
+      sin_vec.push(Fr::from((sin*util::SCALE_FACTOR as f64).floor() as i64));
+    }
+  }
+  let cos = Array::from_shape_vec(IxDyn(&[N, D]), cos_vec).unwrap();
+  let sin = Array::from_shape_vec(IxDyn(&[N, D]), sin_vec).unwrap();
+  (cos, sin)
+}
+  
+// compute Q' or K' from Q or K
+// FIXME: we need to prove this computation is correct in zk-llm, too.
+fn compute_q_or_k_prime(input: &Tensor<Fr>) -> Tensor<Fr> {
+  let input_shape = input.shape();
+  let q_or_k = input.clone().into_raw_vec();
+  let q_or_k = q_or_k.chunks(input_shape[1]).map(|x| x.to_vec()).collect::<Vec<_>>();
+  // slice in odd indices
+  let odd_indices: Vec<Vec<Fr>> = q_or_k.iter().cloned().map(|row| row.into_iter().skip(1).step_by(2).collect()).collect();
+  
+  // slice in even indices
+  let even_indices: Vec<Vec<Fr>> = q_or_k.iter().cloned().map(|row| row.into_iter().step_by(2).collect()).collect();
+  
+  // stack them
+  let result: Vec<Vec<Fr>> = odd_indices.iter().zip(even_indices.iter()).map(|(row_odd, row_even)| {
+    row_odd.iter().zip(row_even.iter()).flat_map(|(&a, &b)| vec![a*Fr::from(-1), b]).collect()
+  }).collect();
+  
+  let flat_result = result.into_iter().flat_map(|inner_vec| inner_vec).collect();
+  let result = Array::from_shape_vec(IxDyn(&[input_shape[0], input_shape[1]]), flat_result).unwrap();
+  result
+}
+
+pub struct RopeBasicBlock;
+impl BasicBlock for RopeBasicBlock{
+  type Proof = (Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>);
+  type Setup = (Vec<G1Affine>,Vec<G2Affine>);
+  fn run(_model: &Vec<Tensor<Fr>>,
+         inputs: &Vec<Tensor<Fr>>) ->
+        Vec<Tensor<Fr>> {
+    
+    // input size is N*D
+    let N = inputs[0].shape()[0];
+    let D = inputs[0].shape()[1];
+    
+    let inputs_prime = compute_q_or_k_prime(&inputs[0]);
+    let (cos, sin) = compute_cos_sin(N, D);
+    let mut rope = Vec::new();
+    for i in 0..N {
+      let mut result_row = Vec::new();
+      for j in 0..D {
+        result_row.push(cos[[i,j]]*inputs[0][[i, j]] + sin[[i,j]]*inputs_prime[[i,j]]);
+      }
+      rope.push(result_row);
+    }
+    let flat_rope = rope.into_iter().flat_map(|inner_vec| inner_vec).collect();
+    vec![Array::from_shape_vec(IxDyn(&[N, D]), flat_rope).unwrap()]
+  }
+
+  fn setup(_srs: (&Vec<G1Affine>,&Vec<G2Affine>),
+           _model: &Data) ->
+          (Vec<G1Affine>,Vec<G2Affine>){
+    // TODO: we can actually perform cos and sin pre-computation here
+    return (Vec::new(), Vec::new());
+  }
+  fn prove<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
+                   _setup: &Self::Setup,
+                   _model: &Data,
+                   inputs: &Vec<Data>,
+                   output: &Data,
+                   _rng: &mut R) ->
+                  (Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>){
+    let N = inputs[0].raw.shape()[0];
+    let D = inputs[0].raw.shape()[1];
+    let domain  = GeneralEvaluationDomain::<Fr>::new(N*D).unwrap();
+    // compute cos and sin
+    let (cos, sin) = compute_cos_sin(N, D);
+    let flat_cos = cos.clone().into_iter().collect::<Vec<_>>();
+    let flat_sin = sin.clone().into_iter().collect::<Vec<_>>();
+    let g_cos = Evaluations::from_vec_and_domain(flat_cos, domain).interpolate();
+    let g_sin = Evaluations::from_vec_and_domain(flat_sin, domain).interpolate();
+    let g_cos_x2 = G2Projective::msm(&srs.1[..N*D], &g_cos.coeffs).unwrap().into();
+    let g_sin_x2 = G2Projective::msm(&srs.1[..N*D], &g_sin.coeffs).unwrap().into();
+    // compute Q' from Q
+    let q_or_k = inputs[0].raw.clone();
+    let q_or_k_prime = compute_q_or_k_prime(&q_or_k);
+    let input_prime_data = Data::new(srs,&q_or_k_prime);
+    let t = (inputs[0].poly.mul(&g_cos) + input_prime_data.poly.mul(&g_sin)).sub(&output.poly).divide_by_vanishing_poly(domain).unwrap().0;
+    let tx = G1Projective::msm(&srs.0[..N*D-1], &t.coeffs).unwrap().into();
+    return (vec![tx, input_prime_data.g1],vec![g_cos_x2, g_sin_x2],Vec::new());
+  }
+  fn verify<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
+                    _model: &DataEnc,
+                    inputs: &Vec<DataEnc>,
+                    output: &DataEnc,
+                    proof: &Self::Proof,
+                    _rng: &mut R){
+    // Verify f(x)*g_cos(x)+f'(x)*g_sin(x)-h(x)=z(x)t(x)
+    let lhs = Bn254::pairing(inputs[0].g1,proof.1[0]) + Bn254::pairing(proof.0[1],proof.1[1]) - Bn254::pairing(output.g1,srs.1[0]);
+    let rhs = Bn254::pairing(proof.0[0],srs.1[inputs[0].len]-srs.1[0]);
+    assert!(lhs==rhs);
+  }
+}
+

--- a/src/basic_block/transpose.rs
+++ b/src/basic_block/transpose.rs
@@ -1,0 +1,104 @@
+use ark_ec::{VariableBaseMSM, pairing::Pairing};
+use ark_poly::{GeneralEvaluationDomain, EvaluationDomain, Evaluations};
+use ark_bn254::{Fr, G1Projective, G1Affine, G2Projective, G2Affine, Bn254};
+use ark_std::{ops::Mul, ops::Sub, One, Zero, UniformRand};
+use rand::Rng;
+use super::{BasicBlock,Data,DataEnc,Tensor};
+
+pub struct TransposeBasicBlock;
+impl BasicBlock for TransposeBasicBlock{
+  type Proof = (Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>);
+  type Setup = (Vec<G1Affine>,Vec<G2Affine>);
+  fn run(_model: &Vec<Tensor<Fr>>,
+         inputs: &Vec<Tensor<Fr>>) ->
+        Vec<Tensor<Fr>>{
+
+    let input = inputs[0].clone();
+    let input_transpose = input.t().to_owned();
+    vec![input_transpose]
+  }
+
+  fn setup(_srs: (&Vec<G1Affine>,&Vec<G2Affine>),
+           _model: &Data) ->
+          (Vec<G1Affine>,Vec<G2Affine>){
+    return (Vec::new(), Vec::new());
+  }
+
+  fn prove<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
+                   _setup: &Self::Setup,
+                   _model: &Data,
+                   inputs: &Vec<Data>,
+                   _output: &Data,
+                   rng: &mut R) ->
+                  (Vec<G1Affine>,Vec<G2Affine>,Vec<Fr>){
+    let beta = Fr::rand(rng);
+    let gamma = Fr::rand(rng);
+    let N = inputs[0].raw.shape()[0];
+    let D = inputs[0].raw.shape()[1];
+
+    let mut z_tmp = Fr::one();
+    let mut ab_tmp = Fr::one();
+    let mut l1_array: Vec<Fr> = Vec::new();
+    let mut z_array: Vec<Fr> = Vec::new();
+    let mut z_array_: Vec<Fr> = Vec::new();
+    let mut ab_array: Vec<Fr> = Vec::new();
+    for n in 0..N {
+      if n == 0{
+        l1_array.push(Fr::one());
+      } else {
+        l1_array.push(Fr::zero());
+      }
+      z_array_.push(z_tmp);
+      for d in 0..D{
+        let a = inputs[0].raw[[n,d]]+beta*Fr::from((n*D+d) as i64)+gamma;
+        //let b = output.raw[n*D+d]+beta*Fr::from((d*D+n) as i64)+gamma; // TODO: should be this one
+        let b = inputs[0].raw[[d,n]]+beta*Fr::from((d*D+n) as i64)+gamma;
+        let a_div_b = a/b;
+        ab_tmp = ab_tmp*a_div_b;
+      }
+      z_tmp = z_tmp*ab_tmp;
+      z_array.push(z_tmp);
+      ab_array.push(ab_tmp);
+      ab_tmp = Fr::one();
+    }
+
+    let domain  = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
+
+    // TODO: need to check L_1(X)*(Z(X)-1)=0    
+    // L_1(X)
+    let l1 = Evaluations::from_vec_and_domain(l1_array, domain).interpolate();
+    // a(X)/b(X)
+    let f = Evaluations::from_vec_and_domain(ab_array, domain).interpolate();
+    // Z(wX)
+    let z = Evaluations::from_vec_and_domain(z_array, domain).interpolate();
+    // Z(X)
+    let z_ = Evaluations::from_vec_and_domain(z_array_, domain).interpolate();
+
+    let l1x = G1Projective::msm_unchecked(&srs.0, &l1.coeffs).into();
+    let fx = G1Projective::msm_unchecked(&srs.0, &f.coeffs).into(); 
+    let gx = G1Projective::msm_unchecked(&srs.0, &z.coeffs).into();
+    let gsx2 = G2Projective::msm(&srs.1[..N], &z_.coeffs).unwrap().into();
+    
+    // T(X) = [Z(wX)-Z(X)*(a(X)/b(X))]/[X^(N)-1]
+    let t = z.sub(&f.mul(&z_)).divide_by_vanishing_poly(domain).unwrap().0;
+    let tx = G1Projective::msm(&srs.0[..N-1], &t.coeffs).unwrap().into();
+    return (vec![tx, gx, fx, l1x],vec![gsx2],Vec::new());
+  }
+
+  fn verify<R: Rng>(srs: (&Vec<G1Affine>,&Vec<G2Affine>),
+                    _model: &DataEnc,
+                    inputs: &Vec<DataEnc>,
+                    _output: &DataEnc,
+                    proof: &Self::Proof,
+                    _rng: &mut R){
+    // Verify Z(wX)-Z(X)*(a(X)/b(X))=[X^(N)-1]T(X)
+    let table_width = inputs[0].shape[0];
+    let lhs = Bn254::pairing(proof.0[1],srs.1[0]) - Bn254::pairing(proof.0[2],proof.1[0]);
+    let rhs = Bn254::pairing(proof.0[0],srs.1[table_width]-srs.1[0]);
+    assert!(lhs==rhs);
+    // Verify L_1(X)*(Z(X)-1)=0   
+    // let l = Bn254::pairing(proof.0[3],proof.1[0]- srs.1[0]).is_zero();
+    // assert!(l);
+  }
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,16 +36,20 @@ fn main() {
   let srs = (&srs.0,&srs.1);
   const N:usize = 1<<6;
   const n:usize = 1<<3;
+  const m: usize = 1<<2;
   let a: Vec<_> = (0..N).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::rand(rng)).collect();
   let b: Vec<_> = (0..N).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::rand(rng)).collect();
   let a_tensor = Array::from_shape_vec(IxDyn(&[N]), a.clone()).unwrap();
   let b_tensor = Array::from_shape_vec(IxDyn(&[N]), b.clone()).unwrap();
   let c_tensor = Array::from_shape_vec(IxDyn(&[n, n]), b.clone()).unwrap();
+  let mat_a_tensor = Array::from_shape_vec(IxDyn(&[1<<3, 1<<2]), a[..1<<5].to_vec()).unwrap();
+  let mat_b_tensor = Array::from_shape_vec(IxDyn(&[1<<2, 1<<3]), b[..1<<5].to_vec()).unwrap();
   test_basic_block::<AddBasicBlock>(srs,&vec![a_tensor.clone()],&vec![a_tensor.clone(),b_tensor.clone()]);
   test_basic_block::<MulBasicBlock>(srs,&vec![a_tensor.clone()],&vec![a_tensor.clone(),b_tensor.clone()]);
   test_basic_block::<CQBasicBlock>(srs,&vec![a_tensor.clone()], &vec![Array::from_shape_vec(IxDyn(&[n]), a[..n].to_vec()).unwrap()]);
   test_basic_block::<CQLinBasicBlock>(srs,&vec![a_tensor.clone()],&vec![Array::from_shape_vec(IxDyn(&[n]), b[..n].to_vec()).unwrap()]);
   test_basic_block::<RopeBasicBlock>(srs,&vec![a_tensor.clone()],&vec![c_tensor.clone()]);
   test_basic_block::<TransposeBasicBlock>(srs,&vec![a_tensor.clone()],&vec![c_tensor.clone()]);
-  test_basic_block::<MatMultBasicBlock>(srs,&vec![a_tensor.clone()],&vec![c_tensor.clone(),c_tensor.clone()]);
+  test_basic_block::<MatMultBasicBlock>(srs,&vec![a_tensor.clone()],&vec![mat_a_tensor.clone(),mat_b_tensor.clone()]);
+  test_basic_block::<BridgeBasicBlock>(srs,&vec![a_tensor.clone()],&vec![a_tensor.clone()]);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,23 +5,31 @@ use ark_std::UniformRand;
 use rand::{rngs::StdRng,SeedableRng};
 use rayon::prelude::*;
 use basic_block::*;
+use ndarray::{Array, IxDyn};
 mod basic_block;
 mod util;
 mod ptau;
 
-fn test_basic_block<BB: BasicBlock>(srs: (&Vec<G1Affine>,&Vec<G2Affine>), model: &Vec<Fr>, inputs: &Vec<Vec<Fr>>){
+fn test_basic_block<BB: BasicBlock>(srs: (&Vec<G1Affine>,&Vec<G2Affine>), model: &Vec<Tensor<Fr>>, inputs: &Vec<Tensor<Fr>>){
   let mut rng = StdRng::from_entropy();
+  // Witness generation
   let output = BB::run(model,inputs);
-  let model = Data::new(srs, model);
+  // One-time setup for model
+  let model = Data::new(srs, &model[0]);
   let setup = BB::setup(srs,&model);
+  // Prover time
   let inputs = inputs.iter().map(|x| Data::new(srs,x)).collect();
-  let output = Data::new(srs,&output);
+  let mut output_data = Data::new(srs,&Tensor::zeros(IxDyn(&[0])));
+  if output.len() != 0 {
+    output_data = Data::new(srs,&output[0]);
+  }
   let mut rng2 = rng.clone();
-  let proof = BB::prove(srs,(&(setup.0),&(setup.1)),&model,&inputs,&output,&mut rng);
+  let proof = BB::prove(srs,&setup,&model,&inputs,&output_data,&mut rng);
   let model = DataEnc::new(&model);
   let inputs = inputs.iter().map(|x| DataEnc::new(x)).collect();
-  let output = DataEnc::new(&output);
-  BB::verify(srs,&model,&inputs,&output,(&(proof.0),&(proof.1),&(proof.2)),&mut rng2);
+  let output = DataEnc::new(&output_data);
+  // Verifier time
+  BB::verify(srs,&model,&inputs,&output,&proof,&mut rng2);
 }
 fn main() {
   let srs = ptau::load_file("challenge",7);
@@ -30,8 +38,14 @@ fn main() {
   const n:usize = 1<<3;
   let a: Vec<_> = (0..N).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::rand(rng)).collect();
   let b: Vec<_> = (0..N).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::rand(rng)).collect();
-  test_basic_block::<AddBasicBlock>(srs,&Vec::new(),&vec![a.clone(),b.clone()]);
-  test_basic_block::<MulBasicBlock>(srs,&Vec::new(),&vec![a.clone(),b.clone()]);
-  test_basic_block::<CQBasicBlock>(srs,&a,&vec![a[..n].to_vec()]);
-  test_basic_block::<CQLinBasicBlock>(srs,&a,&vec![b[..n].to_vec()]);
+  let a_tensor = Array::from_shape_vec(IxDyn(&[N]), a.clone()).unwrap();
+  let b_tensor = Array::from_shape_vec(IxDyn(&[N]), b.clone()).unwrap();
+  let c_tensor = Array::from_shape_vec(IxDyn(&[n, n]), b.clone()).unwrap();
+  test_basic_block::<AddBasicBlock>(srs,&vec![a_tensor.clone()],&vec![a_tensor.clone(),b_tensor.clone()]);
+  test_basic_block::<MulBasicBlock>(srs,&vec![a_tensor.clone()],&vec![a_tensor.clone(),b_tensor.clone()]);
+  test_basic_block::<CQBasicBlock>(srs,&vec![a_tensor.clone()], &vec![Array::from_shape_vec(IxDyn(&[n]), a[..n].to_vec()).unwrap()]);
+  test_basic_block::<CQLinBasicBlock>(srs,&vec![a_tensor.clone()],&vec![Array::from_shape_vec(IxDyn(&[n]), b[..n].to_vec()).unwrap()]);
+  test_basic_block::<RopeBasicBlock>(srs,&vec![a_tensor.clone()],&vec![c_tensor.clone()]);
+  test_basic_block::<TransposeBasicBlock>(srs,&vec![a_tensor.clone()],&vec![c_tensor.clone()]);
+  test_basic_block::<MatMultBasicBlock>(srs,&vec![a_tensor.clone()],&vec![c_tensor.clone(),c_tensor.clone()]);
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,13 +1,16 @@
 use ark_poly::univariate::DensePolynomial;
 use ark_std::ops::Mul;
 use ark_ec::pairing::Pairing;
-use ark_poly::{GeneralEvaluationDomain, EvaluationDomain, DenseUVPolynomial, MultilinearExtension};
+use ark_poly::{GeneralEvaluationDomain, EvaluationDomain, DenseUVPolynomial, MultilinearExtension, DenseMultilinearExtension};
 use ark_bn254::{Fr, G1Projective, G1Affine, G2Projective, G2Affine, Bn254};
 use ark_ff::Field;
-use ark_std::{One, Zero, UniformRand};
+use ark_std::{One, Zero, UniformRand, rc::Rc};
 use ark_std::rand::RngCore;
 use ark_ec::{ScalarMul, VariableBaseMSM};
+use ndarray::{Array, IxDyn, s};
 use rayon::prelude::*;
+
+use crate::Tensor;
 
 pub const SCALE_FACTOR: f64 = (1<<9) as f64;
 pub const NV_MAX: usize = 7;
@@ -369,6 +372,8 @@ pub fn compute_c_batched(
 }
 
 pub struct ZM_proof {
+  pub point: Vec<Fr>,
+  pub value: Fr,
   pub c_pi: G1Affine,
   pub c_q_k: Vec<G1Affine>,
   pub c_q: G1Affine
@@ -426,6 +431,8 @@ pub fn zm_prove<R: RngCore>(
   let pi_com: G1Affine = G1Projective::msm(&srs.0[..pi_coeff.len()], pi_coeff).unwrap().into();
 
   ZM_proof {
+    point: point.to_vec(),
+    value: value,
     c_pi: pi_com,
     c_q_k: c_q_k,
     c_q: q_com
@@ -438,10 +445,10 @@ pub fn zm_verify<R: RngCore>(
   nv: usize,
   com: G1Affine,
   zm_proof: &ZM_proof,
-  value: Fr,
-  point: &[Fr], // u_challenge
   rng: &mut R,
 ) {
+  let point = &zm_proof.point;
+  let value = zm_proof.value;
   let y_challenge = Fr::rand(rng);
   let x_challenge = Fr::rand(rng);
   let z_challenge = Fr::rand(rng);
@@ -492,5 +499,73 @@ pub fn test_zm_polynomial<R: RngCore>(
   let zm_proof = zm_prove(srs, poly, point, value, rng, nv_max);
 
   // pairing
-  zm_verify(srs, nv_max, nv, com, &zm_proof, value, point, rng);
+  zm_verify(srs, nv_max, nv, com, &zm_proof, rng);
+}
+
+// Random polynomial
+pub fn random_polynomial<F: Field, R: RngCore>(
+  nv: usize,
+  rng: &mut R,
+) -> (Vec<Rc<DenseMultilinearExtension<F>>>, Vec<DenseMultilinearExtension<F>>, F) {
+  let mut multiplicands = Vec::new();
+  // only one multiplicand
+  multiplicands.push(Vec::with_capacity(1 << nv));
+  let mut sum = F::zero();
+
+  for _ in 0..(1 << nv) {
+      let mut product = F::one();
+      for multiplicand in &mut multiplicands {
+          let val = F::rand(rng);
+          multiplicand.push(val);
+          product *= val;
+      }
+      sum += product;
+  }
+
+  (
+      multiplicands.clone()
+          .into_iter()
+          .map(|x| Rc::new(DenseMultilinearExtension::from_evaluations_vec(nv, x)))
+          .collect(),
+      multiplicands
+          .into_iter()
+          .map(|x| DenseMultilinearExtension::from_evaluations_vec(nv, x))
+          .collect(),
+      sum,
+  )
+}
+
+// For rectangle matrix in MatMult
+pub fn mat_padding (
+  mat_a: &Tensor<Fr>,
+) -> Tensor<Fr> {
+  let mat_a_shape = mat_a.shape();
+
+  let a_num_row_log = (mat_a_shape[0] as f64).log2() as usize;
+  let a_num_col_log = (mat_a_shape[1] as f64).log2() as usize;
+  let mut new_mat_a = Array::from_shape_vec(IxDyn(&[1 << a_num_row_log, 1 << a_num_col_log]), vec![Fr::zero(); (1 << a_num_row_log) * (1 << a_num_col_log)]).unwrap();
+  new_mat_a.slice_mut(s![..mat_a_shape[0], ..mat_a_shape[1]]).assign(&mat_a);
+  //new_mat_a[[mat_a_shape[0], mat_a_shape[1]]] = Fr::rand(&mut ark_std::test_rng());
+  new_mat_a
+}
+
+// similar to fix_variables in ark-poly, but fix last variables
+pub fn fix_last_variables(
+  poly: &DenseMultilinearExtension<Fr>,
+  point: &[Fr]
+) -> DenseMultilinearExtension<Fr> {
+  let nv = poly.num_vars;
+  let dim = point.len();
+  let mut evals = poly.to_evaluations();
+  let mut evals_len = evals.len();
+  let mut point_len = point.len();
+  while point_len > 0 {
+    let half_eval_len = evals_len / 2;
+    for i in 0..half_eval_len {
+      evals[i] = evals[i] * (Fr::one()-point[point_len-1]) + evals[i+half_eval_len] * point[point_len-1];
+    }
+    evals_len = half_eval_len;
+    point_len -= 1;
+  }
+  DenseMultilinearExtension::from_evaluations_slice(nv - dim, &evals[..(1 << (nv - dim))])
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,16 @@
-use ark_poly::{GeneralEvaluationDomain, EvaluationDomain};
-use ark_bn254::Fr;
-use ark_std::Zero;
+use ark_poly::univariate::DensePolynomial;
+use ark_std::ops::Mul;
+use ark_ec::pairing::Pairing;
+use ark_poly::{GeneralEvaluationDomain, EvaluationDomain, DenseUVPolynomial, MultilinearExtension};
+use ark_bn254::{Fr, G1Projective, G1Affine, G2Projective, G2Affine, Bn254};
+use ark_ff::Field;
+use ark_std::{One, Zero, UniformRand};
+use ark_std::rand::RngCore;
 use ark_ec::{ScalarMul, VariableBaseMSM};
 use rayon::prelude::*;
+
+pub const SCALE_FACTOR: f64 = (1<<9) as f64;
+pub const NV_MAX: usize = 7;
 
 fn bitreverse(mut n: u32, l: u64) -> u32 {
   let mut r = 0;
@@ -102,4 +110,387 @@ pub fn msm<P: VariableBaseMSM>(a: &[P::MulBase], b: &[P::ScalarField]) -> P{
   let a_chunks = a.par_chunks(chunk_size);
   let b_chunks = b.par_chunks(chunk_size);
   return a_chunks.zip(b_chunks).map(|(x,y)|->P{VariableBaseMSM::msm_unchecked(&x, &y)}).sum()
+}
+
+
+/// Below are all for Zeromorph
+/// pow helper function
+fn integer_to_u64_limbs(exp: u128) -> Vec<u64> {
+  let mut limbs: Vec<u64> = Vec::new();
+  let mut remaining_exp = exp;
+
+  while remaining_exp > 0 {
+    let limb = remaining_exp & 0xFFFFFFFFFFFFFFFF; // Mask to obtain the lower 64 bits
+    limbs.push(limb as u64);
+    remaining_exp >>= 64; // Right shift by 64 bits
+  }
+
+  // If the exponent is zero, make sure to include at least one limb representing zero.
+  if limbs.is_empty() {
+    limbs.push(0);
+  }
+
+  limbs
+}
+
+/// univariatization
+/// convert a multilinear polynomial to a univariate polynomial
+/// by evaluating the polynomial at 2^num_vars points
+/// mapping f to U(f)
+pub fn univariazation(
+  polynomial: &impl MultilinearExtension<Fr>,
+) -> DensePolynomial<Fr> {
+  let evals = polynomial.to_evaluations();
+  DensePolynomial::from_coefficients_vec(evals)
+}
+
+/// compute univariatized multilinear quotients U(q_k), k = 0, ..., log_N-1
+/// commiter function
+pub fn compute_multilinear_quotients(polynomial: &impl MultilinearExtension<Fr>, u_challenge: &[Fr]) -> Vec<DensePolynomial<Fr>> {
+  let log_N = u_challenge.len();
+  let evaluations = polynomial.to_evaluations();
+  // Define the vector of quotients q_k, k = 0, ..., log_N-1
+  let mut quotients: Vec<DensePolynomial::<Fr>> = Vec::with_capacity(log_N);
+  // Compute the coefficients of q_{n-1}
+  let mut size_q = 1 << (log_N - 1);
+  let mut q_coeff: Vec<Fr> = Vec::with_capacity(size_q);
+  for l in 0..size_q {
+    q_coeff.push(evaluations[size_q + l] - evaluations[l]);
+  }
+  let q: DensePolynomial<Fr> = DensePolynomial::from_coefficients_vec(q_coeff.clone());
+  
+  quotients.push(q); // [log_N - 1]
+  let mut g: Vec<Fr> = evaluations[0..size_q].to_vec();
+  // Compute q_k in reverse order from k= n-2, i.e. q_{n-2}, ..., q_0
+  for k in 1..log_N {
+    // Compute f_k
+    let mut f_k: Vec<Fr> = Vec::with_capacity(size_q);
+    for l in 0..size_q {
+        f_k.push(g[l] + u_challenge[log_N - k] * q_coeff[l]);
+    }
+    size_q = size_q / 2;
+    let mut new_q_coeff: Vec<Fr> = Vec::with_capacity(size_q);
+    for l in 0..size_q {
+        new_q_coeff.push(f_k[size_q + l] - f_k[l]);
+    }
+    quotients.push(DensePolynomial::from_coefficients_vec(new_q_coeff.clone())); // [log_N - k - 1]
+    q_coeff = new_q_coeff;
+    g = f_k.clone();
+  }
+  quotients.into_iter().rev().collect()
+}
+
+/// Compute batched lifted degree quotient polynomial \hat{q}
+/// commiter function
+pub fn compute_batched_lifted_degree_quotient(quotients: &Vec<DensePolynomial<Fr>>, y_challenge: Fr, N: usize) -> DensePolynomial<Fr> {
+  // Batched lifted degree quotient polynomial
+  let mut result_coeff: Vec<Fr> = vec![Fr::zero(); N];
+  // Compute \hat{q} = \sum_k y^k * X^{N - d_k - 1} * q_k
+  let mut k = 0;
+  let mut scalar = Fr::one(); // y^k
+  for quotient in quotients.iter() {
+    // Rather than explicitly computing the shifts of q_k by N - d_k - 1 (i.e. multiplying q_k by X^{N - d_k - 1})
+    // then accumulating them, we simply accumulate y^k*q_k into \hat{q} at the index offset N - d_k - 1
+    let deg_k = (1 << k) - 1;
+    let offset = N - deg_k - 1;
+    for idx in 0..(deg_k + 1) {
+        result_coeff[offset + idx] += scalar * quotient.coeffs()[idx];
+    }
+    scalar *= y_challenge; // update batching scalar y^k
+    k += 1;
+  }
+  DensePolynomial::from_coefficients_vec(result_coeff.clone())
+}
+
+/// compute partially evaluated degree check polynomial \zeta_x
+/// commiter function
+pub fn compute_partially_evaluated_degree_check_polynomial(batched_quotient: &DensePolynomial<Fr>, quotients: &Vec<DensePolynomial<Fr>>, y_challenge: Fr, x_challenge: Fr) -> DensePolynomial<Fr> {
+  let N = batched_quotient.coeffs().len();
+  let log_N = quotients.len();
+  // Initialize partially evaluated degree check polynomial \zeta_x to \hat{q}
+  let mut result = batched_quotient.clone();
+  let mut y_power = Fr::one(); // y^k
+  for k in 0..log_N {
+    // Accumulate y^k * x^{N - d_k - 1} * q_k into \hat{q}
+    let deg_k = (1 << k) - 1;
+    let challenge_pow= integer_to_u64_limbs((N - deg_k - 1) as u128);
+    let x_power = x_challenge.pow(challenge_pow); // x^{N - d_k - 1}
+    let x_y_power = -x_power * y_power;
+    result = result + quotients[k].mul(x_y_power);
+    y_power *= y_challenge; // update batching scalar y^k
+  }
+  result
+}
+
+/// compute z_x
+/// commiter function
+pub fn compute_partially_evaluated_zeromorph_identity_polynomial(
+  f: &DensePolynomial<Fr>,
+  quotients: &Vec<DensePolynomial<Fr>>,
+  v_evaluation: Fr,
+  u_challenge: &[Fr],
+  x_challenge: Fr,
+) -> DensePolynomial<Fr> {
+  let log_N = quotients.len();
+  let N = 1<<log_N;
+  // Initialize Z_x with f
+  let mut result = f.clone();
+  // Compute Z_x -= v * \Phi_n(x)
+  let N_exp = integer_to_u64_limbs(N);
+  let phi_numerator = x_challenge.pow(N_exp) - Fr::one(); // x^N - 1
+  let phi_n_x = phi_numerator / (x_challenge - Fr::one());
+  result = result + DensePolynomial::from_coefficients_vec(vec![-v_evaluation * phi_n_x]);
+  // Add contribution from q_k polynomials
+  let mut x_power = x_challenge; // x^{2^k}
+  for k in 0..log_N {
+    let x_challenge_exp = integer_to_u64_limbs(1 << k);
+    let x_1_challenge_exp = integer_to_u64_limbs(1 << (k+1));
+    x_power = x_challenge.pow(x_challenge_exp.clone()); // x^{2^k}
+    // \Phi_{n-k-1}(x^{2^{k + 1}})
+    let phi_term_1 = phi_numerator / (x_challenge.pow(x_1_challenge_exp) - Fr::one());
+    // \Phi_{n-k}(x^{2^k})
+    let phi_term_2 = phi_numerator / (x_challenge.pow(x_challenge_exp) - Fr::one());
+    // x^{2^k} * \Phi_{n-k-1}(x^{2^{k+1}}) - u_k *  \Phi_{n-k}(x^{2^k})
+    let scalar = x_power * phi_term_1 - u_challenge[k] * phi_term_2;
+    result = result + quotients[k].mul(-scalar);
+  }
+  result
+}
+
+/// Compute the proof pi
+/// commiter function
+pub fn compute_batched_evaluation_and_degree_check_quotient(
+  zeta_x: DensePolynomial<Fr>,
+  Z_x: DensePolynomial<Fr>,
+  x_challenge: Fr,
+  z_challenge: Fr,
+  N_max: usize,
+) -> DensePolynomial<Fr> {
+  // We cannot commit to polynomials with size > N_max
+  let N = zeta_x.coeffs().len();
+  assert!(N <= N_max);
+
+  // Compute q_{\zeta} and q_Z in place
+  let divisor = DensePolynomial::from_coefficients_vec(vec![-x_challenge, Fr::one()]);
+  let q_zeta = &zeta_x / &divisor;
+  let q_Z = &Z_x / &divisor;
+
+  // Compute batched quotient q_{\zeta} + z*q_Z
+  let batched_quotient = q_zeta.clone() + q_Z.clone().mul(z_challenge);
+
+  // TODO: To complete the degree check, we need to commit to (q_{\zeta} + z*q_Z)*X^{N_max - N - 1}.
+  // Verification then requires a pairing check similar to the standard KZG check but with [1]_2 replaced by
+  // [X^{N_max - N - 1}]_2. Two issues: A) we do not have an SRS with these G2 elements (so need to generate a fake
+  // setup until we can do the real thing), and B) it's not clear how to update our pairing algorithms to do this
+  // type of pairing. For now, simply construct q_{\zeta} + z*q_Z without the shift and do a standard KZG
+  // pairing check. When we're ready, all we have to do to make this fully legit is commit to the shift here and
+  // update the pairing check accordingly. Note: When this is implemented properly, it doesn't make sense to store
+  // the (massive) shifted polynomial of size N_max. Ideally, we would only store the unshifted version and just
+  // compute the shifted commitment directly via a new method.
+  // let batched_shifted_quotient = batched_quotient.clone()*X^{N_max - N - 1}???;
+  let mut shift_vec = vec![Fr::zero(); N_max - N - 1];
+  shift_vec.append(&mut batched_quotient.coeffs().to_vec());
+    
+  //let batched_shifted_quotient = batched_quotient.clone();
+  let batched_shifted_quotient = DensePolynomial::from_coefficients_vec(shift_vec);
+  batched_shifted_quotient
+}
+
+/// Compute Commitment of Zeta_x
+/// verifier function
+pub fn compute_c_zeta_x(
+  c_q: G1Affine,
+  c_q_k: &Vec<G1Affine>,
+  y_challenge: Fr,
+  x_challenge: Fr,
+) -> G1Affine {
+  let log_N = c_q_k.len();
+  let N = 1 << log_N; // Check this later
+  // Contribution from C_q
+  let mut result = c_q.mul(Fr::one());
+    
+  // Contribution from C_q_k, k = 0, ..., log_n
+  for k in 0..log_N {
+    let deg_k = (1 << k) - 1;
+    // Compute scalar y^k * x^{N - deg_k - 1}
+    let y_exp = integer_to_u64_limbs(k as u128);
+    let x_exp = integer_to_u64_limbs(N - deg_k - 1);
+    let scalar = -y_challenge.pow(y_exp) * x_challenge.pow(x_exp);
+    result += c_q_k[k].mul(scalar);
+  }
+  result.into()
+}
+  
+/// Compute Commitment of Z_x
+/// verifier function
+pub fn compute_c_z_x(
+  f_commitment: G1Affine,
+  one_commitment: G1Affine, // G1
+  c_q_k: &Vec<G1Affine>,
+  v_evaluation: Fr,
+  x_challenge: Fr,
+  u_challenge: &[Fr],
+) -> G1Affine {
+  let log_N = c_q_k.len();
+  let N = 1 << log_N;
+  let mut result = f_commitment.mul(Fr::one());
+  // Phi_n(x) = (x^N - 1) / (x - 1)
+  let exp_N = integer_to_u64_limbs(N);
+  let phi_numerator = x_challenge.pow(exp_N) - Fr::one(); // x^N - 1
+  let phi_n_x = phi_numerator / (x_challenge - Fr::one());
+  // For now, workaround solution by minus C_v,x outside
+  // // Add contribution: -v * \Phi_n(x) * [1]_1
+  result += one_commitment.mul(-v_evaluation * phi_n_x);
+  // Add contributions: scalar * [q_k],  k = 0,...,log_N, where
+  // scalar = -"x" * (x^{2^k} * \Phi_{n-k-1}(x^{2^{k+1}}) - u_k * \Phi_{n-k}(x^{2^k}))
+  let mut x_pow_2k = x_challenge; // x^{2^k}
+  let mut x_pow_2kp1 = x_challenge * x_challenge; // x^{2^{k + 1}}
+  for k in 0..log_N {
+    let phi_term_1 = phi_numerator / (x_pow_2kp1 - Fr::one()); // \Phi_{n-k-1}(x^{2^{k + 1}})
+    let phi_term_2 = phi_numerator / (x_pow_2k - Fr::one()); // \Phi_{n-k}(x^{2^k})
+    let scalar = x_pow_2k * phi_term_1 - u_challenge[k] * phi_term_2;
+    result += c_q_k[k].mul(-scalar);
+    // Update powers of challenge x
+    x_pow_2k = x_pow_2kp1;
+    x_pow_2kp1 *= x_pow_2kp1;
+  }
+  result.into()
+}
+
+/// Compute Commitment of Zeta_x + z * Commitment of Z_x
+/// verifier function
+pub fn compute_c_batched(
+  c_zeta_x: G1Affine,
+  c_z_x: G1Affine,
+  z_challenge: Fr,
+) -> G1Affine {
+  let commitment = c_zeta_x + c_z_x.mul(z_challenge);
+  commitment.into()
+}
+
+pub struct ZM_proof {
+  pub c_pi: G1Affine,
+  pub c_q_k: Vec<G1Affine>,
+  pub c_q: G1Affine
+}
+
+// P (C,u = (u0, . . . , un−1), v, f, r) → V(C,u, v)
+// E2E ZeroMorph
+pub fn zm_prove<R: RngCore>(
+  srs: (&Vec<G1Affine>,&Vec<G2Affine>),
+  poly: &impl MultilinearExtension<Fr>,
+  point: &[Fr], // u_challenge
+  value: Fr, // v_evaluation
+  rng: &mut R,
+  nv_max: usize,
+) -> ZM_proof {
+  let nv = poly.num_vars();
+  assert_ne!(nv, 0);
+
+  let uni_poly = univariazation(poly);
+
+  // Committer Step1
+  let quotients = compute_multilinear_quotients(poly, &point);
+
+  // Committer Step2
+  let y_challenge = Fr::rand(rng);
+  let batched_quotient = compute_batched_lifted_degree_quotient(&quotients, y_challenge, 1 << nv);
+
+  // Committer Step3
+  let x_challenge = Fr::rand(rng);
+  let z_challenge = Fr::rand(rng);
+  let zeta_x = compute_partially_evaluated_degree_check_polynomial(&batched_quotient, &quotients, y_challenge, x_challenge);
+  let z_x = compute_partially_evaluated_zeromorph_identity_polynomial(&uni_poly, &quotients, value, &point, x_challenge);
+  let pi = compute_batched_evaluation_and_degree_check_quotient(zeta_x, z_x, x_challenge, z_challenge, 1 << nv_max);
+
+  // Verifier Step0
+  // commit f
+  // let uni_poly_coeff = &uni_poly.coeffs;
+  // let com = G1Projective::msm(&srs.0[..uni_poly_coeff.len()], uni_poly_coeff).unwrap().into();
+
+  // Verifier Step1
+  let mut c_q_k = Vec::new();
+  for quotient in quotients.iter() {
+    let quotient_coeff = &quotient.coeffs;
+    let q_com = G1Projective::msm(&srs.0[..quotient_coeff.len()], quotient_coeff).unwrap().into();
+    c_q_k.push(q_com);
+  }
+
+  // Verifier Step2
+  // commit q_hat
+  let batched_quotient_coeff = &batched_quotient.coeffs;
+  let q_com = G1Projective::msm(&srs.0[..batched_quotient_coeff.len()], batched_quotient_coeff).unwrap().into();
+
+  // commit pi
+  let pi_coeff = &pi.coeffs;
+  let pi_com: G1Affine = G1Projective::msm(&srs.0[..pi_coeff.len()], pi_coeff).unwrap().into();
+
+  ZM_proof {
+    c_pi: pi_com,
+    c_q_k: c_q_k,
+    c_q: q_com
+  }
+}
+
+pub fn zm_verify<R: RngCore>(
+  srs: (&Vec<G1Affine>,&Vec<G2Affine>),
+  nv_max: usize,
+  nv: usize,
+  com: G1Affine,
+  zm_proof: &ZM_proof,
+  value: Fr,
+  point: &[Fr], // u_challenge
+  rng: &mut R,
+) {
+  let y_challenge = Fr::rand(rng);
+  let x_challenge = Fr::rand(rng);
+  let z_challenge = Fr::rand(rng);
+
+  let one_commitment_g1: G1Affine = srs.0[0].clone(); // this way is more efficient than the above one
+  
+  let zeta_x_com = compute_c_zeta_x(zm_proof.c_q, &zm_proof.c_q_k, y_challenge, x_challenge);
+  
+  let z_x_com = compute_c_z_x(com, one_commitment_g1, &zm_proof.c_q_k, value, x_challenge, &point);
+  
+  let c_batched = compute_c_batched(zeta_x_com, z_x_com, z_challenge);
+  // pairing
+  let x_poly = DensePolynomial::from_coefficients_vec(vec![Fr::zero(), Fr::one()]);
+  let mut shift_vec = vec![Fr::zero(); (1<<nv_max) - (1<<nv) - 1];
+  shift_vec.append(&mut vec![Fr::one()]);
+  let degree_poly = DensePolynomial::from_coefficients_vec(shift_vec);
+
+  let x_poly_coeff = &x_poly.coeffs;
+  let x_commitment_g2: G2Affine = G2Projective::msm(&srs.1[..x_poly_coeff.len()], x_poly_coeff).unwrap().into();
+  let one_commitment_g2 = srs.1[0].clone();
+  let degree_poly_coeff = &degree_poly.coeffs;
+  let degree_commitment_g2: G2Affine = G2Projective::msm(&srs.1[..degree_poly_coeff.len()], degree_poly_coeff).unwrap().into();
+
+  let e1 = Bn254::pairing(zm_proof.c_pi, x_commitment_g2+one_commitment_g2.mul(-x_challenge));
+  let e2 = Bn254::pairing(c_batched, degree_commitment_g2);
+  assert_eq!(e1, e2);
+}
+
+// P (C,u = (u0, . . . , un−1), v, f, r) → V(C,u, v)
+// E2E ZeroMorph
+pub fn test_zm_polynomial<R: RngCore>(
+  srs: (&Vec<G1Affine>,&Vec<G2Affine>),
+  poly: &impl MultilinearExtension<Fr>,
+  point: &[Fr], // u_challenge
+  value: Fr, // v_evaluation
+  rng: &mut R,
+  nv_max: usize,
+) {
+  let nv = poly.num_vars();
+  assert_ne!(nv, 0);
+  let uni_poly = univariazation(poly);
+
+  // commit f
+  let uni_poly_coeff = &uni_poly.coeffs;
+  let com = G1Projective::msm(&srs.0[..uni_poly_coeff.len()], uni_poly_coeff).unwrap().into();
+
+  // ZeroMorph Pairing check
+  let zm_proof = zm_prove(srs, poly, point, value, rng, nv_max);
+
+  // pairing
+  zm_verify(srs, nv_max, nv, com, &zm_proof, value, point, rng);
 }


### PR DESCRIPTION
This branch contains the following features:
- Replace Vec<Vec<Fr>> by Tensor to include shape information and the supports from that ndarray
- MatMult protocol in zkVPD scheme (similar to [Libra](https://eprint.iacr.org/2019/317.pdf)) w/ ZeroMorph
- Bridge argument between ZeroMorph commitment and KZG commitment
- Rope argument (but this might be replaced by integrating multiple existing arguments (i.e., mul, permute, ...))
- Transpose argument (but we might have no need to use this argument; currently, it is not maintained)

(Not ready to be merged. But it is good to read and think about how to integrate these into master branch.)
Still in progress or debugging:
- ZeroMorph crashed for some polynomials, it might be because of my ignorance of some boundary conditions
- Improve readability of the codes
- Append argument (it might also be not necessary)