### PR TITLE
Debug tool for verification process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ ndarray = { version = "0.15.6", features = ["serde", "rayon"] }
 tract-onnx = "0.21.2"
 sha3 = "0.10.8"
 bincode = "1.3.3"
+
+[features]
+debug = []

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -135,7 +135,9 @@ impl Graph {
     assert_eq!(Bn254::multi_pairing(pairings.0.iter(), pairings.1.iter()), PairingOutput::zero());
   }
 
-  pub fn verify_for_debug(
+  // This function should be only used for debugging purposes (it is very slow). 
+  // It verifies the proofs without combining pairing checks so that we can see which BasicBlock is failing.
+  pub fn verify_for_each_pairing(
     &self,
     srs: &SRS,
     models: &Vec<&ArrayD<DataEnc>>,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,4 +1,3 @@
-use crate::basic_block;
 use crate::basic_block::*;
 use crate::util;
 use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine, G2Projective};

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,3 +1,4 @@
+use crate::basic_block;
 use crate::basic_block::*;
 use crate::util;
 use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
@@ -135,7 +136,7 @@ impl Graph {
     assert_eq!(Bn254::multi_pairing(pairings.0.iter(), pairings.1.iter()), PairingOutput::zero());
   }
 
-  // This function should be only used for debugging purposes (it is very slow). 
+  // This function should be only used for debugging purposes (it is very slow).
   // It verifies the proofs without combining pairing checks so that we can see which BasicBlock is failing.
   pub fn verify_for_each_pairing(
     &self,
@@ -149,7 +150,17 @@ impl Graph {
     let mut cache = HashMap::new();
     self.nodes.iter().enumerate().for_each(|(i, n)| {
       println!("verifying (debug mode) {i} {:?}", self.basic_blocks[n.basic_block]);
-      let myInputs = n.inputs.iter().map(|(j, k)| if *j < 0 { inputs[*k] } else { &(outputs[*j as usize][*k]) }).collect();
+      let myInputs = n
+        .inputs
+        .iter()
+        .map(|(basicblock_idx, output_idx)| {
+          if *basicblock_idx < 0 {
+            inputs[*output_idx]
+          } else {
+            &(outputs[*basicblock_idx as usize][*output_idx])
+          }
+        })
+        .collect();
       let pairings = self.basic_blocks[n.basic_block].verify(srs, models[n.basic_block], &myInputs, outputs[i], proofs[i], rng, &mut cache);
       let mut bytes = Vec::new();
       let temp: (Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>) = (proofs[i].0.clone(), proofs[i].1.clone(), proofs[i].2.clone());

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,6 +1,7 @@
 use crate::basic_block::*;
 use crate::util;
 use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
+use ark_ec::bn::Bn;
 use ark_ec::pairing::{Pairing, PairingOutput};
 use ark_poly::univariate::DensePolynomial;
 use ark_serialize::CanonicalSerialize;
@@ -132,6 +133,35 @@ impl Graph {
       .collect();
     let pairings = util::combine_pairing_checks(&pairings.iter().flatten().collect());
     assert_eq!(Bn254::multi_pairing(pairings.0.iter(), pairings.1.iter()), PairingOutput::zero());
+  }
+
+  pub fn verify_for_debug(
+    &self,
+    srs: &SRS,
+    models: &Vec<&ArrayD<DataEnc>>,
+    inputs: &Vec<&ArrayD<DataEnc>>,
+    outputs: &Vec<&Vec<&ArrayD<DataEnc>>>,
+    proofs: &Vec<(&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>)>,
+    rng: &mut StdRng,
+  ) {
+    let mut cache = HashMap::new();
+    self.nodes.iter().enumerate().for_each(|(i, n)| {
+      println!("verifying (debug mode) {i} {:?}", self.basic_blocks[n.basic_block]);
+      let myInputs = n.inputs.iter().map(|(j, k)| if *j < 0 { inputs[*k] } else { &(outputs[*j as usize][*k]) }).collect();
+      let pairings = self.basic_blocks[n.basic_block].verify(srs, models[n.basic_block], &myInputs, outputs[i], proofs[i], rng, &mut cache);
+      let mut bytes = Vec::new();
+      let temp: (Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>) = (proofs[i].0.clone(), proofs[i].1.clone(), proofs[i].2.clone());
+      temp.serialize_uncompressed(&mut bytes).unwrap();
+      util::add_randomness(rng, bytes);
+      pairings.iter().for_each(|p| {
+        assert!(p
+          .iter()
+          .fold(PairingOutput::<Bn<ark_bn254::Config>>::zero(), |acc, x| {
+            acc + Bn254::pairing(x.0, x.1)
+          })
+          .is_zero());
+      });
+    });
   }
 
   pub fn new() -> Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,9 @@ fn verify(srs: &SRS, graph: &Graph) {
   let mut rng = StdRng::from_seed(buf);
 
   // Verify:
+  #[cfg(feature = "debug")]
+  graph.verify_for_each_pairing(srs, &modelsEnc, &inputsEnc, &outputsEnc, &proofs, &mut rng);
+  #[cfg(not(feature = "debug"))]
   graph.verify(srs, &modelsEnc, &inputsEnc, &outputsEnc, &proofs, &mut rng);
 }
 


### PR DESCRIPTION
In our current verification process, if an ONNX model passes all `running`, `setting`, `encoding`, and `proving` stages but fails during `verifying`, we have no way of knowing which BasicBlock went wrong. This small PR adds a tool, `Graph.verify_for_each_pairing`, as an alternative to `Graph.verify` to aid in debugging.