### PR TITLE
Fiat-Shamir + Serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,11 @@ ark-ff = {version = "0.4", features = ["parallel"]}
 ark-ec = "0.4"
 ark-poly = {version = "0.4", features = ["parallel"]}
 ark-bn254 = "0.4"
+ark-serialize = { version = "0.4", features = ["derive"] }
+serde = { version = "1.0.201", features = ["derive"] }
 rand = "0.8.5"
 rayon = "1"
-ndarray = "0.15.6"
+ndarray = { version = "0.15.6", features = ["serde"] }
 tract-onnx = "0.21.2"
+sha3 = "0.10.8"
+bincode = "1.3.3"

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -1,9 +1,10 @@
 #![allow(unused_imports)]
-use crate::util;
+use crate::{util, util::ark_de, util::ark_se};
 pub use add::AddBasicBlock;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_poly::univariate::DensePolynomial;
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::UniformRand;
 pub use constant::ConstBasicBlock;
 pub use cq::CQBasicBlock;
@@ -19,6 +20,7 @@ pub use ops::*;
 pub use permute::PermuteBasicBlock;
 use rand::{rngs::StdRng, SeedableRng};
 pub use rope::RoPEBasicBlock;
+use serde::{Deserialize, Serialize};
 pub use sub::SubBasicBlock;
 pub use sum::SumBasicBlock;
 pub mod add;
@@ -50,11 +52,15 @@ pub struct SRS {
 
 pub type PairingCheck = Vec<(G1Affine, G2Affine)>;
 
-#[derive(Clone)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct Data {
+  #[serde(serialize_with = "ark_se", deserialize_with = "ark_de")]
   pub raw: Vec<Fr>,
+  #[serde(serialize_with = "ark_se", deserialize_with = "ark_de")]
   pub poly: DensePolynomial<Fr>,
+  #[serde(serialize_with = "ark_se", deserialize_with = "ark_de")]
   pub g1: G1Projective,
+  #[serde(serialize_with = "ark_se", deserialize_with = "ark_de")]
   pub r: Fr,
 }
 
@@ -74,8 +80,10 @@ impl Data {
   }
 }
 
+#[derive(Clone, Deserialize, Serialize)]
 pub struct DataEnc {
   pub len: usize,
+  #[serde(serialize_with = "ark_se", deserialize_with = "ark_de")]
   pub g1: G1Affine,
 }
 

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -1,5 +1,5 @@
 #![allow(unused_imports)]
-use crate::{util, util::ark_de, util::ark_se};
+use crate::util::{self, ark_de, ark_se};
 pub use add::AddBasicBlock;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_poly::univariate::DensePolynomial;

