### PR TITLE
Graph

### DIFF
--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -67,7 +67,7 @@ pub trait BasicBlock {
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     setup: (&Vec<G1Affine>, &Vec<G2Affine>),
     model: &Data,
-    inputs: &Vec<Data>,
+    inputs: &Vec<&Data>,
     output: &Data,
     rng: &mut StdRng,
   ) -> (Vec<G1Affine>, Vec<G2Affine>) {
@@ -77,7 +77,7 @@ pub trait BasicBlock {
     &self,
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     model: &DataEnc,
-    inputs: &Vec<DataEnc>,
+    inputs: &Vec<&DataEnc>,
     output: &DataEnc,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     rng: &mut StdRng,

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -5,6 +5,7 @@ use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine};
 use ark_poly::univariate::DensePolynomial;
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_std::UniformRand;
+pub use constant::ConstBasicBlock;
 pub use cq::CQBasicBlock;
 pub use cqlin::CQLinBasicBlock;
 pub use mul::MulBasicBlock;
@@ -12,6 +13,7 @@ use ndarray::ArrayD;
 use rand::{rngs::StdRng, SeedableRng};
 pub use relu::ReLUBasicBlock;
 pub mod add;
+pub mod constant;
 pub mod cq;
 pub mod cqlin;
 pub mod mul;
@@ -54,7 +56,7 @@ impl DataEnc {
   }
 }
 pub trait BasicBlock {
-  fn run(&self, model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) -> ArrayD<Fr> {
+  fn run(&self, model: &ArrayD<Fr>, inputs: &Vec<&ArrayD<Fr>>) -> ArrayD<Fr> {
     ArrayD::zeros(vec![])
   }
   fn setup(&self, srs: (&Vec<G1Affine>, &Vec<G2Affine>), model: &Data) -> (Vec<G1Affine>, Vec<G2Affine>) {

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -10,10 +10,12 @@ pub use cqlin::CQLinBasicBlock;
 pub use mul::MulBasicBlock;
 use ndarray::ArrayD;
 use rand::{rngs::StdRng, SeedableRng};
+pub use relu::ReLUBasicBlock;
 pub mod add;
 pub mod cq;
 pub mod cqlin;
 pub mod mul;
+pub mod relu;
 
 pub struct Data {
   pub raw: ArrayD<Fr>,

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -9,7 +9,7 @@ pub use cq::CQBasicBlock;
 pub use cqlin::CQLinBasicBlock;
 pub use mul::MulBasicBlock;
 use ndarray::ArrayD;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, SeedableRng};
 pub mod add;
 pub mod cq;
 pub mod cqlin;
@@ -52,29 +52,31 @@ impl DataEnc {
   }
 }
 pub trait BasicBlock {
-  fn run(model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) -> ArrayD<Fr> {
+  fn run(&self, model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) -> ArrayD<Fr> {
     ArrayD::zeros(vec![])
   }
-  fn setup(srs: (&Vec<G1Affine>, &Vec<G2Affine>), model: &Data) -> (Vec<G1Affine>, Vec<G2Affine>) {
+  fn setup(&self, srs: (&Vec<G1Affine>, &Vec<G2Affine>), model: &Data) -> (Vec<G1Affine>, Vec<G2Affine>) {
     (Vec::new(), Vec::new())
   }
-  fn prove<R: Rng>(
+  fn prove(
+    &self,
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     setup: (&Vec<G1Affine>, &Vec<G2Affine>),
     model: &Data,
     inputs: &Vec<Data>,
     output: &Data,
-    rng: &mut R,
+    rng: &mut StdRng,
   ) -> (Vec<G1Affine>, Vec<G2Affine>) {
     (Vec::new(), Vec::new())
   }
-  fn verify<R: Rng>(
+  fn verify(
+    &self,
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     model: &DataEnc,
     inputs: &Vec<DataEnc>,
     output: &DataEnc,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
-    rng: &mut R,
+    rng: &mut StdRng,
   ) {
     ()
   }

--- a/src/basic_block/add.rs
+++ b/src/basic_block/add.rs
@@ -16,7 +16,7 @@ impl BasicBlock for AddBasicBlock {
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     _setup: (&Vec<G1Affine>, &Vec<G2Affine>),
     _model: &Data,
-    inputs: &Vec<Data>,
+    inputs: &Vec<&Data>,
     output: &Data,
     rng: &mut StdRng,
   ) -> (Vec<G1Affine>, Vec<G2Affine>) {
@@ -28,7 +28,7 @@ impl BasicBlock for AddBasicBlock {
     &self,
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     _model: &DataEnc,
-    inputs: &Vec<DataEnc>,
+    inputs: &Vec<&DataEnc>,
     output: &DataEnc,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     _rng: &mut StdRng,

--- a/src/basic_block/add.rs
+++ b/src/basic_block/add.rs
@@ -6,9 +6,9 @@ use rand::rngs::StdRng;
 
 pub struct AddBasicBlock;
 impl BasicBlock for AddBasicBlock {
-  fn run(&self, _model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) -> ArrayD<Fr> {
+  fn run(&self, _model: &ArrayD<Fr>, inputs: &Vec<&ArrayD<Fr>>) -> ArrayD<Fr> {
     let mut r = ArrayD::zeros(inputs[0].shape());
-    azip!((&x in &inputs[0], &y in &inputs[1], z in &mut r) *z = x + y);
+    azip!((&x in inputs[0], &y in inputs[1], z in &mut r) *z = x + y);
     r
   }
   fn prove(

--- a/src/basic_block/add.rs
+++ b/src/basic_block/add.rs
@@ -2,34 +2,36 @@ use super::{BasicBlock, Data, DataEnc};
 use ark_bn254::{Bn254, Fr, G1Affine, G2Affine};
 use ark_ec::pairing::Pairing;
 use ndarray::{azip, ArrayD};
-use rand::Rng;
+use rand::rngs::StdRng;
 
 pub struct AddBasicBlock;
 impl BasicBlock for AddBasicBlock {
-  fn run(_model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) -> ArrayD<Fr> {
+  fn run(&self, _model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) -> ArrayD<Fr> {
     let mut r = ArrayD::zeros(inputs[0].shape());
     azip!((&x in &inputs[0], &y in &inputs[1], z in &mut r) *z = x + y);
     r
   }
-  fn prove<R: Rng>(
+  fn prove(
+    &self,
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     _setup: (&Vec<G1Affine>, &Vec<G2Affine>),
     _model: &Data,
     inputs: &Vec<Data>,
     output: &Data,
-    rng: &mut R,
+    rng: &mut StdRng,
   ) -> (Vec<G1Affine>, Vec<G2Affine>) {
     // Blinding
     let C = srs.0[0] * (inputs[0].r + inputs[1].r - output.r);
     (vec![C.into()], Vec::new())
   }
-  fn verify<R: Rng>(
+  fn verify(
+    &self,
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     _model: &DataEnc,
     inputs: &Vec<DataEnc>,
     output: &DataEnc,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
-    _rng: &mut R,
+    _rng: &mut StdRng,
   ) {
     // Verify f(x)+g(x)=h(x)
     let lhs = Bn254::pairing(inputs[0].g1 + inputs[1].g1, srs.1[0]);

--- a/src/basic_block/constant.rs
+++ b/src/basic_block/constant.rs
@@ -1,0 +1,10 @@
+use super::BasicBlock;
+use ark_bn254::Fr;
+use ndarray::ArrayD;
+
+pub struct ConstBasicBlock;
+impl BasicBlock for ConstBasicBlock {
+  fn run(&self, model: &ArrayD<Fr>, _inputs: &Vec<&ArrayD<Fr>>) -> ArrayD<Fr> {
+    model.clone()
+  }
+}

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -10,7 +10,7 @@ use ark_std::{
   ops::{Mul, Sub},
   One, UniformRand, Zero,
 };
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, SeedableRng};
 use rayon::prelude::*;
 use std::collections::HashMap;
 
@@ -29,7 +29,7 @@ struct BProof {
 
 pub struct CQBasicBlock;
 impl BasicBlock for CQBasicBlock {
-  fn setup(srs: (&Vec<G1Affine>, &Vec<G2Affine>), model: &Data) -> (Vec<G1Affine>, Vec<G2Affine>) {
+  fn setup(&self, srs: (&Vec<G1Affine>, &Vec<G2Affine>), model: &Data) -> (Vec<G1Affine>, Vec<G2Affine>) {
     let N = model.raw.len();
     let domain_2N = GeneralEvaluationDomain::<Fr>::new(2 * N).unwrap();
     let domain_N = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
@@ -58,13 +58,14 @@ impl BasicBlock for CQBasicBlock {
     setup.extend(L_i_0_x_1);
     return (setup, vec![T_x_2]);
   }
-  fn prove<R: Rng>(
+  fn prove(
+    &self,
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     setup: (&Vec<G1Affine>, &Vec<G2Affine>),
     model: &Data,
     inputs: &Vec<Data>,
     _output: &Data,
-    rng: &mut R,
+    rng: &mut StdRng,
   ) -> (Vec<G1Affine>, Vec<G2Affine>) {
     let N = model.raw.len();
     let n = inputs[0].raw.len();
@@ -141,13 +142,14 @@ impl BasicBlock for CQBasicBlock {
 
     return (proof, vec![setup.1[0], f_x_2]);
   }
-  fn verify<R: Rng>(
+  fn verify(
+    &self,
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     model: &DataEnc,
     inputs: &Vec<DataEnc>,
     _output: &DataEnc,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
-    rng: &mut R,
+    rng: &mut StdRng,
   ) {
     let N = model.len;
     let n = inputs[0].len;

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -63,7 +63,7 @@ impl BasicBlock for CQBasicBlock {
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     setup: (&Vec<G1Affine>, &Vec<G2Affine>),
     model: &Data,
-    inputs: &Vec<Data>,
+    inputs: &Vec<&Data>,
     _output: &Data,
     rng: &mut StdRng,
   ) -> (Vec<G1Affine>, Vec<G2Affine>) {
@@ -146,7 +146,7 @@ impl BasicBlock for CQBasicBlock {
     &self,
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     model: &DataEnc,
-    inputs: &Vec<DataEnc>,
+    inputs: &Vec<&DataEnc>,
     _output: &DataEnc,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     rng: &mut StdRng,

--- a/src/basic_block/cqlin.rs
+++ b/src/basic_block/cqlin.rs
@@ -119,7 +119,7 @@ impl BasicBlock for CQLinBasicBlock {
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     setup: (&Vec<G1Affine>, &Vec<G2Affine>),
     model: &Data,
-    inputs: &Vec<Data>,
+    inputs: &Vec<&Data>,
     output: &Data,
     rng: &mut StdRng,
   ) -> (Vec<G1Affine>, Vec<G2Affine>) {
@@ -186,7 +186,7 @@ impl BasicBlock for CQLinBasicBlock {
     &self,
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     model: &DataEnc,
-    inputs: &Vec<DataEnc>,
+    inputs: &Vec<&DataEnc>,
     output: &DataEnc,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     rng: &mut StdRng,

--- a/src/basic_block/cqlin.rs
+++ b/src/basic_block/cqlin.rs
@@ -13,7 +13,7 @@ use rayon::prelude::*;
 
 pub struct CQLinBasicBlock;
 impl BasicBlock for CQLinBasicBlock {
-  fn run(&self, model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) -> ArrayD<Fr> {
+  fn run(&self, model: &ArrayD<Fr>, inputs: &Vec<&ArrayD<Fr>>) -> ArrayD<Fr> {
     assert_eq!(model.shape()[0], inputs[0].len());
     let m = model.shape()[0];
     let n = model.shape()[1];

--- a/src/basic_block/cqlin.rs
+++ b/src/basic_block/cqlin.rs
@@ -8,12 +8,12 @@ use ark_ff::Field;
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain, Polynomial};
 use ark_std::{UniformRand, Zero};
 use ndarray::ArrayD;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, SeedableRng};
 use rayon::prelude::*;
 
 pub struct CQLinBasicBlock;
 impl BasicBlock for CQLinBasicBlock {
-  fn run(model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) -> ArrayD<Fr> {
+  fn run(&self, model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) -> ArrayD<Fr> {
     assert_eq!(model.shape()[0], inputs[0].len());
     let m = model.shape()[0];
     let n = model.shape()[1];
@@ -25,7 +25,7 @@ impl BasicBlock for CQLinBasicBlock {
     }
     return r;
   }
-  fn setup(srs: (&Vec<G1Affine>, &Vec<G2Affine>), model: &Data) -> (Vec<G1Affine>, Vec<G2Affine>) {
+  fn setup(&self, srs: (&Vec<G1Affine>, &Vec<G2Affine>), model: &Data) -> (Vec<G1Affine>, Vec<G2Affine>) {
     let m = model.raw.shape()[0];
     let n = model.raw.shape()[1];
     let N = srs.1.len() - 1;
@@ -114,13 +114,14 @@ impl BasicBlock for CQLinBasicBlock {
     setup.append(&mut L_H_i_x);
     (setup, vec![M_x.into()])
   }
-  fn prove<R: Rng>(
+  fn prove(
+    &self,
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     setup: (&Vec<G1Affine>, &Vec<G2Affine>),
     model: &Data,
     inputs: &Vec<Data>,
     output: &Data,
-    rng: &mut R,
+    rng: &mut StdRng,
   ) -> (Vec<G1Affine>, Vec<G2Affine>) {
     let m = model.raw.shape()[0];
     let n = model.raw.shape()[1];
@@ -181,13 +182,14 @@ impl BasicBlock for CQLinBasicBlock {
 
     return (proof, vec![M_x_2]);
   }
-  fn verify<R: Rng>(
+  fn verify(
+    &self,
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     model: &DataEnc,
     inputs: &Vec<DataEnc>,
     output: &DataEnc,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
-    rng: &mut R,
+    rng: &mut StdRng,
   ) {
     let m = model.shape[0];
     let n = model.shape[1];

--- a/src/basic_block/mul.rs
+++ b/src/basic_block/mul.rs
@@ -19,7 +19,7 @@ impl BasicBlock for MulBasicBlock {
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     _setup: (&Vec<G1Affine>, &Vec<G2Affine>),
     _model: &Data,
-    inputs: &Vec<Data>,
+    inputs: &Vec<&Data>,
     output: &Data,
     _rng: &mut StdRng,
   ) -> (Vec<G1Affine>, Vec<G2Affine>) {
@@ -44,7 +44,7 @@ impl BasicBlock for MulBasicBlock {
     &self,
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     _model: &DataEnc,
-    inputs: &Vec<DataEnc>,
+    inputs: &Vec<&DataEnc>,
     output: &DataEnc,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     _rng: &mut StdRng,

--- a/src/basic_block/mul.rs
+++ b/src/basic_block/mul.rs
@@ -5,22 +5,23 @@ use ark_ec::pairing::Pairing;
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_std::{ops::Mul, ops::Sub, UniformRand};
 use ndarray::{azip, ArrayD};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, SeedableRng};
 
 pub struct MulBasicBlock;
 impl BasicBlock for MulBasicBlock {
-  fn run(_model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) -> ArrayD<Fr> {
+  fn run(&self, _model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) -> ArrayD<Fr> {
     let mut r = ArrayD::zeros(inputs[0].shape());
     azip!((&x in &inputs[0], &y in &inputs[1], z in &mut r) *z = x * y);
     r
   }
-  fn prove<R: Rng>(
+  fn prove(
+    &self,
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     _setup: (&Vec<G1Affine>, &Vec<G2Affine>),
     _model: &Data,
     inputs: &Vec<Data>,
     output: &Data,
-    _rng: &mut R,
+    _rng: &mut StdRng,
   ) -> (Vec<G1Affine>, Vec<G2Affine>) {
     let N = inputs[0].raw.len();
     let domain = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
@@ -39,13 +40,14 @@ impl BasicBlock for MulBasicBlock {
     let C = C.into();
     return (vec![tx, C], vec![gx2]);
   }
-  fn verify<R: Rng>(
+  fn verify(
+    &self,
     srs: (&Vec<G1Affine>, &Vec<G2Affine>),
     _model: &DataEnc,
     inputs: &Vec<DataEnc>,
     output: &DataEnc,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
-    _rng: &mut R,
+    _rng: &mut StdRng,
   ) {
     // Verify f(x)*g(x)-h(x)=z(x)t(x)
     let lhs = Bn254::pairing(inputs[0].g1, proof.1[0]) - Bn254::pairing(output.g1, srs.1[0]);

--- a/src/basic_block/mul.rs
+++ b/src/basic_block/mul.rs
@@ -9,9 +9,9 @@ use rand::{rngs::StdRng, SeedableRng};
 
 pub struct MulBasicBlock;
 impl BasicBlock for MulBasicBlock {
-  fn run(&self, _model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) -> ArrayD<Fr> {
+  fn run(&self, _model: &ArrayD<Fr>, inputs: &Vec<&ArrayD<Fr>>) -> ArrayD<Fr> {
     let mut r = ArrayD::zeros(inputs[0].shape());
-    azip!((&x in &inputs[0], &y in &inputs[1], z in &mut r) *z = x * y);
+    azip!((&x in inputs[0], &y in inputs[1], z in &mut r) *z = x * y);
     r
   }
   fn prove(

--- a/src/basic_block/relu.rs
+++ b/src/basic_block/relu.rs
@@ -1,0 +1,16 @@
+use super::{BasicBlock, Data, DataEnc};
+use ark_bn254::{Bn254, Fr, G1Affine, G2Affine};
+use ark_ec::pairing::Pairing;
+use ark_ff::BigInt;
+use ark_std::Zero;
+use ndarray::{azip, ArrayD};
+use rand::rngs::StdRng;
+
+pub struct ReLUBasicBlock;
+impl BasicBlock for ReLUBasicBlock {
+  fn run(&self, _model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) -> ArrayD<Fr> {
+    let mut r = ArrayD::zeros(inputs[0].shape());
+    azip!((&x in &inputs[0], z in &mut r) if x.0 < BigInt::new([1<<28,0,0,0]){*z = x}else{*z = Fr::zero()});
+    r
+  }
+}

--- a/src/basic_block/relu.rs
+++ b/src/basic_block/relu.rs
@@ -1,16 +1,13 @@
-use super::{BasicBlock, Data, DataEnc};
-use ark_bn254::{Bn254, Fr, G1Affine, G2Affine};
-use ark_ec::pairing::Pairing;
-use ark_ff::BigInt;
+use super::BasicBlock;
+use ark_bn254::Fr;
 use ark_std::Zero;
 use ndarray::{azip, ArrayD};
-use rand::rngs::StdRng;
 
 pub struct ReLUBasicBlock;
 impl BasicBlock for ReLUBasicBlock {
-  fn run(&self, _model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) -> ArrayD<Fr> {
+  fn run(&self, _model: &ArrayD<Fr>, inputs: &Vec<&ArrayD<Fr>>) -> ArrayD<Fr> {
     let mut r = ArrayD::zeros(inputs[0].shape());
-    azip!((&x in &inputs[0], z in &mut r) if x.0 < BigInt::new([1<<28,0,0,0]){*z = x}else{*z = Fr::zero()});
+    azip!((&x in inputs[0], z in &mut r) if x < Fr::from(1<<28){*z = x}else{*z = Fr::zero()});
     r
   }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,0 +1,22 @@
+use crate::basic_block::BasicBlock;
+use ark_bn254::Fr;
+use ndarray::ArrayD;
+
+struct Node {
+  basic_block: usize,
+  input_nodes: Vec<usize>,
+  output_nodes: Vec<usize>,
+}
+
+pub struct Graph {
+  basic_blocks: Vec<Box<dyn BasicBlock>>,
+  nodes: Vec<Node>,
+  input_node: usize,
+}
+
+impl Graph {
+  pub fn run(&self, inputs: Vec<ArrayD<Fr>>) -> Vec<ArrayD<Fr>> {
+    let outputs = vec![Vec::<ArrayD<Fr>>::new(); self.nodes.len()];
+    return Vec::new();
+  }
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2,16 +2,16 @@ use crate::basic_block::BasicBlock;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 
-struct Node {
-  basic_block: usize,
-  input_nodes: Vec<usize>,
-  output_nodes: Vec<usize>,
+pub struct Node {
+  pub basic_block: usize,
+  pub input_nodes: Vec<usize>,
+  pub output_nodes: Vec<usize>,
 }
 
 pub struct Graph {
-  basic_blocks: Vec<Box<dyn BasicBlock>>,
-  nodes: Vec<Node>,
-  input_node: usize,
+  pub basic_blocks: Vec<Box<dyn BasicBlock>>,
+  pub nodes: Vec<Node>,
+  pub input_node: usize,
 }
 
 impl Graph {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -15,8 +15,31 @@ pub struct Graph {
 }
 
 impl Graph {
-  pub fn run(&self, inputs: Vec<ArrayD<Fr>>) -> Vec<ArrayD<Fr>> {
-    let outputs = vec![Vec::<ArrayD<Fr>>::new(); self.nodes.len()];
-    return Vec::new();
+  pub fn run(&self, inputs: &Vec<&ArrayD<Fr>>, models: &Vec<&ArrayD<Fr>>) -> Vec<ArrayD<Fr>> {
+    let mut outputs = vec![ArrayD::zeros(vec![]); self.nodes.len()];
+    // Run the nodes that have no inputs
+    for i in 0..self.nodes.len() {
+      if self.nodes[i].input_nodes.len() == 0 && i != self.input_node {
+        outputs[i] = self.basic_blocks[self.nodes[i].basic_block].run(&models[self.nodes[i].basic_block], &vec![]);
+      }
+    }
+    // DFS:
+    let mut stack = vec![self.input_node];
+    while stack.len() > 0 {
+      let curr = stack.pop().unwrap();
+      let currNode = &self.nodes[curr];
+      if curr == self.input_node {
+        outputs[curr] = self.basic_blocks[currNode.basic_block].run(&models[currNode.basic_block], inputs);
+      } else {
+        let myInputs = currNode.input_nodes.iter().map(|i| &(outputs[*i])).collect();
+        outputs[curr] = self.basic_blocks[currNode.basic_block].run(&models[currNode.basic_block], &myInputs);
+      }
+      for n in &currNode.output_nodes {
+        if *self.nodes[*n].input_nodes.last().unwrap() == curr {
+          stack.push(*n);
+        }
+      }
+    }
+    return outputs;
   }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,6 +1,8 @@
 use crate::basic_block::BasicBlock;
-use ark_bn254::Fr;
+use crate::basic_block::*;
+use ark_bn254::{Fr, G1Affine, G2Affine};
 use ndarray::ArrayD;
+use rand::rngs::StdRng;
 
 pub struct Node {
   pub basic_block: usize,
@@ -41,5 +43,54 @@ impl Graph {
       }
     }
     return outputs;
+  }
+  pub fn setup(&self, srs: (&Vec<G1Affine>, &Vec<G2Affine>), models: &Vec<&Data>) -> Vec<(Vec<G1Affine>, Vec<G2Affine>)> {
+    self.basic_blocks.iter().zip(models.iter()).map(|(b, m)| b.setup(srs, m)).collect()
+  }
+  pub fn prove(
+    &self,
+    srs: (&Vec<G1Affine>, &Vec<G2Affine>),
+    setups: &Vec<(&Vec<G1Affine>, &Vec<G2Affine>)>,
+    models: &Vec<&Data>,
+    inputs: &Vec<&Data>,
+    outputs: &Vec<&Data>,
+    rng: &mut StdRng,
+  ) -> Vec<(Vec<G1Affine>, Vec<G2Affine>)> {
+    self
+      .nodes
+      .iter()
+      .enumerate()
+      .map(|(i, n)| {
+        if i == self.input_node {
+          self.basic_blocks[n.basic_block].prove(srs, setups[n.basic_block], models[n.basic_block], &inputs, outputs[i], rng)
+        } else {
+          let inputs = n.input_nodes.iter().map(|j| outputs[*j]).collect();
+          self.basic_blocks[n.basic_block].prove(srs, setups[n.basic_block], models[n.basic_block], &inputs, outputs[i], rng)
+        }
+      })
+      .collect()
+  }
+  pub fn verify(
+    &self,
+    srs: (&Vec<G1Affine>, &Vec<G2Affine>),
+    models: &Vec<&DataEnc>,
+    inputs: &Vec<&DataEnc>,
+    outputs: &Vec<&DataEnc>,
+    proofs: &Vec<(&Vec<G1Affine>, &Vec<G2Affine>)>,
+    rng: &mut StdRng,
+  ) {
+    self
+      .nodes
+      .iter()
+      .enumerate()
+      .map(|(i, n)| {
+        if i == self.input_node {
+          self.basic_blocks[n.basic_block].verify(srs, models[n.basic_block], inputs, outputs[i], proofs[i], rng)
+        } else {
+          let inputs = n.input_nodes.iter().map(|j| outputs[*j]).collect();
+          self.basic_blocks[n.basic_block].verify(srs, models[n.basic_block], &inputs, outputs[i], proofs[i], rng)
+        }
+      })
+      .collect()
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,22 +7,23 @@ use ndarray::{arr1, ArrayD};
 use rand::{rngs::StdRng, SeedableRng};
 use rayon::prelude::*;
 mod basic_block;
+mod graph;
 mod ptau;
 mod util;
 
-fn test_basic_block<BB: BasicBlock>(srs: (&Vec<G1Affine>, &Vec<G2Affine>), model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) {
+fn test_basic_block<BB: BasicBlock>(basic_block: BB, srs: (&Vec<G1Affine>, &Vec<G2Affine>), model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) {
   let mut rng = StdRng::from_entropy();
-  let output = BB::run(model, inputs);
+  let output = basic_block.run(model, inputs);
   let model = Data::new(srs, model);
-  let setup = BB::setup(srs, &model);
+  let setup = basic_block.setup(srs, &model);
   let inputs = inputs.iter().map(|x| Data::new(srs, x)).collect();
   let output = Data::new(srs, &output);
   let mut rng2 = rng.clone();
-  let proof = BB::prove(srs, (&(setup.0), &(setup.1)), &model, &inputs, &output, &mut rng);
+  let proof = basic_block.prove(srs, (&(setup.0), &(setup.1)), &model, &inputs, &output, &mut rng);
   let model = DataEnc::new(srs, &model);
   let inputs = inputs.iter().map(|x| DataEnc::new(srs, x)).collect();
   let output = DataEnc::new(srs, &output);
-  BB::verify(srs, &model, &inputs, &output, (&(proof.0), &(proof.1)), &mut rng2);
+  basic_block.verify(srs, &model, &inputs, &output, (&(proof.0), &(proof.1)), &mut rng2);
 }
 fn main() {
   let srs = ptau::load_file("challenge", 7);
@@ -34,15 +35,27 @@ fn main() {
   let a: Vec<_> = (0..N).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::rand(rng)).collect();
   let a1 = a.clone();
   let b: Vec<_> = (0..N).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::rand(rng)).collect();
-  test_basic_block::<AddBasicBlock>(srs, &arr1(&vec![]).into_dyn(), &vec![arr1(&a).into_dyn(), arr1(&b).into_dyn()]);
-  test_basic_block::<MulBasicBlock>(srs, &arr1(&vec![]).into_dyn(), &vec![arr1(&a).into_dyn(), arr1(&b).into_dyn()]);
-  test_basic_block::<CQBasicBlock>(srs, &arr1(&a).into_dyn(), &vec![arr1(&a[..n]).into_dyn()]);
-  test_basic_block::<CQLinBasicBlock>(
+  test_basic_block(
+    AddBasicBlock {},
+    srs,
+    &arr1(&vec![]).into_dyn(),
+    &vec![arr1(&a).into_dyn(), arr1(&b).into_dyn()],
+  );
+  test_basic_block(
+    MulBasicBlock {},
+    srs,
+    &arr1(&vec![]).into_dyn(),
+    &vec![arr1(&a).into_dyn(), arr1(&b).into_dyn()],
+  );
+  test_basic_block(CQBasicBlock {}, srs, &arr1(&a).into_dyn(), &vec![arr1(&a[..n]).into_dyn()]);
+  test_basic_block(
+    CQLinBasicBlock {},
     srs,
     &ArrayD::from_shape_vec(vec![m1, N / m1], a).unwrap(),
     &vec![arr1(&b[..m1]).into_dyn()],
   );
-  test_basic_block::<CQLinBasicBlock>(
+  test_basic_block(
+    CQLinBasicBlock {},
     srs,
     &ArrayD::from_shape_vec(vec![m2, N / m2], a1).unwrap(),
     &vec![arr1(&b[..m2]).into_dyn()],

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use ark_bn254::Fr;
 use basic_block::*;
 use graph::{Graph, Node};
 use ndarray::{arr1, ArrayD};
-use rand::Rng;
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use rayon::prelude::*;
 mod basic_block;
 mod graph;
@@ -65,19 +65,38 @@ fn main() {
   let matrix: Vec<_> = (0..N).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::from(rng.gen_range(-2..2))).collect();
   let input: Vec<_> = (0..m).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::from(rng.gen_range(-4..4))).collect();
 
+  //Run:
   let matrix = ArrayD::from_shape_vec(vec![m, N / m], matrix).unwrap();
   let input = arr1(&input).into_dyn();
+  let inputs = vec![&input];
   let empty = ArrayD::zeros(vec![]);
   let constant = arr1(&vec![Fr::from(1 << 6); 1 << 2]).into_dyn();
-  let relu_cq_table = util::gen_cq_table(&(*(graph.basic_blocks[1])), 1 << 6);
-  let outputs = graph.run(&vec![&input], &vec![&matrix, &empty, &constant, &empty, &empty, &relu_cq_table]);
+  let relu_cq_table = util::gen_cq_table(&graph.basic_blocks[1], 1 << 6);
+  let models = vec![&matrix, &empty, &constant, &empty, &empty, &relu_cq_table];
+  let outputs = graph.run(&inputs, &models);
 
-  let relu_cq_table = relu_cq_table.clone().into_raw_vec();
-  for x in outputs[4].clone().into_raw_vec() {
-    assert!(relu_cq_table.contains(&x), "{:?}", x);
-  }
+  //Setup:
+  let models: Vec<_> = models.iter().map(|x| Data::new(srs, x)).collect();
+  let models = models.iter().map(|x| x).collect();
+  let setups = graph.setup(srs, &models);
+  let setups = setups.iter().map(|x| (&x.0, &x.1)).collect();
 
-  //setup over basic_blocks
-  //prove over nodes
-  //verify over nodes
+  //Prove:
+  let inputs: Vec<_> = inputs.iter().map(|x| Data::new(srs, x)).collect();
+  let inputs = inputs.iter().map(|x| x).collect();
+  let outputs: Vec<_> = outputs.iter().map(|x| Data::new(srs, x)).collect();
+  let outputs = outputs.iter().map(|x| x).collect();
+  let mut rng = StdRng::from_entropy();
+  let mut rng2 = rng.clone();
+  let proofs = graph.prove(srs, &setups, &models, &inputs, &outputs, &mut rng);
+  let proofs = proofs.iter().map(|x| (&x.0, &x.1)).collect();
+
+  //Verify:
+  let models: Vec<_> = models.iter().map(|x| DataEnc::new(srs, x)).collect();
+  let models = models.iter().map(|x| x).collect();
+  let inputs: Vec<_> = inputs.iter().map(|x| DataEnc::new(srs, x)).collect();
+  let inputs = inputs.iter().map(|x| x).collect();
+  let outputs: Vec<_> = outputs.iter().map(|x| DataEnc::new(srs, x)).collect();
+  let outputs = outputs.iter().map(|x| x).collect();
+  graph.verify(srs, &models, &inputs, &outputs, &proofs, &mut rng2);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 use ark_bn254::{Fr, G1Affine, G2Affine};
 use ark_std::UniformRand;
 use basic_block::*;
+use graph::{Graph, Node};
 use ndarray::{arr1, ArrayD};
 use rand::{rngs::StdRng, SeedableRng};
 use rayon::prelude::*;
@@ -28,36 +29,26 @@ fn test_basic_block<BB: BasicBlock>(basic_block: BB, srs: (&Vec<G1Affine>, &Vec<
 fn main() {
   let srs = ptau::load_file("challenge", 7);
   let srs = (&srs.0, &srs.1);
-  const N: usize = 1 << 6;
-  const n: usize = 1 << 3;
-  const m1: usize = 1 << 2;
-  const m2: usize = 1 << 4;
-  let a: Vec<_> = (0..N).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::rand(rng)).collect();
-  let a1 = a.clone();
-  let b: Vec<_> = (0..N).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::rand(rng)).collect();
-  test_basic_block(
-    AddBasicBlock {},
-    srs,
-    &arr1(&vec![]).into_dyn(),
-    &vec![arr1(&a).into_dyn(), arr1(&b).into_dyn()],
-  );
-  test_basic_block(
-    MulBasicBlock {},
-    srs,
-    &arr1(&vec![]).into_dyn(),
-    &vec![arr1(&a).into_dyn(), arr1(&b).into_dyn()],
-  );
-  test_basic_block(CQBasicBlock {}, srs, &arr1(&a).into_dyn(), &vec![arr1(&a[..n]).into_dyn()]);
-  test_basic_block(
-    CQLinBasicBlock {},
-    srs,
-    &ArrayD::from_shape_vec(vec![m1, N / m1], a).unwrap(),
-    &vec![arr1(&b[..m1]).into_dyn()],
-  );
-  test_basic_block(
-    CQLinBasicBlock {},
-    srs,
-    &ArrayD::from_shape_vec(vec![m2, N / m2], a1).unwrap(),
-    &vec![arr1(&b[..m2]).into_dyn()],
-  );
+  let a: Vec<_> = (0..1 << 6).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::rand(rng)).collect();
+  let g = Graph {
+    basic_blocks: vec![Box::new(CQLinBasicBlock), Box::new(ReLUBasicBlock), Box::new(CQBasicBlock)],
+    nodes: vec![
+      Node {
+        basic_block: 0,
+        input_nodes: vec![],
+        output_nodes: vec![1, 2],
+      },
+      Node {
+        basic_block: 1,
+        input_nodes: vec![0],
+        output_nodes: vec![2],
+      },
+      Node {
+        basic_block: 2,
+        input_nodes: vec![0, 1],
+        output_nodes: vec![],
+      },
+    ],
+    input_node: 0,
+  };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,54 +1,83 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use ark_bn254::{Fr, G1Affine, G2Affine};
-use ark_std::UniformRand;
+use ark_bn254::Fr;
 use basic_block::*;
 use graph::{Graph, Node};
 use ndarray::{arr1, ArrayD};
-use rand::{rngs::StdRng, SeedableRng};
+use rand::Rng;
 use rayon::prelude::*;
 mod basic_block;
 mod graph;
 mod ptau;
+#[cfg(test)]
+mod tests;
 mod util;
 
-fn test_basic_block<BB: BasicBlock>(basic_block: BB, srs: (&Vec<G1Affine>, &Vec<G2Affine>), model: &ArrayD<Fr>, inputs: &Vec<ArrayD<Fr>>) {
-  let mut rng = StdRng::from_entropy();
-  let output = basic_block.run(model, inputs);
-  let model = Data::new(srs, model);
-  let setup = basic_block.setup(srs, &model);
-  let inputs = inputs.iter().map(|x| Data::new(srs, x)).collect();
-  let output = Data::new(srs, &output);
-  let mut rng2 = rng.clone();
-  let proof = basic_block.prove(srs, (&(setup.0), &(setup.1)), &model, &inputs, &output, &mut rng);
-  let model = DataEnc::new(srs, &model);
-  let inputs = inputs.iter().map(|x| DataEnc::new(srs, x)).collect();
-  let output = DataEnc::new(srs, &output);
-  basic_block.verify(srs, &model, &inputs, &output, (&(proof.0), &(proof.1)), &mut rng2);
-}
 fn main() {
   let srs = ptau::load_file("challenge", 7);
   let srs = (&srs.0, &srs.1);
-  let a: Vec<_> = (0..1 << 6).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::rand(rng)).collect();
-  let g = Graph {
-    basic_blocks: vec![Box::new(CQLinBasicBlock), Box::new(ReLUBasicBlock), Box::new(CQBasicBlock)],
+  let graph = Graph {
+    basic_blocks: vec![
+      Box::new(CQLinBasicBlock),
+      Box::new(ReLUBasicBlock),
+      Box::new(ConstBasicBlock),
+      Box::new(MulBasicBlock),
+      Box::new(AddBasicBlock),
+      Box::new(CQBasicBlock),
+    ],
     nodes: vec![
       Node {
         basic_block: 0,
         input_nodes: vec![],
-        output_nodes: vec![1, 2],
+        output_nodes: vec![1, 4],
       },
       Node {
         basic_block: 1,
         input_nodes: vec![0],
-        output_nodes: vec![2],
+        output_nodes: vec![3],
       },
       Node {
         basic_block: 2,
-        input_nodes: vec![0, 1],
+        input_nodes: vec![],
+        output_nodes: vec![3],
+      },
+      Node {
+        basic_block: 3,
+        input_nodes: vec![2, 1],
+        output_nodes: vec![4],
+      },
+      Node {
+        basic_block: 4,
+        input_nodes: vec![0, 3],
+        output_nodes: vec![5],
+      },
+      Node {
+        basic_block: 5,
+        input_nodes: vec![4],
         output_nodes: vec![],
       },
     ],
     input_node: 0,
   };
+
+  const N: usize = 1 << 6;
+  const m: usize = 1 << 4;
+  let matrix: Vec<_> = (0..N).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::from(rng.gen_range(-2..2))).collect();
+  let input: Vec<_> = (0..m).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::from(rng.gen_range(-4..4))).collect();
+
+  let matrix = ArrayD::from_shape_vec(vec![m, N / m], matrix).unwrap();
+  let input = arr1(&input).into_dyn();
+  let empty = ArrayD::zeros(vec![]);
+  let constant = arr1(&vec![Fr::from(1 << 6); 1 << 2]).into_dyn();
+  let relu_cq_table = util::gen_cq_table(&(*(graph.basic_blocks[1])), 1 << 6);
+  let outputs = graph.run(&vec![&input], &vec![&matrix, &empty, &constant, &empty, &empty, &relu_cq_table]);
+
+  let relu_cq_table = relu_cq_table.clone().into_raw_vec();
+  for x in outputs[4].clone().into_raw_vec() {
+    assert!(relu_cq_table.contains(&x), "{:?}", x);
+  }
+
+  //setup over basic_blocks
+  //prove over nodes
+  //verify over nodes
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,60 @@
+use crate::basic_block::*;
+use crate::ptau;
+use ark_bn254::{Fr, G1Affine, G2Affine};
+use ark_std::UniformRand;
+use ndarray::{arr1, ArrayD};
+use rand::{rngs::StdRng, SeedableRng};
+use rayon::prelude::*;
+
+fn testBasicBlock<BB: BasicBlock>(basic_block: BB, srs: (&Vec<G1Affine>, &Vec<G2Affine>), model: &ArrayD<Fr>, inputs: &Vec<&ArrayD<Fr>>) {
+  let mut rng = StdRng::from_entropy();
+  let output = basic_block.run(model, inputs);
+  let model = Data::new(srs, model);
+  let setup = basic_block.setup(srs, &model);
+  let inputs = inputs.iter().map(|x| Data::new(srs, x)).collect();
+  let output = Data::new(srs, &output);
+  let mut rng2 = rng.clone();
+  let proof = basic_block.prove(srs, (&(setup.0), &(setup.1)), &model, &inputs, &output, &mut rng);
+  let model = DataEnc::new(srs, &model);
+  let inputs = inputs.iter().map(|x| DataEnc::new(srs, x)).collect();
+  let output = DataEnc::new(srs, &output);
+  basic_block.verify(srs, &model, &inputs, &output, (&(proof.0), &(proof.1)), &mut rng2);
+}
+
+#[test]
+fn testBasicBlocks() {
+  let srs = ptau::load_file("challenge", 7);
+  let srs = (&srs.0, &srs.1);
+  const N: usize = 1 << 6;
+  const n: usize = 1 << 3;
+  const m1: usize = 1 << 2;
+  const m2: usize = 1 << 4;
+  let a: Vec<_> = (0..N).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::rand(rng)).collect();
+  let a1 = a.clone();
+  let b: Vec<_> = (0..N).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::rand(rng)).collect();
+  testBasicBlock(
+    AddBasicBlock {},
+    srs,
+    &arr1(&vec![]).into_dyn(),
+    &vec![&arr1(&a).into_dyn(), &arr1(&b).into_dyn()],
+  );
+  testBasicBlock(
+    MulBasicBlock {},
+    srs,
+    &arr1(&vec![]).into_dyn(),
+    &vec![&arr1(&a).into_dyn(), &arr1(&b).into_dyn()],
+  );
+  testBasicBlock(CQBasicBlock {}, srs, &arr1(&a).into_dyn(), &vec![&arr1(&a[..n]).into_dyn()]);
+  testBasicBlock(
+    CQLinBasicBlock {},
+    srs,
+    &ArrayD::from_shape_vec(vec![m1, N / m1], a).unwrap(),
+    &vec![&arr1(&b[..m1]).into_dyn()],
+  );
+  testBasicBlock(
+    CQLinBasicBlock {},
+    srs,
+    &ArrayD::from_shape_vec(vec![m2, N / m2], a1).unwrap(),
+    &vec![&arr1(&b[..m2]).into_dyn()],
+  );
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11,12 +11,14 @@ fn testBasicBlock<BB: BasicBlock>(basic_block: BB, srs: (&Vec<G1Affine>, &Vec<G2
   let output = basic_block.run(model, inputs);
   let model = Data::new(srs, model);
   let setup = basic_block.setup(srs, &model);
-  let inputs = inputs.iter().map(|x| Data::new(srs, x)).collect();
+  let inputs: Vec<_> = inputs.iter().map(|x| Data::new(srs, x)).collect();
+  let inputs = inputs.iter().map(|x| x).collect();
   let output = Data::new(srs, &output);
   let mut rng2 = rng.clone();
   let proof = basic_block.prove(srs, (&(setup.0), &(setup.1)), &model, &inputs, &output, &mut rng);
   let model = DataEnc::new(srs, &model);
-  let inputs = inputs.iter().map(|x| DataEnc::new(srs, x)).collect();
+  let inputs: Vec<_> = inputs.iter().map(|x| DataEnc::new(srs, x)).collect();
+  let inputs = inputs.iter().map(|x| x).collect();
   let output = DataEnc::new(srs, &output);
   basic_block.verify(srs, &model, &inputs, &output, (&(proof.0), &(proof.1)), &mut rng2);
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -106,10 +106,10 @@ pub fn msm<P: VariableBaseMSM>(a: &[P::MulBase], b: &[P::ScalarField]) -> P {
   return a_chunks.zip(b_chunks).map(|(x, y)| -> P { VariableBaseMSM::msm_unchecked(&x, &y) }).sum();
 }
 
-pub fn gen_cq_table(basic_block: &dyn BasicBlock, table_size: usize) -> ArrayD<Fr> {
+pub fn gen_cq_table(basic_block: &Box<dyn BasicBlock>, table_size: usize) -> ArrayD<Fr> {
   let range: Vec<_> = (0..table_size).map(|i| Fr::from(i as u32) - Fr::from((table_size >> 1) as u32)).collect();
   let range = arr1(&range).into_dyn();
-  let result = basic_block.run(&ArrayD::zeros(vec![]), &vec![&range]);
+  let result = (*basic_block).run(&ArrayD::zeros(vec![]), &vec![&range]);
   let mut r = ArrayD::zeros(range.shape());
   let table_size = Fr::from(table_size as u32);
   azip!((&x in &range, &y in &result, z in &mut r) *z = x + y * table_size);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,10 @@
 #![allow(dead_code)]
+use crate::BasicBlock;
 use ark_bn254::Fr;
 use ark_ec::{ScalarMul, VariableBaseMSM};
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_std::Zero;
+use ndarray::{arr1, azip, ArrayD};
 use rayon::prelude::*;
 
 fn bitreverse(mut n: u32, l: u64) -> u32 {
@@ -102,4 +104,14 @@ pub fn msm<P: VariableBaseMSM>(a: &[P::MulBase], b: &[P::ScalarField]) -> P {
   let a_chunks = a.par_chunks(chunk_size);
   let b_chunks = b.par_chunks(chunk_size);
   return a_chunks.zip(b_chunks).map(|(x, y)| -> P { VariableBaseMSM::msm_unchecked(&x, &y) }).sum();
+}
+
+pub fn gen_cq_table(basic_block: &dyn BasicBlock, table_size: usize) -> ArrayD<Fr> {
+  let range: Vec<_> = (0..table_size).map(|i| Fr::from(i as u32) - Fr::from((table_size >> 1) as u32)).collect();
+  let range = arr1(&range).into_dyn();
+  let result = basic_block.run(&ArrayD::zeros(vec![]), &vec![&range]);
+  let mut r = ArrayD::zeros(range.shape());
+  let table_size = Fr::from(table_size as u32);
+  azip!((&x in &range, &y in &result, z in &mut r) *z = x + y * table_size);
+  r
 }


### PR DESCRIPTION
Changes:
- Add `ConstBasicBlock` and `ReLUBasicBlock`
- Made `BasicBlock` object-safe
  - Added `&self` parameters
  - Removed generic parameters: `R` becomes `StdRng`
- Switched from passing a vector of objects to passing a vector of pointers, which avoids copying data
- Made `Graph` struct
  - `run` is a DFS
  - `setup` is in parallel over the blocks
  - `prove` and `verify` are in parallel over the nodes
- Proved a sample `graph`: a 1-layer NN with Linear and ReLU layers
- Moved `BasicBlock` tests to a unit test (invoked with `cargo test`)