### PR TITLE
Cache alphas and betas

### DIFF
--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -2,8 +2,7 @@
 use crate::util::{self, ark_de, ark_se};
 pub use add::AddBasicBlock;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
-use ark_poly::univariate::DensePolynomial;
-use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
+use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::UniformRand;
 pub use constant::ConstBasicBlock;
@@ -21,6 +20,7 @@ pub use permute::PermuteBasicBlock;
 use rand::{rngs::StdRng, SeedableRng};
 pub use rope::RoPEBasicBlock;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 pub use sub::SubBasicBlock;
 pub use sum::SumBasicBlock;
 pub mod add;
@@ -50,6 +50,17 @@ pub struct SRS {
   pub Y2P: G2Projective,
 }
 
+// During proofs and verifications, a cache is used to prevent recomputation across basic blocks / proofs.
+// These are the types of the elements in the cache.
+pub enum CacheValues {
+  CQTableDict(HashMap<Fr, usize>),
+  CQ2TableDict(HashMap<(Fr, Fr), usize>),
+  FieldElem(Fr),
+  G1Elem(G1Affine),
+  G2Elem(G2Affine),
+}
+pub type ProveVerifyCache = HashMap<String, CacheValues>;
+
 pub type PairingCheck = Vec<(G1Affine, G2Affine)>;
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -68,7 +79,7 @@ impl Data {
   pub fn new(srs: &SRS, raw: &[Fr]) -> Data {
     let N = raw.len();
     let domain = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
-    let f = DensePolynomial { coeffs: domain.ifft(&raw) };
+    let f = DensePolynomial::from_coefficients_vec(domain.ifft(&raw));
     let fx = util::msm::<G1Projective>(&srs.X1A, &f.coeffs);
     let mut rng = StdRng::from_entropy();
     return Data {
@@ -126,6 +137,7 @@ pub trait BasicBlock: std::fmt::Debug {
     _inputs: &Vec<&ArrayD<Data>>,
     _outputs: &Vec<&ArrayD<Data>>,
     _rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>) {
     (Vec::new(), Vec::new())
   }
@@ -138,6 +150,7 @@ pub trait BasicBlock: std::fmt::Debug {
     _outputs: &Vec<&ArrayD<DataEnc>>,
     _proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     _rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     vec![]
   }

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -50,14 +50,14 @@ pub struct SRS {
   pub Y2P: G2Projective,
 }
 
-// During proofs and verifications, a cache is used to prevent recomputation across basic blocks / proofs.
+// During proofs and verifications, a cache is used to prevent recomputation.
 // These are the types of the elements in the cache.
 pub enum CacheValues {
   CQTableDict(HashMap<Fr, usize>),
   CQ2TableDict(HashMap<(Fr, Fr), usize>),
-  FieldElem(Fr),
-  G1Elem(G1Affine),
-  G2Elem(G2Affine),
+  Fr(Fr),
+  Data(Data),
+  G2(G2Affine),
 }
 pub type ProveVerifyCache = HashMap<String, CacheValues>;
 

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -55,7 +55,7 @@ pub struct SRS {
 pub enum CacheValues {
   CQTableDict(HashMap<Fr, usize>),
   CQ2TableDict(HashMap<(Fr, Fr), usize>),
-  Fr(Fr),
+  RLCRandom(Fr),
   Data(Data),
   G2(G2Affine),
 }

--- a/src/basic_block/add.rs
+++ b/src/basic_block/add.rs
@@ -1,4 +1,4 @@
-use super::{BasicBlock, Data, DataEnc, PairingCheck, SRS};
+use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ndarray::{arr1, azip, ArrayD, IxDyn};
 use rand::rngs::StdRng;
@@ -39,6 +39,7 @@ impl BasicBlock for AddBasicBlock {
     outputs: &Vec<&ArrayD<DataEnc>>,
     _proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     _rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     // Verify f(x)+g(x)=h(x)
     assert!(inputs[0][0].g1 + inputs[1][0].g1 == outputs[0][0].g1);

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -1,10 +1,10 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, Data, DataEnc, PairingCheck, SRS};
+use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
 use crate::util;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
-use ark_poly::{evaluations::univariate::Evaluations, univariate::DensePolynomial, EvaluationDomain, GeneralEvaluationDomain};
+use ark_poly::{evaluations::univariate::Evaluations, univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain};
 use ark_std::{
   ops::{Mul, Sub},
   One, UniformRand, Zero,
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct CQBasicBlock {
-  pub table_dict: HashMap<Fr, usize>,
   pub setup: Option<(i32, usize)>,
 }
 
@@ -60,6 +59,7 @@ impl BasicBlock for CQBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     _outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    cache: &mut ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>) {
     assert!(inputs.len() == 1 && inputs[0].len() == 1);
     let model = &model[0];
@@ -73,19 +73,23 @@ impl BasicBlock for CQBasicBlock {
     let Q_i_x_1 = &setup.0[..N];
     let L_i_x_1 = &setup.0[N..2 * N];
     let L_i_0_x_1 = &setup.0[2 * N..];
-    if self.table_dict.len() == 0 {
+    let CacheValues::CQTableDict(table_dict) = cache.entry(format!("{:p}_table_dict", self)).or_insert(CacheValues::CQTableDict(HashMap::new()))
+    else {
+      panic!("Cache type error")
+    };
+    if table_dict.len() == 0 {
       for i in 0..N {
-        self.table_dict.insert(model.raw[i], i);
+        table_dict.insert(model.raw[i], i);
       }
     }
 
     // Calculate m
     let mut m_i = HashMap::new();
     for x in input.raw.iter() {
-      if !self.table_dict.contains_key(x) {
+      if !table_dict.contains_key(x) {
         println!("{:?},{:?}", x, -*x);
       }
-      m_i.entry(self.table_dict.get(x).unwrap()).and_modify(|y| *y += 1).or_insert(1);
+      m_i.entry(table_dict.get(x).unwrap()).and_modify(|y| *y += 1).or_insert(1);
     }
     let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.iter().map(|(i, y)| (L_i_x_1[**i], Fr::from(*y as u32))).unzip();
     let m_x = util::msm::<G1Projective>(&temp, &temp2);
@@ -106,14 +110,18 @@ impl BasicBlock for CQBasicBlock {
     let B_i: Vec<Fr> = input.raw.iter().map(|x| (*x + beta).inverse().unwrap()).collect();
     let B_poly = Evaluations::from_vec_and_domain(B_i.clone(), domain_n).interpolate();
     let B_Q_poly = B_poly
-      .mul(&(input.poly.clone() + (DensePolynomial { coeffs: vec![beta] })))
-      .sub(&DensePolynomial { coeffs: vec![Fr::one()] })
+      .mul(&(input.poly.clone() + (DensePolynomial::from_coefficients_vec(vec![beta]))))
+      .sub(&DensePolynomial::from_coefficients_vec(vec![Fr::one()]))
       .divide_by_vanishing_poly(domain_n)
       .unwrap()
       .0;
     let B_x = util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs);
     let B_Q_x = util::msm::<G1Projective>(&srs.X1A, &B_Q_poly.coeffs);
-    let B_zero_div = util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs[1..]);
+    let B_zero_div = if B_poly.is_zero() {
+      G1Projective::zero()
+    } else {
+      util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs[1..])
+    };
     let B_DC = util::msm::<G1Projective>(&srs.X1A[N - n..], &B_poly.coeffs);
 
     let f_x_2 = util::msm::<G2Projective>(&srs.X2A, &input.poly.coeffs) + srs.Y2P * input.r;
@@ -143,6 +151,7 @@ impl BasicBlock for CQBasicBlock {
     _outputs: &Vec<&ArrayD<DataEnc>>,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     let mut checks = Vec::new();
     let N = model[0].len;

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -73,7 +73,8 @@ impl BasicBlock for CQBasicBlock {
     let Q_i_x_1 = &setup.0[..N];
     let L_i_x_1 = &setup.0[N..2 * N];
     let L_i_0_x_1 = &setup.0[2 * N..];
-    let CacheValues::CQTableDict(table_dict) = cache.entry(format!("{:p}_table_dict", self)).or_insert(CacheValues::CQTableDict(HashMap::new()))
+    let CacheValues::CQTableDict(table_dict) =
+      cache.entry(format!("cq_table_dict_{:p}", self)).or_insert_with(|| CacheValues::CQTableDict(HashMap::new()))
     else {
       panic!("Cache type error")
     };

--- a/src/basic_block/cq2.rs
+++ b/src/basic_block/cq2.rs
@@ -87,7 +87,8 @@ impl BasicBlock for CQ2BasicBlock {
     let L_i_x_1 = &setup.0[2 * N..3 * N];
     let L_i_0_x_1 = &setup.0[3 * N..];
 
-    let CacheValues::CQ2TableDict(table_dict) = cache.entry(format!("{:p}_table_dict", self)).or_insert(CacheValues::CQ2TableDict(HashMap::new()))
+    let CacheValues::CQ2TableDict(table_dict) =
+      cache.entry(format!("cq2_table_dict_{:p}", self)).or_insert_with(|| CacheValues::CQ2TableDict(HashMap::new()))
     else {
       panic!("Cache type error")
     };

--- a/src/basic_block/cq2.rs
+++ b/src/basic_block/cq2.rs
@@ -1,10 +1,10 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, Data, DataEnc, PairingCheck, SRS};
+use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
 use crate::util;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
-use ark_poly::{evaluations::univariate::Evaluations, univariate::DensePolynomial, EvaluationDomain, GeneralEvaluationDomain};
+use ark_poly::{evaluations::univariate::Evaluations, univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain};
 use ark_std::{
   ops::{Mul, Sub},
   One, UniformRand, Zero,
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct CQ2BasicBlock {
-  pub table_dict: HashMap<(Fr, Fr), usize>,
   pub setup: Option<(Box<dyn BasicBlock>, i32, usize)>,
 }
 
@@ -67,6 +66,7 @@ impl BasicBlock for CQ2BasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     _outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    cache: &mut ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>) {
     assert!(inputs.len() == 2 && inputs[0].len() == 1 && inputs[1].len() == 1);
     let N = model[0].raw.len();
@@ -87,9 +87,13 @@ impl BasicBlock for CQ2BasicBlock {
     let L_i_x_1 = &setup.0[2 * N..3 * N];
     let L_i_0_x_1 = &setup.0[3 * N..];
 
-    if self.table_dict.len() == 0 {
+    let CacheValues::CQ2TableDict(table_dict) = cache.entry(format!("{:p}_table_dict", self)).or_insert(CacheValues::CQ2TableDict(HashMap::new()))
+    else {
+      panic!("Cache type error")
+    };
+    if table_dict.len() == 0 {
       for i in 0..N {
-        self.table_dict.insert((model[0].raw[i], model[1].raw[i]), i);
+        table_dict.insert((model[0].raw[i], model[1].raw[i]), i);
       }
     }
 
@@ -97,10 +101,10 @@ impl BasicBlock for CQ2BasicBlock {
     let mut m_i = HashMap::new();
     for x in inputs[0].raw.iter().zip(inputs[1].raw.iter()) {
       let temp = (*x.0, *x.1);
-      if !self.table_dict.contains_key(&temp) {
+      if !table_dict.contains_key(&temp) {
         println!("{:?}", temp);
       }
-      m_i.entry(self.table_dict.get(&temp).unwrap()).and_modify(|y| *y += 1).or_insert(1);
+      m_i.entry(table_dict.get(&temp).unwrap()).and_modify(|y| *y += 1).or_insert(1);
     }
     let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.iter().map(|(i, y)| (L_i_x_1[**i], Fr::from(*y as u32))).unzip();
     let m_x = util::msm::<G1Projective>(&temp, &temp2);
@@ -130,14 +134,18 @@ impl BasicBlock for CQ2BasicBlock {
     let B_i: Vec<Fr> = agg_input.raw.iter().map(|x| (*x + beta).inverse().unwrap()).collect();
     let B_poly = Evaluations::from_vec_and_domain(B_i.clone(), domain_n).interpolate();
     let B_Q_poly = B_poly
-      .mul(&(agg_input.poly.clone() + (DensePolynomial { coeffs: vec![beta] })))
-      .sub(&DensePolynomial { coeffs: vec![Fr::one()] })
+      .mul(&(agg_input.poly.clone() + (DensePolynomial::from_coefficients_vec(vec![beta]))))
+      .sub(&DensePolynomial::from_coefficients_vec(vec![Fr::one()]))
       .divide_by_vanishing_poly(domain_n)
       .unwrap()
       .0;
     let B_x = util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs);
     let B_Q_x = util::msm::<G1Projective>(&srs.X1A, &B_Q_poly.coeffs);
-    let B_zero_div = util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs[1..]);
+    let B_zero_div = if B_poly.is_zero() {
+      G1Projective::zero()
+    } else {
+      util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs[1..])
+    };
     let B_DC = util::msm::<G1Projective>(&srs.X1A[N - n..], &B_poly.coeffs);
 
     let f_x_2 = util::msm::<G2Projective>(&srs.X2A, &agg_input.poly.coeffs) + srs.Y2P * agg_input.r;
@@ -171,6 +179,7 @@ impl BasicBlock for CQ2BasicBlock {
     _outputs: &Vec<&ArrayD<DataEnc>>,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     let mut checks = Vec::new();
     let inputs = vec![&inputs[0][0], &inputs[1][0]];

--- a/src/basic_block/cqlin.rs
+++ b/src/basic_block/cqlin.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
 use crate::util::{self, calc_pow};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
@@ -111,17 +111,24 @@ impl BasicBlock for CQLinBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
-    _cache: &mut ProveVerifyCache,
+    cache: &mut ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>) {
     let l = inputs[0].len();
     let m = model.len();
     let n = model[0].raw.len();
     let N = srs.X2P.len() - 1;
     let domain_m = GeneralEvaluationDomain::<Fr>::new(m).unwrap();
-    let alpha = Fr::rand(rng);
+    let CacheValues::Fr(alpha) = cache.entry("cqlin_alpha".to_owned()).or_insert_with(|| CacheValues::Fr(Fr::rand(rng))) else {
+      panic!("Cache type error")
+    };
+    let alpha = alpha.clone();
 
-    let alpha_pow = calc_pow(alpha, l);
-    let alpha_pow = Data::new(srs, &alpha_pow); // r is ignored (unnecessary msm)
+    let CacheValues::Data(alpha_pow) =
+      cache.entry(format!("cqlin_alpha_msm_{l}")).or_insert_with(|| CacheValues::Data(Data::new(srs, &calc_pow(alpha, l))))
+    else {
+      panic!("Cache type error")
+    };
+    let alpha_pow = alpha_pow.clone();
 
     let mut flat_A = vec![Fr::zero(); m];
     let mut flat_A_r = Fr::zero();
@@ -203,7 +210,7 @@ impl BasicBlock for CQLinBasicBlock {
     outputs: &Vec<&ArrayD<DataEnc>>,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     rng: &mut StdRng,
-    _cache: &mut ProveVerifyCache,
+    cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     let mut checks = Vec::new();
     let l = inputs[0].len();
@@ -217,7 +224,10 @@ impl BasicBlock for CQLinBasicBlock {
 
     let [M_x] = proof.1[..] else { panic!("Wrong proof format") };
 
-    let alpha = Fr::rand(rng);
+    let CacheValues::Fr(alpha) = cache.entry("cqlin_alpha".to_owned()).or_insert_with(|| CacheValues::Fr(Fr::rand(rng))) else {
+      panic!("Cache type error")
+    };
+    let alpha = alpha.clone();
     let alpha_pow = calc_pow(alpha, l);
 
     // Calculate flat_A

--- a/src/basic_block/cqlin.rs
+++ b/src/basic_block/cqlin.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, Data, DataEnc, PairingCheck, SRS};
+use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
 use crate::util::{self, calc_pow};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
@@ -111,6 +111,7 @@ impl BasicBlock for CQLinBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>) {
     let l = inputs[0].len();
     let m = model.len();
@@ -202,6 +203,7 @@ impl BasicBlock for CQLinBasicBlock {
     outputs: &Vec<&ArrayD<DataEnc>>,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     let mut checks = Vec::new();
     let l = inputs[0].len();

--- a/src/basic_block/cqlin.rs
+++ b/src/basic_block/cqlin.rs
@@ -118,7 +118,7 @@ impl BasicBlock for CQLinBasicBlock {
     let n = model[0].raw.len();
     let N = srs.X2P.len() - 1;
     let domain_m = GeneralEvaluationDomain::<Fr>::new(m).unwrap();
-    let CacheValues::Fr(alpha) = cache.entry("cqlin_alpha".to_owned()).or_insert_with(|| CacheValues::Fr(Fr::rand(rng))) else {
+    let CacheValues::RLCRandom(alpha) = cache.entry("cqlin_alpha".to_owned()).or_insert_with(|| CacheValues::RLCRandom(Fr::rand(rng))) else {
       panic!("Cache type error")
     };
     let alpha = alpha.clone();
@@ -224,7 +224,7 @@ impl BasicBlock for CQLinBasicBlock {
 
     let [M_x] = proof.1[..] else { panic!("Wrong proof format") };
 
-    let CacheValues::Fr(alpha) = cache.entry("cqlin_alpha".to_owned()).or_insert_with(|| CacheValues::Fr(Fr::rand(rng))) else {
+    let CacheValues::RLCRandom(alpha) = cache.entry("cqlin_alpha".to_owned()).or_insert_with(|| CacheValues::RLCRandom(Fr::rand(rng))) else {
       panic!("Cache type error")
     };
     let alpha = alpha.clone();

--- a/src/basic_block/eq.rs
+++ b/src/basic_block/eq.rs
@@ -1,4 +1,4 @@
-use super::{BasicBlock, Data, DataEnc, PairingCheck, SRS};
+use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
 use ark_bn254::{G1Affine, G1Projective, G2Affine, G2Projective};
 use ndarray::ArrayD;
 use rand::rngs::StdRng;
@@ -14,6 +14,7 @@ impl BasicBlock for EqBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     _outputs: &Vec<&ArrayD<Data>>,
     _rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>) {
     assert!(inputs.len() == 2 && inputs[0].ndim() == 1 && inputs[1].ndim() == 1);
     // Blinding
@@ -29,6 +30,7 @@ impl BasicBlock for EqBasicBlock {
     _outputs: &Vec<&ArrayD<DataEnc>>,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     _rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     // Verify f(x)+g(x)=h(x)
     vec![vec![

--- a/src/basic_block/matmul.rs
+++ b/src/basic_block/matmul.rs
@@ -1,10 +1,10 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, Data, DataEnc, PairingCheck, SRS};
+use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
 use crate::util::{self, calc_pow};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
-use ark_poly::{univariate::DensePolynomial, EvaluationDomain, GeneralEvaluationDomain};
+use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain};
 use ark_std::{ops::Mul, ops::Sub, UniformRand, Zero};
 use ndarray::{ArrayD, Ix1, Ix2, IxDyn};
 use rand::{rngs::StdRng, SeedableRng};
@@ -37,6 +37,7 @@ impl BasicBlock for MatMulBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>) {
     let l = inputs[0].len();
     let m = inputs[0][0].raw.len();
@@ -86,25 +87,29 @@ impl BasicBlock for MatMulBasicBlock {
 
     // Calculate Left
     let left_raw: Vec<Fr> = (0..m).map(|i| flat_A.raw[i] * flat_B.raw[i]).collect();
-    let left_poly = DensePolynomial {
-      coeffs: domain_m.ifft(&left_raw),
-    };
+    let left_poly = DensePolynomial::from_coefficients_vec(domain_m.ifft(&left_raw));
     let left_x = util::msm::<G1Projective>(&srs.X1A, &left_poly.coeffs);
     let left_Q_poly = flat_A.poly.mul(&flat_B.poly).sub(&left_poly).divide_by_vanishing_poly(domain_m).unwrap().0;
     let left_Q_x = util::msm::<G1Projective>(&srs.X1A, &left_Q_poly.coeffs);
     let left_zero = srs.X1A[0] * (Fr::from(m as u32).inverse().unwrap() * left_raw.iter().sum::<Fr>());
-    let left_zero_div = util::msm::<G1Projective>(&srs.X1A, &left_poly.coeffs[1..]);
+    let left_zero_div = if left_poly.is_zero() {
+      G1Projective::zero()
+    } else {
+      util::msm::<G1Projective>(&srs.X1A, &left_poly.coeffs[1..])
+    };
     let flat_B_g2 = util::msm::<G2Projective>(&srs.X2A, &flat_B.poly.coeffs) + srs.Y2P * flat_B.r;
 
     // Calculate Right
     let right_raw: Vec<Fr> = (0..n).map(|i| flat_C.raw[i] * beta_pow.raw[i]).collect();
-    let right_poly = DensePolynomial {
-      coeffs: domain_n.ifft(&right_raw),
-    };
+    let right_poly = DensePolynomial::from_coefficients_vec(domain_n.ifft(&right_raw));
     let right_x = util::msm::<G1Projective>(&srs.X1A, &right_poly.coeffs);
     let right_Q_poly = flat_C.poly.mul(&beta_pow.poly).sub(&right_poly).divide_by_vanishing_poly(domain_n).unwrap().0;
     let right_Q_x = util::msm::<G1Projective>(&srs.X1A, &right_Q_poly.coeffs);
-    let right_zero_div = util::msm::<G1Projective>(&srs.X1A, &right_poly.coeffs[1..]);
+    let right_zero_div = if right_poly.is_zero() {
+      G1Projective::zero()
+    } else {
+      util::msm::<G1Projective>(&srs.X1A, &right_poly.coeffs[1..])
+    };
 
     // Blinding
     let mut rng2 = StdRng::from_entropy();
@@ -130,6 +135,7 @@ impl BasicBlock for MatMulBasicBlock {
     outputs: &Vec<&ArrayD<DataEnc>>,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     let mut checks = Vec::new();
     let l = inputs[0].len();

--- a/src/basic_block/matmul.rs
+++ b/src/basic_block/matmul.rs
@@ -44,11 +44,11 @@ impl BasicBlock for MatMulBasicBlock {
     let n = inputs[1].len();
     let domain_m = GeneralEvaluationDomain::<Fr>::new(m).unwrap();
     let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
-    let CacheValues::Fr(alpha) = cache.entry("matmul_alpha".to_owned()).or_insert_with(|| CacheValues::Fr(Fr::rand(rng))) else {
+    let CacheValues::RLCRandom(alpha) = cache.entry("matmul_alpha".to_owned()).or_insert_with(|| CacheValues::RLCRandom(Fr::rand(rng))) else {
       panic!("Cache type error")
     };
     let alpha = alpha.clone();
-    let CacheValues::Fr(beta) = cache.entry("matmul_beta".to_owned()).or_insert_with(|| CacheValues::Fr(Fr::rand(rng))) else {
+    let CacheValues::RLCRandom(beta) = cache.entry("matmul_beta".to_owned()).or_insert_with(|| CacheValues::RLCRandom(Fr::rand(rng))) else {
       panic!("Cache type error")
     };
     let beta = beta.clone();
@@ -161,11 +161,11 @@ impl BasicBlock for MatMulBasicBlock {
     };
     let flat_B_g2 = proof.1[0];
 
-    let CacheValues::Fr(alpha) = cache.entry("matmul_alpha".to_owned()).or_insert_with(|| CacheValues::Fr(Fr::rand(rng))) else {
+    let CacheValues::RLCRandom(alpha) = cache.entry("matmul_alpha".to_owned()).or_insert_with(|| CacheValues::RLCRandom(Fr::rand(rng))) else {
       panic!("Cache type error")
     };
     let alpha = alpha.clone();
-    let CacheValues::Fr(beta) = cache.entry("matmul_beta".to_owned()).or_insert_with(|| CacheValues::Fr(Fr::rand(rng))) else {
+    let CacheValues::RLCRandom(beta) = cache.entry("matmul_beta".to_owned()).or_insert_with(|| CacheValues::RLCRandom(Fr::rand(rng))) else {
       panic!("Cache type error")
     };
     let beta = beta.clone();

--- a/src/basic_block/matmul.rs
+++ b/src/basic_block/matmul.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
 use crate::util::{self, calc_pow};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
@@ -37,20 +37,34 @@ impl BasicBlock for MatMulBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
-    _cache: &mut ProveVerifyCache,
+    cache: &mut ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>) {
     let l = inputs[0].len();
     let m = inputs[0][0].raw.len();
     let n = inputs[1].len();
     let domain_m = GeneralEvaluationDomain::<Fr>::new(m).unwrap();
     let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
-    let alpha = Fr::rand(rng);
-    let beta = Fr::rand(rng);
+    let CacheValues::Fr(alpha) = cache.entry("matmul_alpha".to_owned()).or_insert_with(|| CacheValues::Fr(Fr::rand(rng))) else {
+      panic!("Cache type error")
+    };
+    let alpha = alpha.clone();
+    let CacheValues::Fr(beta) = cache.entry("matmul_beta".to_owned()).or_insert_with(|| CacheValues::Fr(Fr::rand(rng))) else {
+      panic!("Cache type error")
+    };
+    let beta = beta.clone();
 
-    let alpha_pow = calc_pow(alpha, l);
-    let alpha_pow = Data::new(srs, &alpha_pow); // r is ignored (unnecessary msm)
-    let beta_pow = calc_pow(beta, n);
-    let beta_pow = Data::new(srs, &beta_pow); // r is ignored
+    let CacheValues::Data(alpha_pow) =
+      cache.entry(format!("matmul_alpha_msm_{l}")).or_insert_with(|| CacheValues::Data(Data::new(srs, &calc_pow(alpha, l))))
+    else {
+      panic!("Cache type error")
+    };
+    let alpha_pow = alpha_pow.clone();
+    let CacheValues::Data(beta_pow) =
+      cache.entry(format!("matmul_beta_msm_{n}")).or_insert_with(|| CacheValues::Data(Data::new(srs, &calc_pow(beta, n))))
+    else {
+      panic!("Cache type error")
+    };
+    let beta_pow = beta_pow.clone();
 
     let mut flat_A = vec![Fr::zero(); m];
     let mut flat_A_r = Fr::zero();
@@ -135,7 +149,7 @@ impl BasicBlock for MatMulBasicBlock {
     outputs: &Vec<&ArrayD<DataEnc>>,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     rng: &mut StdRng,
-    _cache: &mut ProveVerifyCache,
+    cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     let mut checks = Vec::new();
     let l = inputs[0].len();
@@ -147,13 +161,24 @@ impl BasicBlock for MatMulBasicBlock {
     };
     let flat_B_g2 = proof.1[0];
 
-    let alpha = Fr::rand(rng);
-    let beta = Fr::rand(rng);
+    let CacheValues::Fr(alpha) = cache.entry("matmul_alpha".to_owned()).or_insert_with(|| CacheValues::Fr(Fr::rand(rng))) else {
+      panic!("Cache type error")
+    };
+    let alpha = alpha.clone();
+    let CacheValues::Fr(beta) = cache.entry("matmul_beta".to_owned()).or_insert_with(|| CacheValues::Fr(Fr::rand(rng))) else {
+      panic!("Cache type error")
+    };
+    let beta = beta.clone();
 
-    let alpha_pow = calc_pow(alpha, l); // r is ignored
-    let beta_pow = calc_pow(beta, n); // r is ignored
-    let beta_pow_coeff = domain_n.ifft(&beta_pow);
-    let beta_pow_g2: G2Affine = util::msm::<G2Projective>(&srs.X2A, &beta_pow_coeff).into();
+    let alpha_pow = calc_pow(alpha, l);
+    let beta_pow = calc_pow(beta, n);
+    let CacheValues::G2(beta_pow_g2) = cache
+      .entry(format!("matmul_beta_msm_g2_{n}"))
+      .or_insert_with(|| CacheValues::G2(util::msm::<G2Projective>(&srs.X2A, &domain_n.ifft(&beta_pow)).into()))
+    else {
+      panic!("Cache type error")
+    };
+    let beta_pow_g2 = beta_pow_g2.clone();
 
     // Calculate flat_A
     let temp: Vec<_> = (0..l).map(|i| inputs[0][i].g1).collect();

--- a/src/basic_block/mul.rs
+++ b/src/basic_block/mul.rs
@@ -1,4 +1,4 @@
-use super::{BasicBlock, Data, DataEnc, PairingCheck, SRS};
+use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
 use crate::util;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
@@ -25,6 +25,7 @@ impl BasicBlock for MulConstBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     _rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>) {
     let C = srs.X1P[0] * (Fr::from(self.c as u32) * inputs[0][0].r - outputs[0][0].r);
     return (vec![C], vec![]);
@@ -38,6 +39,7 @@ impl BasicBlock for MulConstBasicBlock {
     outputs: &Vec<&ArrayD<DataEnc>>,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     _rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     vec![vec![
       (inputs[0][0].g1, (srs.X2P[0] * Fr::from(self.c as u32)).into()),
@@ -62,6 +64,7 @@ impl BasicBlock for MulScalarBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     _rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>) {
     let inp0 = &inputs[0][0];
     let inp1 = &inputs[1][0];
@@ -78,6 +81,7 @@ impl BasicBlock for MulScalarBasicBlock {
     outputs: &Vec<&ArrayD<DataEnc>>,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     _rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     let mut checks = Vec::new();
     // Verify f(x)*g(x)=h(x)
@@ -111,6 +115,7 @@ impl BasicBlock for MulBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     _rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>) {
     let inp0 = &inputs[0][0];
     let inp1 = &inputs[1][0];
@@ -135,6 +140,7 @@ impl BasicBlock for MulBasicBlock {
     outputs: &Vec<&ArrayD<DataEnc>>,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     _rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     let mut checks = vec![];
     // Verify f(x)*g(x)-h(x)=z(x)t(x)

--- a/src/basic_block/permute.rs
+++ b/src/basic_block/permute.rs
@@ -43,7 +43,7 @@ impl BasicBlock for PermuteBasicBlock {
     rng: &mut StdRng,
     cache: &mut ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>) {
-    let CacheValues::Fr(alpha) = cache.entry("permute_alpha".to_owned()).or_insert_with(|| CacheValues::Fr(Fr::rand(rng))) else {
+    let CacheValues::RLCRandom(alpha) = cache.entry("permute_alpha".to_owned()).or_insert_with(|| CacheValues::RLCRandom(Fr::rand(rng))) else {
       panic!("Cache type error")
     };
     let alpha = alpha.clone();
@@ -154,7 +154,7 @@ impl BasicBlock for PermuteBasicBlock {
     cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     let mut checks = Vec::new();
-    let CacheValues::Fr(alpha) = cache.entry("permute_alpha".to_owned()).or_insert_with(|| CacheValues::Fr(Fr::rand(rng))) else {
+    let CacheValues::RLCRandom(alpha) = cache.entry("permute_alpha".to_owned()).or_insert_with(|| CacheValues::RLCRandom(Fr::rand(rng))) else {
       panic!("Cache type error")
     };
     let alpha = alpha.clone();

--- a/src/basic_block/permute.rs
+++ b/src/basic_block/permute.rs
@@ -1,10 +1,10 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, Data, DataEnc, PairingCheck, SRS};
+use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
 use crate::util::{self, calc_pow};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
-use ark_poly::{univariate::DensePolynomial, EvaluationDomain, GeneralEvaluationDomain};
+use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain};
 use ark_std::{ops::Mul, ops::Sub, UniformRand, Zero};
 use ndarray::{Array, ArrayD, Axis};
 use rand::{rngs::StdRng, SeedableRng};
@@ -41,6 +41,7 @@ impl BasicBlock for PermuteBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>) {
     let alpha = Fr::rand(rng);
     let (input, output) = (inputs[0], outputs[0]);
@@ -84,24 +85,28 @@ impl BasicBlock for PermuteBasicBlock {
 
     // Calculate Left
     let left_raw: Vec<Fr> = (0..m).map(|i| flat_L.raw[i] * alpha_pow[i * n]).collect();
-    let left_poly = DensePolynomial {
-      coeffs: domain_m.ifft(&left_raw),
-    };
+    let left_poly = DensePolynomial::from_coefficients_vec(domain_m.ifft(&left_raw));
     let left_x = util::msm::<G1Projective>(&srs.X1A, &left_poly.coeffs);
     let left_Q_poly = flat_L.poly.mul(&b.poly).sub(&left_poly).divide_by_vanishing_poly(domain_m).unwrap().0;
     let left_Q_x = util::msm::<G1Projective>(&srs.X1A, &left_Q_poly.coeffs);
     let left_zero = srs.X1A[0] * (Fr::from(m as u32).inverse().unwrap() * left_raw.iter().sum::<Fr>());
-    let left_zero_div = util::msm::<G1Projective>(&srs.X1A, &left_poly.coeffs[1..]);
+    let left_zero_div = if left_poly.is_zero() {
+      G1Projective::zero()
+    } else {
+      util::msm::<G1Projective>(&srs.X1A, &left_poly.coeffs[1..])
+    };
 
     // Calculate Right
     let right_raw: Vec<Fr> = (0..m2).map(|i| flat_R.raw[i] * alpha_pow[self.permutation.1[i]]).collect();
-    let right_poly = DensePolynomial {
-      coeffs: domain_m2.ifft(&right_raw),
-    };
+    let right_poly = DensePolynomial::from_coefficients_vec(domain_m2.ifft(&right_raw));
     let right_x = util::msm::<G1Projective>(&srs.X1A, &right_poly.coeffs);
     let right_Q_poly = flat_R.poly.mul(&d.poly).sub(&right_poly).divide_by_vanishing_poly(domain_m2).unwrap().0;
     let right_Q_x = util::msm::<G1Projective>(&srs.X1A, &right_Q_poly.coeffs);
-    let right_zero_div = util::msm::<G1Projective>(&srs.X1A, &right_poly.coeffs[1..]);
+    let right_zero_div = if right_poly.is_zero() {
+      G1Projective::zero()
+    } else {
+      util::msm::<G1Projective>(&srs.X1A, &right_poly.coeffs[1..])
+    };
 
     // Blinding
     let mut rng2 = StdRng::from_entropy();
@@ -127,6 +132,7 @@ impl BasicBlock for PermuteBasicBlock {
     outputs: &Vec<&ArrayD<DataEnc>>,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     let mut checks = Vec::new();
     let alpha = Fr::rand(rng);

--- a/src/basic_block/permute.rs
+++ b/src/basic_block/permute.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
 use crate::util::{self, calc_pow};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
@@ -41,9 +41,12 @@ impl BasicBlock for PermuteBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
-    _cache: &mut ProveVerifyCache,
+    cache: &mut ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>) {
-    let alpha = Fr::rand(rng);
+    let CacheValues::Fr(alpha) = cache.entry("permute_alpha".to_owned()).or_insert_with(|| CacheValues::Fr(Fr::rand(rng))) else {
+      panic!("Cache type error")
+    };
+    let alpha = alpha.clone();
     let (input, output) = (inputs[0], outputs[0]);
 
     // n rows, m columns in input
@@ -56,10 +59,26 @@ impl BasicBlock for PermuteBasicBlock {
     let domain_m2 = GeneralEvaluationDomain::<Fr>::new(m2).unwrap();
 
     let alpha_pow = calc_pow(alpha, n * m);
-    let b: Vec<_> = (0..m).map(|i| alpha_pow[i * n]).collect();
-    let b = Data::new(srs, &b);
-    let d: Vec<_> = (0..m2).map(|i| alpha_pow[self.permutation.1[i]]).collect();
-    let d = Data::new(srs, &d);
+
+    let CacheValues::Data(b) = cache.entry(format!("permute_b_msm_{m}_{n}")).or_insert_with(|| {
+      CacheValues::Data({
+        let b: Vec<_> = (0..m).map(|i| alpha_pow[i * n]).collect();
+        Data::new(srs, &b)
+      })
+    }) else {
+      panic!("Cache type error")
+    };
+    let b = b.clone();
+
+    let CacheValues::Data(d) = cache.entry(format!("permute_d_msm_{self:p}")).or_insert_with(|| {
+      CacheValues::Data({
+        let d: Vec<_> = (0..m2).map(|i| alpha_pow[self.permutation.1[i]]).collect();
+        Data::new(srs, &d)
+      })
+    }) else {
+      panic!("Cache type error")
+    };
+    let d = d.clone();
 
     let mut flat_L = vec![Fr::zero(); m];
     let mut flat_L_r = Fr::zero();
@@ -132,10 +151,13 @@ impl BasicBlock for PermuteBasicBlock {
     outputs: &Vec<&ArrayD<DataEnc>>,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     rng: &mut StdRng,
-    _cache: &mut ProveVerifyCache,
+    cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     let mut checks = Vec::new();
-    let alpha = Fr::rand(rng);
+    let CacheValues::Fr(alpha) = cache.entry("permute_alpha".to_owned()).or_insert_with(|| CacheValues::Fr(Fr::rand(rng))) else {
+      panic!("Cache type error")
+    };
+    let alpha = alpha.clone();
     let (input, output) = (inputs[0], outputs[0]);
 
     // n rows, m columns in input
@@ -156,10 +178,21 @@ impl BasicBlock for PermuteBasicBlock {
     let c: Vec<_> = (0..n2).map(|i| alpha_pow[self.permutation.0[i]]).collect();
     let d: Vec<_> = (0..m2).map(|i| alpha_pow[self.permutation.1[i]]).collect();
 
-    let b_coeff = domain_m.ifft(&b);
-    let b_g2: G2Affine = util::msm::<G2Projective>(&srs.X2A, &b_coeff).into();
-    let d_coeff = domain_m2.ifft(&d);
-    let d_g2: G2Affine = util::msm::<G2Projective>(&srs.X2A, &d_coeff).into();
+    let CacheValues::G2(b_g2) = cache
+      .entry(format!("permute_b_msm_g2_{m}_{n}"))
+      .or_insert_with(|| CacheValues::G2(util::msm::<G2Projective>(&srs.X2A, &domain_m.ifft(&b)).into()))
+    else {
+      panic!("Cache type error")
+    };
+    let b_g2 = b_g2.clone();
+
+    let CacheValues::G2(d_g2) = cache
+      .entry(format!("permute_d_msm_g2_{self:p}"))
+      .or_insert_with(|| CacheValues::G2(util::msm::<G2Projective>(&srs.X2A, &domain_m2.ifft(&d)).into()))
+    else {
+      panic!("Cache type error")
+    };
+    let d_g2 = d_g2.clone();
 
     // Calculate flat_L
     let temp: Vec<_> = (0..n).map(|i| input[i].g1).collect();

--- a/src/basic_block/sub.rs
+++ b/src/basic_block/sub.rs
@@ -1,4 +1,4 @@
-use super::{BasicBlock, Data, DataEnc, PairingCheck, SRS};
+use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ndarray::{arr1, azip, ArrayD, IxDyn};
 use rand::rngs::StdRng;
@@ -39,6 +39,7 @@ impl BasicBlock for SubBasicBlock {
     outputs: &Vec<&ArrayD<DataEnc>>,
     _proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     _rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     // Verify f(x)-g(x)=h(x)
     assert!(inputs[0][0].g1 - inputs[1][0].g1 == outputs[0][0].g1);

--- a/src/basic_block/sum.rs
+++ b/src/basic_block/sum.rs
@@ -1,10 +1,10 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, Data, DataEnc, PairingCheck, SRS};
+use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
 use crate::util;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
-use ark_poly::{univariate::DensePolynomial, EvaluationDomain, GeneralEvaluationDomain};
+use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain};
 use ark_std::{UniformRand, Zero};
 use ndarray::{arr1, ArrayD};
 use rand::{rngs::StdRng, SeedableRng};
@@ -25,6 +25,7 @@ impl BasicBlock for SumBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     _rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>) {
     let input = inputs[0];
     let l = input.len();
@@ -38,13 +39,15 @@ impl BasicBlock for SumBasicBlock {
       }
       input_r += input[i].r;
     }
-    let input_poly = DensePolynomial {
-      coeffs: domain_m.ifft(&input_raw),
-    }; // sum poly?
+    let input_poly = DensePolynomial::from_coefficients_vec(domain_m.ifft(&input_raw)); // sum poly?
 
     let mut rng2 = StdRng::from_entropy();
     let zero_div_r = Fr::rand(&mut rng2);
-    let zero_div = util::msm::<G1Projective>(&srs.X1A, &input_poly.coeffs[1..]) + srs.Y1P * zero_div_r;
+    let zero_div = if input_poly.is_zero() {
+      G1Projective::zero()
+    } else {
+      util::msm::<G1Projective>(&srs.X1A, &input_poly.coeffs[1..])
+    } + srs.Y1P * zero_div_r;
     let C = -srs.X1P[1] * zero_div_r + srs.X1P[0] * (input_r - outputs[0][0].r * Fr::from(m as u32).inverse().unwrap());
     return (vec![zero_div, C], vec![]);
   }
@@ -57,6 +60,7 @@ impl BasicBlock for SumBasicBlock {
     outputs: &Vec<&ArrayD<DataEnc>>,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>),
     _rng: &mut StdRng,
+    _cache: &mut ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     let m = inputs[0][0].len;
     let [zero_div, C] = proof.0[..] else { panic!("Wrong proof format") };

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -6,6 +6,7 @@ use ark_serialize::CanonicalSerialize;
 use ark_std::Zero;
 use ndarray::ArrayD;
 use rand::rngs::StdRng;
+use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct Node {
@@ -59,13 +60,14 @@ impl Graph {
     outputs: &Vec<&Vec<&ArrayD<Data>>>,
     rng: &mut StdRng,
   ) -> Vec<(Vec<G1Affine>, Vec<G2Affine>)> {
+    let mut cache = HashMap::new();
     self
       .nodes
       .iter()
       .enumerate()
       .map(|(i, n)| {
         let myInputs: Vec<&ArrayD<Data>> = n.inputs.iter().map(|(j, k)| if *j < 0 { inputs[*k] } else { &(outputs[*j as usize][*k]) }).collect();
-        let proof = self.basic_blocks[n.basic_block].prove(srs, setups[n.basic_block], models[n.basic_block], &myInputs, outputs[i], rng);
+        let proof = self.basic_blocks[n.basic_block].prove(srs, setups[n.basic_block], models[n.basic_block], &myInputs, outputs[i], rng, &mut cache);
         let proof: (Vec<G1Affine>, Vec<G2Affine>) = (
           proof.0.iter().map(|x| (*x).into()).collect(),
           proof.1.iter().map(|x| (*x).into()).collect(),
@@ -87,13 +89,14 @@ impl Graph {
     proofs: &Vec<(&Vec<G1Affine>, &Vec<G2Affine>)>,
     rng: &mut StdRng,
   ) {
+    let mut cache = HashMap::new();
     let pairings: Vec<Vec<PairingCheck>> = self
       .nodes
       .iter()
       .enumerate()
       .map(|(i, n)| {
         let myInputs = n.inputs.iter().map(|(j, k)| if *j < 0 { inputs[*k] } else { &(outputs[*j as usize][*k]) }).collect();
-        let pairings = self.basic_blocks[n.basic_block].verify(srs, models[n.basic_block], &myInputs, outputs[i], proofs[i], rng);
+        let pairings = self.basic_blocks[n.basic_block].verify(srs, models[n.basic_block], &myInputs, outputs[i], proofs[i], rng, &mut cache);
         let mut bytes = Vec::new();
         let temp: (Vec<G1Affine>, Vec<G2Affine>) = (proofs[i].0.clone(), proofs[i].1.clone());
         temp.serialize_uncompressed(&mut bytes).unwrap();

--- a/src/layer/matmul.rs
+++ b/src/layer/matmul.rs
@@ -1,7 +1,6 @@
 use crate::basic_block::*;
 use crate::graph::*;
 use crate::layer::Layer;
-use std::collections::HashMap;
 
 pub struct MatMulLayer;
 impl Layer for MatMulLayer {
@@ -10,7 +9,6 @@ impl Layer for MatMulLayer {
     let matmul = graph.addBB(Box::new(MatMulBasicBlock {}));
     let change_SF = graph.addBB(Box::new(ChangeSFBasicBlock { input_SF: 6, output_SF: 3 }));
     let change_SF_check = graph.addBB(Box::new(CQ2BasicBlock {
-      table_dict: HashMap::new(),
       setup: Some((Box::new(ChangeSFBasicBlock { input_SF: 6, output_SF: 3 }), -(1 << 5), 1 << 6)),
     }));
     let matmul_output = graph.addNode(matmul, vec![(-1, 0), (-2, 0)]);

--- a/src/layer/relu.rs
+++ b/src/layer/relu.rs
@@ -1,7 +1,6 @@
 use crate::basic_block::*;
 use crate::graph::*;
 use crate::layer::Layer;
-use std::collections::HashMap;
 
 pub struct ReLULayer;
 impl Layer for ReLULayer {
@@ -9,7 +8,6 @@ impl Layer for ReLULayer {
     let mut graph = Graph::new();
     let relu = graph.addBB(Box::new(ReLUBasicBlock { input_SF: 3, output_SF: 3 }));
     let relu_check = graph.addBB(Box::new(CQ2BasicBlock {
-      table_dict: HashMap::new(),
       setup: Some((Box::new(ReLUBasicBlock { input_SF: 3, output_SF: 3 }), -(1 << 5), 1 << 6)),
     }));
     let relu_output = graph.addNode(relu, vec![(-1, 0)]);

--- a/src/onnx.rs
+++ b/src/onnx.rs
@@ -51,7 +51,7 @@ pub fn load_file(filename: &str) -> (Graph, Vec<ArrayD<Fr>>) {
     local_graph.basic_blocks = vec![];
     for basic_block in temp.into_iter() {
       let name = format!("{basic_block:?}");
-      let idx = *basic_blocks_idx.entry(name).or_insert(graph.basic_blocks.len());
+      let idx = *basic_blocks_idx.entry(name).or_insert_with(|| graph.basic_blocks.len());
       local_block_idx.push(idx);
       if idx == graph.basic_blocks.len() {
         setups.push(basic_block.genModel());

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -24,7 +24,8 @@ fn testBasicBlock<BB: BasicBlock>(mut basic_block: BB, srs: &SRS, model: &ArrayD
   let outputs: Vec<ArrayD<Data>> = basic_block.encodeOutputs(srs, &model, &inputs, &outputs);
   let outputs: Vec<&ArrayD<Data>> = outputs.iter().map(|output| output).collect();
   let mut rng2 = rng.clone();
-  let proof = basic_block.prove(srs, setup, &model, &inputs, &outputs, &mut rng);
+  let mut cache = HashMap::new();
+  let proof = basic_block.prove(srs, setup, &model, &inputs, &outputs, &mut rng, &mut cache);
   let proof: (Vec<G1Affine>, Vec<G2Affine>) = (
     proof.0.iter().map(|y| (*y).into()).collect(),
     proof.1.iter().map(|y| (*y).into()).collect(),
@@ -35,7 +36,8 @@ fn testBasicBlock<BB: BasicBlock>(mut basic_block: BB, srs: &SRS, model: &ArrayD
   let inputs: Vec<&ArrayD<DataEnc>> = inputs.iter().map(|input| input).collect();
   let outputs: Vec<ArrayD<DataEnc>> = outputs.iter().map(|x| (*x).map(|y| DataEnc::new(srs, y))).collect();
   let outputs: Vec<&ArrayD<DataEnc>> = outputs.iter().map(|output| output).collect();
-  let pairings = basic_block.verify(srs, &model, &inputs, &outputs, proof, &mut rng2);
+  let mut cache = HashMap::new();
+  let pairings = basic_block.verify(srs, &model, &inputs, &outputs, proof, &mut rng2, &mut cache);
   let pairings = pairings.iter().map(|x| x).collect();
   let pairings = util::combine_pairing_checks(&pairings);
   assert_eq!(Bn254::multi_pairing(pairings.0.iter(), pairings.1.iter()), PairingOutput::zero());
@@ -66,24 +68,8 @@ fn testBasicBlocks() {
   testBasicBlock(AddBasicBlock {}, srs, &empty, &vec![&b, &a_1]);
   testBasicBlock(SubBasicBlock {}, srs, &empty, &vec![&a_1, &b]);
   testBasicBlock(SubBasicBlock {}, srs, &empty, &vec![&b, &a_1]);
-  testBasicBlock(
-    CQBasicBlock {
-      table_dict: HashMap::new(),
-      setup: None,
-    },
-    srs,
-    &a,
-    &vec![&a_n],
-  );
-  testBasicBlock(
-    CQ2BasicBlock {
-      table_dict: HashMap::new(),
-      setup: None,
-    },
-    srs,
-    &ab,
-    &vec![&a_n, &b_n],
-  );
+  testBasicBlock(CQBasicBlock { setup: None }, srs, &a, &vec![&a_n]);
+  testBasicBlock(CQ2BasicBlock { setup: None }, srs, &ab, &vec![&a_n, &b_n]);
 
   let l: usize = 1 << 3;
   let m: usize = 1 << 2;

--- a/src/util.rs
+++ b/src/util.rs
@@ -198,8 +198,8 @@ pub fn combine_pairing_checks(checks: &Vec<&PairingCheck>) -> (Vec<G1Affine>, Ve
   let mut curr = gamma;
   for check in checks.iter() {
     for pairing in check.iter() {
-      A.entry(pairing.0).or_insert(HashSet::new()).insert((pairing.1, curr));
-      B.entry(pairing.1).or_insert(HashSet::new()).insert((pairing.0, curr));
+      A.entry(pairing.0).or_insert_with(|| HashSet::new()).insert((pairing.1, curr));
+      B.entry(pairing.1).or_insert_with(|| HashSet::new()).insert((pairing.0, curr));
     }
     curr *= gamma;
   }


### PR DESCRIPTION
- Added a `ProveVerifyCache` object which allows for caching across proofs and across verifications.
- Moved the `table_dict` object in `CQBasicBlock`/`CQ2BasicBlock` to the `ProveVerifyCache`.
- Combined the alphas and betas in `MatMul`/`CQLin`/`Permute` to a single alpha/beta, and used caching to prevent the prover/verifier from recomputing MSMs.
- There was an error when adding / subtracting vectors of all zero, which as been fixed.

Closes #23.