--- a/src/basic_block/cq2.rs
+++ b/src/basic_block/cq2.rs
@@ -76,7 +76,7 @@ impl BasicBlock for CQ2BasicBlock {
     let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
     let alpha = Fr::rand(rng);
     let agg_input: Vec<_> = inputs[0].raw.iter().zip(inputs[1].raw.iter()).map(|(x, y)| *x + *y * alpha).collect();
-    let mut agg_input = Data::new(srs, &agg_input); //Unnecessary msm
+    let mut agg_input = Data::new(srs, &agg_input); // Unnecessary msm
     agg_input.r = inputs[0].r + inputs[1].r * alpha;
     let agg_model_g1 = model[0].g1 + model[1].g1 * alpha;
     let agg_model_r = model[0].r + model[1].r * alpha;

--- a/src/basic_block/cqlin.rs
+++ b/src/basic_block/cqlin.rs
@@ -91,7 +91,7 @@ impl BasicBlock for CQLinBasicBlock {
     let mut temp = temp[m..].to_vec();
     util::fft_in_place(domain_m, &mut temp);
     let mut Q: Vec<_> = (0..m).into_par_iter().map(|i| temp[i] * domain_m.element(i) * m_inv).collect();
-    let M_x = (0..m).into_par_iter().map(|i| (0..n).map(|j| U2[i][j] * model[i].raw[j]).sum::<G2Projective>()).sum::<G2Projective>(); //TODO: Change to msm
+    let M_x = (0..m).into_par_iter().map(|i| (0..n).map(|j| U2[i][j] * model[i].raw[j]).sum::<G2Projective>()).sum::<G2Projective>(); // TODO: Change to msm
 
     let mut setup = R;
     setup.append(&mut Q);
@@ -120,7 +120,7 @@ impl BasicBlock for CQLinBasicBlock {
     let alpha = Fr::rand(rng);
 
     let alpha_pow = calc_pow(alpha, l);
-    let alpha_pow = Data::new(srs, &alpha_pow); //r is ignored (unnecessary msm)
+    let alpha_pow = Data::new(srs, &alpha_pow); // r is ignored (unnecessary msm)
 
     let mut flat_A = vec![Fr::zero(); m];
     let mut flat_A_r = Fr::zero();

--- a/src/basic_block/matmul.rs
+++ b/src/basic_block/matmul.rs
@@ -47,9 +47,9 @@ impl BasicBlock for MatMulBasicBlock {
     let beta = Fr::rand(rng);
 
     let alpha_pow = calc_pow(alpha, l);
-    let alpha_pow = Data::new(srs, &alpha_pow); //r is ignored (unnecessary msm)
+    let alpha_pow = Data::new(srs, &alpha_pow); // r is ignored (unnecessary msm)
     let beta_pow = calc_pow(beta, n);
-    let beta_pow = Data::new(srs, &beta_pow); //r is ignored
+    let beta_pow = Data::new(srs, &beta_pow); // r is ignored
 
     let mut flat_A = vec![Fr::zero(); m];
     let mut flat_A_r = Fr::zero();
@@ -144,8 +144,8 @@ impl BasicBlock for MatMulBasicBlock {
     let alpha = Fr::rand(rng);
     let beta = Fr::rand(rng);
 
-    let alpha_pow = calc_pow(alpha, l); //r is ignored
-    let beta_pow = calc_pow(beta, n); //r is ignored
+    let alpha_pow = calc_pow(alpha, l); // r is ignored
+    let beta_pow = calc_pow(beta, n); // r is ignored
     let beta_pow_coeff = domain_n.ifft(&beta_pow);
     let beta_pow_g2: G2Affine = util::msm::<G2Projective>(&srs.X2A, &beta_pow_coeff).into();
 
@@ -190,7 +190,7 @@ impl BasicBlock for MatMulBasicBlock {
     // Assume right(0) = left(0)*n/m (which assumes ∑left=∑right)
     let right_zero: G1Affine = (left_zero * (Fr::from(m as u32) * Fr::from(n as u32).inverse().unwrap())).into();
 
-    //check right(x) - right(0) is divisible by x
+    // check right(x) - right(0) is divisible by x
     checks.push(vec![
       ((right_x - right_zero).into(), srs.X2A[0]),
       (-right_zero_div, srs.X2A[1]),

--- a/src/basic_block/permute.rs
+++ b/src/basic_block/permute.rs
@@ -189,7 +189,7 @@ impl BasicBlock for PermuteBasicBlock {
     // Assume right(0) = left(0)*m/m2 (which assumes ∑left=∑right)
     let right_zero: G1Affine = (left_zero * (Fr::from(m as u32) * Fr::from(m2 as u32).inverse().unwrap())).into();
 
-    //check right(x) - right(0) is divisible by x
+    // check right(x) - right(0) is divisible by x
     checks.push(vec![
       ((right_x - right_zero).into(), srs.X2A[0]),
       (-right_zero_div, srs.X2A[1]),

--- a/src/basic_block/sub.rs
+++ b/src/basic_block/sub.rs
@@ -10,7 +10,7 @@ impl BasicBlock for SubBasicBlock {
     assert!(inputs.len() == 2 && inputs[0].ndim() == 1 && inputs[1].ndim() == 1);
     let mut r = ArrayD::zeros(IxDyn(&[std::cmp::max(inputs[0].len(), inputs[1].len())]));
     if inputs[0].len() == 1 {
-      azip!((r in &mut r, &x in inputs[1]) *r = x - inputs[0][0]);
+      azip!((r in &mut r, &y in inputs[1]) *r = inputs[0][0] - y);
     } else if inputs[1].len() == 1 {
       azip!((r in &mut r, &x in inputs[0]) *r = x - inputs[1][0]);
     } else {

--- a/src/basic_block/sum.rs
+++ b/src/basic_block/sum.rs
@@ -40,7 +40,7 @@ impl BasicBlock for SumBasicBlock {
     }
     let input_poly = DensePolynomial {
       coeffs: domain_m.ifft(&input_raw),
-    }; //sum poly?
+    }; // sum poly?
 
     let mut rng2 = StdRng::from_entropy();
     let zero_div_r = Fr::rand(&mut rng2);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -10,7 +10,7 @@ use rand::rngs::StdRng;
 #[derive(Debug)]
 pub struct Node {
   pub basic_block: usize,
-  pub inputs: Vec<(i32, usize)>, //(node, output #)
+  pub inputs: Vec<(i32, usize)>, // (node, output #)
 }
 
 #[derive(Debug)]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2,6 +2,7 @@ use crate::basic_block::*;
 use crate::util;
 use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::pairing::{Pairing, PairingOutput};
+use ark_serialize::CanonicalSerialize;
 use ark_std::Zero;
 use ndarray::ArrayD;
 use rand::rngs::StdRng;
@@ -57,14 +58,22 @@ impl Graph {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&Vec<&ArrayD<Data>>>,
     rng: &mut StdRng,
-  ) -> Vec<(Vec<G1Projective>, Vec<G2Projective>)> {
+  ) -> Vec<(Vec<G1Affine>, Vec<G2Affine>)> {
     self
       .nodes
       .iter()
       .enumerate()
       .map(|(i, n)| {
         let myInputs: Vec<&ArrayD<Data>> = n.inputs.iter().map(|(j, k)| if *j < 0 { inputs[*k] } else { &(outputs[*j as usize][*k]) }).collect();
-        self.basic_blocks[n.basic_block].prove(srs, setups[n.basic_block], models[n.basic_block], &myInputs, outputs[i], rng)
+        let proof = self.basic_blocks[n.basic_block].prove(srs, setups[n.basic_block], models[n.basic_block], &myInputs, outputs[i], rng);
+        let proof: (Vec<G1Affine>, Vec<G2Affine>) = (
+          proof.0.iter().map(|x| (*x).into()).collect(),
+          proof.1.iter().map(|x| (*x).into()).collect(),
+        );
+        let mut bytes = Vec::new();
+        proof.serialize_uncompressed(&mut bytes).unwrap();
+        util::add_randomness(rng, bytes);
+        proof
       })
       .collect()
   }
@@ -84,7 +93,12 @@ impl Graph {
       .enumerate()
       .map(|(i, n)| {
         let myInputs = n.inputs.iter().map(|(j, k)| if *j < 0 { inputs[*k] } else { &(outputs[*j as usize][*k]) }).collect();
-        self.basic_blocks[n.basic_block].verify(srs, models[n.basic_block], &myInputs, outputs[i], proofs[i], rng)
+        let pairings = self.basic_blocks[n.basic_block].verify(srs, models[n.basic_block], &myInputs, outputs[i], proofs[i], rng);
+        let mut bytes = Vec::new();
+        let temp: (Vec<G1Affine>, Vec<G2Affine>) = (proofs[i].0.clone(), proofs[i].1.clone());
+        temp.serialize_uncompressed(&mut bytes).unwrap();
+        util::add_randomness(rng, bytes);
+        pairings
       })
       .collect();
     let pairings = util::combine_pairing_checks(&pairings.iter().flatten().collect());

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,19 +21,19 @@ mod tests;
 mod util;
 
 fn prove(srs: &SRS, graph: &mut Graph, models: Vec<ArrayD<Fr>>) {
-  //Run:
+  // Run:
   let input: Vec<_> = (0..4).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::from(rng.gen_range(-4..4))).collect();
   let input = arr1(&input).into_dyn();
   let inputs = vec![&input];
   let models = models.iter().map(|x| x).collect();
   let outputs = graph.run(&inputs, &models);
 
-  //Setup:
+  // Setup:
   let models: Vec<ArrayD<Data>> = models.iter().map(|model| convert_to_data(srs, model)).collect();
   let models: Vec<&ArrayD<Data>> = models.iter().map(|model| model).collect();
   let setups = graph.setup(srs, &models);
 
-  //Encode Data:
+  // Encode Data:
   let setups: Vec<(Vec<G1Affine>, Vec<G2Affine>)> =
     setups.iter().map(|x| (x.0.iter().map(|y| (*y).into()).collect(), x.1.iter().map(|y| (*y).into()).collect())).collect();
   let setups = setups.iter().map(|x| (&x.0, &x.1)).collect();
@@ -49,7 +49,7 @@ fn prove(srs: &SRS, graph: &mut Graph, models: Vec<ArrayD<Fr>>) {
   let outputsEnc: Vec<Vec<ArrayD<DataEnc>>> =
     outputs.iter().map(|output| (**output).iter().map(|x| (*x).map(|y| DataEnc::new(srs, y))).collect()).collect();
 
-  //Save files:
+  // Save files:
   let modelsEncBytes = bincode::serialize(&modelsEnc).unwrap();
   let inputsEncBytes = bincode::serialize(&inputsEnc).unwrap();
   let outputsEncBytes = bincode::serialize(&outputsEnc).unwrap();
@@ -57,7 +57,7 @@ fn prove(srs: &SRS, graph: &mut Graph, models: Vec<ArrayD<Fr>>) {
   fs::write("inputsEnc", &inputsEncBytes).unwrap();
   fs::write("outputsEnc", &outputsEncBytes).unwrap();
 
-  //Fiat-Shamir:
+  // Fiat-Shamir:
   let mut hasher = Keccak256::new();
   hasher.update(modelsEncBytes);
   hasher.update(inputsEncBytes);
@@ -66,13 +66,13 @@ fn prove(srs: &SRS, graph: &mut Graph, models: Vec<ArrayD<Fr>>) {
   hasher.finalize_into((&mut buf).into());
   let mut rng = StdRng::from_seed(buf);
 
-  //Prove:
+  // Prove:
   let proofs = graph.prove(srs, &setups, &models, &inputs, &outputs, &mut rng);
   proofs.serialize_uncompressed(File::create("proofs").unwrap()).unwrap();
 }
 
 fn verify(srs: &SRS, graph: &Graph) {
-  //Read Files:
+  // Read Files:
   let proofs = Vec::<(Vec<G1Affine>, Vec<G2Affine>)>::deserialize_uncompressed_unchecked(File::open("proofs").unwrap()).unwrap();
   let proofs = proofs.iter().map(|x| (&x.0, &x.1)).collect();
   let mut modelsEncBytes = Vec::new();
@@ -89,7 +89,7 @@ fn verify(srs: &SRS, graph: &Graph) {
   let outputsEnc: Vec<Vec<&ArrayD<DataEnc>>> = outputsEnc.iter().map(|output| output.iter().map(|x| x).collect()).collect();
   let outputsEnc: Vec<&Vec<&ArrayD<DataEnc>>> = outputsEnc.iter().map(|x| x).collect();
 
-  //Fiat-Shamir:
+  // Fiat-Shamir:
   let mut hasher = Keccak256::new();
   hasher.update(modelsEncBytes);
   hasher.update(inputsEncBytes);
@@ -98,7 +98,7 @@ fn verify(srs: &SRS, graph: &Graph) {
   hasher.finalize_into((&mut buf).into());
   let mut rng = StdRng::from_seed(buf);
 
-  //Verify:
+  // Verify:
   graph.verify(srs, &modelsEnc, &inputsEnc, &outputsEnc, &proofs, &mut rng);
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,15 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
+use crate::graph::Graph;
 use ark_bn254::{Fr, G1Affine, G2Affine};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use basic_block::*;
-use ndarray::ArrayD;
+use ndarray::{arr1, ArrayD};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use rayon::prelude::*;
+use sha3::{Digest, Keccak256};
+use std::fs::{self, File};
+use std::io::Read;
 use util::convert_to_data;
 mod basic_block;
 mod graph;
@@ -15,52 +20,93 @@ mod ptau;
 mod tests;
 mod util;
 
-fn main() {
-  let srs = &ptau::load_file("challenge", 7);
-  let (mut graph, models) = onnx::load_file("sample.onnx");
-
-  const n: usize = 1 << 2;
-  let input: Vec<_> = (0..n).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::from(rng.gen_range(-4..4))).collect();
-  let input = ArrayD::from_shape_vec(vec![n], input).unwrap();
-
+fn prove(srs: &SRS, graph: &mut Graph, models: Vec<ArrayD<Fr>>) {
   //Run:
+  let input: Vec<_> = (0..4).into_par_iter().map_init(rand::thread_rng, |rng, _| Fr::from(rng.gen_range(-4..4))).collect();
+  let input = arr1(&input).into_dyn();
   let inputs = vec![&input];
   let models = models.iter().map(|x| x).collect();
   let outputs = graph.run(&inputs, &models);
-  let outputs: Vec<Vec<&ArrayD<Fr>>> = outputs.iter().map(|output| output.iter().map(|x| x).collect()).collect();
-  let outputs: Vec<&Vec<&ArrayD<Fr>>> = outputs.iter().map(|output| output).collect();
 
   //Setup:
   let models: Vec<ArrayD<Data>> = models.iter().map(|model| convert_to_data(srs, model)).collect();
   let models: Vec<&ArrayD<Data>> = models.iter().map(|model| model).collect();
   let setups = graph.setup(srs, &models);
-  //Converting to affine
+
+  //Encode Data:
   let setups: Vec<(Vec<G1Affine>, Vec<G2Affine>)> =
     setups.iter().map(|x| (x.0.iter().map(|y| (*y).into()).collect(), x.1.iter().map(|y| (*y).into()).collect())).collect();
   let setups = setups.iter().map(|x| (&x.0, &x.1)).collect();
-
-  //Prove:
+  let modelsEnc: Vec<ArrayD<DataEnc>> = models.iter().map(|model| (**model).map(|x| DataEnc::new(srs, x))).collect();
   let inputs: Vec<ArrayD<Data>> = inputs.iter().map(|input| convert_to_data(srs, input)).collect();
   let inputs: Vec<&ArrayD<Data>> = inputs.iter().map(|input| input).collect();
+  let inputsEnc: Vec<ArrayD<DataEnc>> = inputs.iter().map(|x| (*x).map(|y| DataEnc::new(srs, y))).collect();
+  let outputs: Vec<Vec<&ArrayD<Fr>>> = outputs.iter().map(|output| output.iter().map(|x| x).collect()).collect();
+  let outputs: Vec<&Vec<&ArrayD<Fr>>> = outputs.iter().map(|output| output).collect();
   let outputs: Vec<Vec<ArrayD<Data>>> = graph.encodeOutputs(srs, &models, &inputs, &outputs);
   let outputs: Vec<Vec<&ArrayD<Data>>> = outputs.iter().map(|outputs| outputs.iter().map(|x| x).collect()).collect();
   let outputs: Vec<&Vec<&ArrayD<Data>>> = outputs.iter().map(|x| x).collect();
-  let mut rng = StdRng::from_entropy();
-  let mut rng2 = rng.clone();
+  let outputsEnc: Vec<Vec<ArrayD<DataEnc>>> =
+    outputs.iter().map(|output| (**output).iter().map(|x| (*x).map(|y| DataEnc::new(srs, y))).collect()).collect();
+
+  //Save files:
+  let modelsEncBytes = bincode::serialize(&modelsEnc).unwrap();
+  let inputsEncBytes = bincode::serialize(&inputsEnc).unwrap();
+  let outputsEncBytes = bincode::serialize(&outputsEnc).unwrap();
+  fs::write("modelsEnc", &modelsEncBytes).unwrap();
+  fs::write("inputsEnc", &inputsEncBytes).unwrap();
+  fs::write("outputsEnc", &outputsEncBytes).unwrap();
+
+  //Fiat-Shamir:
+  let mut hasher = Keccak256::new();
+  hasher.update(modelsEncBytes);
+  hasher.update(inputsEncBytes);
+  hasher.update(outputsEncBytes);
+  let mut buf = [0u8; 32];
+  hasher.finalize_into((&mut buf).into());
+  let mut rng = StdRng::from_seed(buf);
+
+  //Prove:
   let proofs = graph.prove(srs, &setups, &models, &inputs, &outputs, &mut rng);
-  //Converting to affine
   let proofs: Vec<(Vec<G1Affine>, Vec<G2Affine>)> =
     proofs.iter().map(|x| (x.0.iter().map(|y| (*y).into()).collect(), x.1.iter().map(|y| (*y).into()).collect())).collect();
+  proofs.serialize_uncompressed(File::create("proofs").unwrap()).unwrap();
+}
+
+fn verify(srs: &SRS, graph: &Graph) {
+  //Read Files:
+  let proofs = Vec::<(Vec<G1Affine>, Vec<G2Affine>)>::deserialize_uncompressed_unchecked(File::open("proofs").unwrap()).unwrap();
   let proofs = proofs.iter().map(|x| (&x.0, &x.1)).collect();
+  let mut modelsEncBytes = Vec::new();
+  File::open("modelsEnc").unwrap().read_to_end(&mut modelsEncBytes).unwrap();
+  let modelsEnc: Vec<ArrayD<DataEnc>> = bincode::deserialize(&modelsEncBytes).unwrap();
+  let modelsEnc: Vec<&ArrayD<DataEnc>> = modelsEnc.iter().map(|model| model).collect();
+  let mut inputsEncBytes = Vec::new();
+  File::open("inputsEnc").unwrap().read_to_end(&mut inputsEncBytes).unwrap();
+  let inputsEnc: Vec<ArrayD<DataEnc>> = bincode::deserialize(&inputsEncBytes).unwrap();
+  let inputsEnc: Vec<&ArrayD<DataEnc>> = inputsEnc.iter().map(|input| input).collect();
+  let mut outputsEncBytes = Vec::new();
+  File::open("outputsEnc").unwrap().read_to_end(&mut outputsEncBytes).unwrap();
+  let outputsEnc: Vec<Vec<ArrayD<DataEnc>>> = bincode::deserialize(&outputsEncBytes).unwrap();
+  let outputsEnc: Vec<Vec<&ArrayD<DataEnc>>> = outputsEnc.iter().map(|output| output.iter().map(|x| x).collect()).collect();
+  let outputsEnc: Vec<&Vec<&ArrayD<DataEnc>>> = outputsEnc.iter().map(|x| x).collect();
+
+  //Fiat-Shamir:
+  let mut hasher = Keccak256::new();
+  hasher.update(modelsEncBytes);
+  hasher.update(inputsEncBytes);
+  hasher.update(outputsEncBytes);
+  let mut buf = [0u8; 32];
+  hasher.finalize_into((&mut buf).into());
+  let mut rng = StdRng::from_seed(buf);
 
   //Verify:
-  let models: Vec<ArrayD<DataEnc>> = models.iter().map(|model| (**model).map(|x| DataEnc::new(srs, x))).collect();
-  let models: Vec<&ArrayD<DataEnc>> = models.iter().map(|model| model).collect();
-  let inputs: Vec<ArrayD<DataEnc>> = inputs.iter().map(|x| (*x).map(|y| DataEnc::new(srs, y))).collect();
-  let inputs: Vec<&ArrayD<DataEnc>> = inputs.iter().map(|input| input).collect();
-  let outputs: Vec<Vec<ArrayD<DataEnc>>> =
-    outputs.iter().map(|output| (**output).iter().map(|x| (*x).map(|y| DataEnc::new(srs, y))).collect()).collect();
-  let outputs: Vec<Vec<&ArrayD<DataEnc>>> = outputs.iter().map(|output| output.iter().map(|x| x).collect()).collect();
-  let outputs: Vec<&Vec<&ArrayD<DataEnc>>> = outputs.iter().map(|x| x).collect();
-  graph.verify(srs, &models, &inputs, &outputs, &proofs, &mut rng2);
+  graph.verify(srs, &modelsEnc, &inputsEnc, &outputsEnc, &proofs, &mut rng);
+}
+
+fn main() {
+  let srs = &ptau::load_file("challenge", 7);
+  let (mut graph, models) = onnx::load_file("sample.onnx");
+  prove(&srs, &mut graph, models);
+  verify(&srs, &graph);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,8 +68,6 @@ fn prove(srs: &SRS, graph: &mut Graph, models: Vec<ArrayD<Fr>>) {
 
   //Prove:
   let proofs = graph.prove(srs, &setups, &models, &inputs, &outputs, &mut rng);
-  let proofs: Vec<(Vec<G1Affine>, Vec<G2Affine>)> =
-    proofs.iter().map(|x| (x.0.iter().map(|y| (*y).into()).collect(), x.1.iter().map(|y| (*y).into()).collect())).collect();
   proofs.serialize_uncompressed(File::create("proofs").unwrap()).unwrap();
 }
 

--- a/src/onnx.rs
+++ b/src/onnx.rs
@@ -17,8 +17,8 @@ pub fn load_file(filename: &str) -> (Graph, Vec<ArrayD<Fr>>) {
     nodes: vec![],
     outputs: vec![],
   };
-  let mut basic_blocks_idx: HashMap<String, usize> = HashMap::new(); //BasicBlock to graph.basic_blocks index
-  let mut outputs_idx: HashMap<String, Vec<(i32, usize)>> = HashMap::new(); //Graph node name to graph.nodes outputs
+  let mut basic_blocks_idx: HashMap<String, usize> = HashMap::new(); // BasicBlock to graph.basic_blocks index
+  let mut outputs_idx: HashMap<String, Vec<(i32, usize)>> = HashMap::new(); // Graph node name to graph.nodes outputs
   let mut setups = vec![];
 
   for tensor in onnx_graph.initializer {

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,6 +7,7 @@ use ark_ec::AffineRepr;
 use ark_ec::{ScalarMul, VariableBaseMSM};
 use ark_ff::PrimeField;
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{UniformRand, Zero};
 use ndarray::{arr1, concatenate, Array1, ArrayD, Axis, IxDyn};
 use rand::{rngs::StdRng, SeedableRng};
@@ -102,6 +103,24 @@ pub fn toeplitz_mul<G: ScalarMul + std::ops::MulAssign<Fr>>(domain: GeneralEvalu
   let mut r = circulant_mul(domain, &m2, &temp2);
   r.resize(n, G::zero());
   r
+}
+
+pub fn ark_se<S, A: CanonicalSerialize>(a: &A, s: S) -> Result<S::Ok, S::Error>
+where
+  S: serde::Serializer,
+{
+  let mut bytes = vec![];
+  a.serialize_compressed(&mut bytes).map_err(serde::ser::Error::custom)?;
+  s.serialize_bytes(&bytes)
+}
+
+pub fn ark_de<'de, D, A: CanonicalDeserialize>(data: D) -> Result<A, D::Error>
+where
+  D: serde::de::Deserializer<'de>,
+{
+  let s: Vec<u8> = serde::de::Deserialize::deserialize(data)?;
+  let a = A::deserialize_compressed_unchecked(s.as_slice());
+  a.map_err(serde::de::Error::custom)
 }
 
 pub fn msm<P: VariableBaseMSM>(a: &[P::MulBase], b: &[P::ScalarField]) -> P {

--- a/src/util.rs
+++ b/src/util.rs
@@ -106,6 +106,9 @@ pub fn toeplitz_mul<G: ScalarMul + std::ops::MulAssign<Fr>>(domain: GeneralEvalu
   r
 }
 
+// For serialization, ArrayD uses serde while G1Affine uses ark_serialize.
+// In order to bridge between the two, the following code snippet is used:
+// https://github.com/arkworks-rs/algebra/issues/178#issuecomment-1413219278
 pub fn ark_se<S, A: CanonicalSerialize>(a: &A, s: S) -> Result<S::Ok, S::Error>
 where
   S: serde::Serializer,

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,8 +10,9 @@ use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{UniformRand, Zero};
 use ndarray::{arr1, concatenate, Array1, ArrayD, Axis, IxDyn};
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{rngs::StdRng, RngCore, SeedableRng};
 use rayon::prelude::*;
+use sha3::{Digest, Keccak256};
 use std::collections::HashMap;
 use std::collections::{BTreeSet, HashSet};
 
@@ -121,6 +122,17 @@ where
   let s: Vec<u8> = serde::de::Deserialize::deserialize(data)?;
   let a = A::deserialize_compressed_unchecked(s.as_slice());
   a.map_err(serde::de::Error::custom)
+}
+
+pub fn add_randomness(rng: &mut StdRng, mut bytes: Vec<u8>) {
+  let mut buf = vec![0u8; 32];
+  rng.fill_bytes(&mut buf);
+  bytes.append(&mut buf);
+  let mut buf = [0u8; 32];
+  let mut hasher = Keccak256::new();
+  hasher.update(bytes);
+  hasher.finalize_into((&mut buf).into());
+  *rng = StdRng::from_seed(buf);
 }
 
 pub fn msm<P: VariableBaseMSM>(a: &[P::MulBase], b: &[P::ScalarField]) -> P {


### PR DESCRIPTION
- Saves `models`, `inputs`, `outputs`, and `proofs` to disk using serde and ark_serialize.
- The bytes from `models`, `inputs`, and `outputs` are hashed via Keccak-256, and then passed as the seed to the intial `rng`.
  - After each basic block is proven, the proof is hashed and passed into the `rng` as well.
- This makes the proof secure and non-interactive using the Fiat-Shamir heuristic.

Closes #13.