### PR TITLE
Removing extraneous recomputation

### DIFF
--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -85,12 +85,20 @@ pub trait BasicBlock {
   fn run(&self, _model: &ArrayD<Fr>, _inputs: &Vec<&ArrayD<Fr>>) -> Vec<ArrayD<Fr>> {
     vec![]
   }
+
+  // This function encodes the outputs of the BasicBlock into Data objects.
+  // It defaults to running Data::new() on the last dimension of the outputs which runs an FFT and an MSM.
+  // But for certain basic blocks such as add and reshape, this can be done much faster, and it should be overriden in these cases.
   fn encodeOutputs(&self, srs: &SRS, _model: &ArrayD<Data>, _inputs: &Vec<&ArrayD<Data>>, outputs: &Vec<&ArrayD<Fr>>) -> Vec<ArrayD<Data>> {
     outputs.iter().map(|x| util::convert_to_data(srs, x)).collect()
   }
+
+  // The subsequent setup/prove/verify functions run on encoded Data objects (vector commitments).
+  // This reduces computation because the Data objects can be encoded once at the beginning and then reused for these functions.
   fn setup(&self, _srs: &SRS, _model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>) {
     (Vec::new(), Vec::new())
   }
+
   fn prove(
     &mut self,
     _srs: &SRS,
@@ -102,6 +110,7 @@ pub trait BasicBlock {
   ) -> (Vec<G1Projective>, Vec<G2Projective>) {
     (Vec::new(), Vec::new())
   }
+
   fn verify(
     &self,
     _srs: &SRS,

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -47,6 +47,7 @@ pub struct SRS {
   pub Y1P: G1Projective,
   pub Y2P: G2Projective,
 }
+#[derive(Clone)]
 pub struct Data {
   pub raw: Vec<Fr>,
   pub poly: DensePolynomial<Fr>,
@@ -83,6 +84,9 @@ impl DataEnc {
 pub trait BasicBlock {
   fn run(&self, _model: &ArrayD<Fr>, _inputs: &Vec<&ArrayD<Fr>>) -> Vec<ArrayD<Fr>> {
     vec![]
+  }
+  fn encodeOutputs(&self, srs: &SRS, _model: &ArrayD<Data>, _inputs: &Vec<&ArrayD<Data>>, outputs: &Vec<&ArrayD<Fr>>) -> Vec<ArrayD<Data>> {
+    outputs.iter().map(|x| util::convert_to_data(srs, x)).collect()
   }
   fn setup(&self, _srs: &SRS, _model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>) {
     (Vec::new(), Vec::new())

--- a/src/basic_block/add.rs
+++ b/src/basic_block/add.rs
@@ -23,7 +23,7 @@ impl BasicBlock for AddBasicBlock {
     let b = inputs[1].first().unwrap();
     vec![arr0(Data {
       raw: outputs[0].clone().into_raw_vec(),
-      poly: a.poly.clone() + b.poly.clone(),
+      poly: (&a.poly) + (&b.poly),
       g1: a.g1 + b.g1,
       r: a.r + b.r,
     })

--- a/src/basic_block/add.rs
+++ b/src/basic_block/add.rs
@@ -1,7 +1,7 @@
 use super::{BasicBlock, Data, DataEnc, SRS};
 use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::pairing::Pairing;
-use ndarray::{azip, ArrayD, IxDyn};
+use ndarray::{arr0, azip, ArrayD, IxDyn};
 use rand::rngs::StdRng;
 
 pub struct AddBasicBlock;
@@ -18,37 +18,30 @@ impl BasicBlock for AddBasicBlock {
     }
     vec![r]
   }
-  fn prove(
-    &mut self,
-    srs: &SRS,
-    _setup: (&Vec<G1Affine>, &Vec<G2Affine>),
-    _model: &ArrayD<Data>,
-    inputs: &Vec<&ArrayD<Data>>,
-    outputs: &Vec<&ArrayD<Data>>,
-    _rng: &mut StdRng,
-  ) -> (Vec<G1Projective>, Vec<G2Projective>) {
+  fn encodeOutputs(&self, _srs: &SRS, _model: &ArrayD<Data>, inputs: &Vec<&ArrayD<Data>>, outputs: &Vec<&ArrayD<Fr>>) -> Vec<ArrayD<Data>> {
     let a = inputs[0].first().unwrap();
     let b = inputs[1].first().unwrap();
-    let c = outputs[0].first().unwrap();
-    // Blinding
-    let C = srs.X1P[0] * (a.r + b.r - c.r);
-    (vec![C], Vec::new())
+    vec![arr0(Data {
+      raw: outputs[0].clone().into_raw_vec(),
+      poly: a.poly.clone() + b.poly.clone(),
+      g1: a.g1 + b.g1,
+      r: a.r + b.r,
+    })
+    .into_dyn()]
   }
   fn verify(
     &self,
-    srs: &SRS,
+    _srs: &SRS,
     _model: &ArrayD<DataEnc>,
     inputs: &Vec<&ArrayD<DataEnc>>,
     outputs: &Vec<&ArrayD<DataEnc>>,
-    proof: (&Vec<G1Affine>, &Vec<G2Affine>),
+    _proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     _rng: &mut StdRng,
   ) {
     let a = inputs[0].first().unwrap();
     let b = inputs[1].first().unwrap();
     let c = outputs[0].first().unwrap();
     // Verify f(x)+g(x)=h(x)
-    let lhs = Bn254::pairing(a.g1 + b.g1, srs.X2A[0]);
-    let rhs = Bn254::pairing(c.g1, srs.X2A[0]) + Bn254::pairing(proof.0[0], srs.Y2A);
-    assert!(lhs == rhs);
+    assert!(a.g1 + b.g1 == c.g1);
   }
 }

--- a/src/basic_block/sub.rs
+++ b/src/basic_block/sub.rs
@@ -1,7 +1,7 @@
 use super::{BasicBlock, Data, DataEnc, SRS};
 use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::pairing::Pairing;
-use ndarray::{azip, ArrayD, IxDyn};
+use ndarray::{arr0, azip, ArrayD, IxDyn};
 use rand::rngs::StdRng;
 
 pub struct SubBasicBlock;
@@ -18,37 +18,30 @@ impl BasicBlock for SubBasicBlock {
     }
     vec![r]
   }
-  fn prove(
-    &mut self,
-    srs: &SRS,
-    _setup: (&Vec<G1Affine>, &Vec<G2Affine>),
-    _model: &ArrayD<Data>,
-    inputs: &Vec<&ArrayD<Data>>,
-    outputs: &Vec<&ArrayD<Data>>,
-    _rng: &mut StdRng,
-  ) -> (Vec<G1Projective>, Vec<G2Projective>) {
+  fn encodeOutputs(&self, _srs: &SRS, _model: &ArrayD<Data>, inputs: &Vec<&ArrayD<Data>>, outputs: &Vec<&ArrayD<Fr>>) -> Vec<ArrayD<Data>> {
     let a = inputs[0].first().unwrap();
     let b = inputs[1].first().unwrap();
-    let c = outputs[0].first().unwrap();
-    // Blinding
-    let C = srs.X1P[0] * (a.r - b.r - c.r);
-    (vec![C], Vec::new())
+    vec![arr0(Data {
+      raw: outputs[0].clone().into_raw_vec(),
+      poly: (&a.poly) - (&b.poly),
+      g1: a.g1 - b.g1,
+      r: a.r - b.r,
+    })
+    .into_dyn()]
   }
   fn verify(
     &self,
-    srs: &SRS,
+    _srs: &SRS,
     _model: &ArrayD<DataEnc>,
     inputs: &Vec<&ArrayD<DataEnc>>,
     outputs: &Vec<&ArrayD<DataEnc>>,
-    proof: (&Vec<G1Affine>, &Vec<G2Affine>),
+    _proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     _rng: &mut StdRng,
   ) {
     let a = inputs[0].first().unwrap();
     let b = inputs[1].first().unwrap();
     let c = outputs[0].first().unwrap();
     // Verify f(x)-g(x)=h(x)
-    let lhs = Bn254::pairing(a.g1 - b.g1, srs.X2A[0]);
-    let rhs = Bn254::pairing(c.g1, srs.X2A[0]) + Bn254::pairing(proof.0[0], srs.Y2A);
-    assert!(lhs == rhs);
+    assert!(a.g1 - b.g1 == c.g1);
   }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -23,6 +23,20 @@ impl Graph {
     });
     return outputs;
   }
+  pub fn encodeOutputs(
+    &self,
+    srs: &SRS,
+    models: &Vec<&ArrayD<Data>>,
+    inputs: &Vec<&ArrayD<Data>>,
+    outputs: &Vec<&Vec<&ArrayD<Fr>>>,
+  ) -> Vec<Vec<ArrayD<Data>>> {
+    let mut outputsEnc = vec![vec![]; self.nodes.len()];
+    self.nodes.iter().enumerate().for_each(|(i, n)| {
+      let myInputs = n.inputs.iter().map(|(j, k)| if *j < 0 { inputs[*k] } else { &(outputsEnc[*j as usize][*k]) }).collect();
+      outputsEnc[i] = self.basic_blocks[n.basic_block].encodeOutputs(srs, &models[n.basic_block], &myInputs, outputs[i]);
+    });
+    return outputsEnc;
+  }
   pub fn setup(&self, srs: &SRS, models: &Vec<&ArrayD<Data>>) -> Vec<(Vec<G1Projective>, Vec<G2Projective>)> {
     self.basic_blocks.iter().zip(models.iter()).map(|(b, m)| b.setup(srs, *m)).collect()
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ fn main() {
   let models = vec![&matrix, &empty, &relu_cq_table];
   let outputs = graph.run(&inputs, &models);
   let outputs: Vec<Vec<&ArrayD<Fr>>> = outputs.iter().map(|output| output.iter().map(|x| x).collect()).collect();
+  let outputs: Vec<&Vec<&ArrayD<Fr>>> = outputs.iter().map(|output| output).collect();
 
   //Setup:
   let models: Vec<ArrayD<Data>> = models.iter().map(|model| convert_to_data(srs, model)).collect();
@@ -67,7 +68,7 @@ fn main() {
   //Prove:
   let inputs: Vec<ArrayD<Data>> = inputs.iter().map(|input| convert_to_data(srs, input)).collect();
   let inputs: Vec<&ArrayD<Data>> = inputs.iter().map(|input| input).collect();
-  let outputs: Vec<Vec<ArrayD<Data>>> = outputs.iter().map(|outputs| outputs.iter().map(|output| convert_to_data(srs, output)).collect()).collect();
+  let outputs: Vec<Vec<ArrayD<Data>>> = graph.encodeOutputs(srs, &models, &inputs, &outputs);
   let outputs: Vec<Vec<&ArrayD<Data>>> = outputs.iter().map(|outputs| outputs.iter().map(|x| x).collect()).collect();
   let outputs: Vec<&Vec<&ArrayD<Data>>> = outputs.iter().map(|x| x).collect();
   let mut rng = StdRng::from_entropy();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -20,7 +20,7 @@ fn testBasicBlock<BB: BasicBlock>(mut basic_block: BB, srs: &SRS, model: &ArrayD
   let setup = (&setup.0, &setup.1);
   let inputs: Vec<ArrayD<Data>> = inputs.iter().map(|input| convert_to_data(srs, input)).collect();
   let inputs: Vec<&ArrayD<Data>> = inputs.iter().map(|input| input).collect();
-  let outputs: Vec<ArrayD<Data>> = outputs.iter().map(|output| convert_to_data(srs, output)).collect();
+  let outputs: Vec<ArrayD<Data>> = basic_block.encodeOutputs(srs, &model, &inputs, &outputs);
   let outputs: Vec<&ArrayD<Data>> = outputs.iter().map(|output| output).collect();
   let mut rng2 = rng.clone();
   let proof = basic_block.prove(srs, setup, &model, &inputs, &outputs, &mut rng);


### PR DESCRIPTION
- Added `encodeOutputs` method to `BasicBlock`
  - Defaults to running an fft and an msm
- Implemented `encodeOutputs` for `AddBasicBlock` which adds the `g1` commitments of the inputs
  - This avoids recomputing the fft and msm for the output
- Updated main and unit tests