### PR TITLE
Copy constraint padding and blinding

### DIFF
--- a/src/basic_block/copy_constraint.rs
+++ b/src/basic_block/copy_constraint.rs
@@ -25,23 +25,30 @@ use std::{
   iter::{once, repeat},
 };
 
-fn flat_index(shape: &IxDyn, idx: &IxDyn, N: usize) -> usize {
-  assert!(shape.ndim() == idx.ndim());
+fn flat_index(shape: &IxDyn, idx: &Option<IxDyn>, N: usize) -> Option<(usize, usize)> {
+  assert!(*idx == None || shape.ndim() == idx.as_ref().unwrap().ndim());
   let mut product = vec![];
   // If inputs and outputs do not have the same last dimension, then the one
   // with the smaller dimension will have had their polynomials constructed from
   // a smaller evaluation domain. This indexing enables the smaller dimension's
   // roots of unity evaluation values to line up to the larger one.
-  let spacing = N / shape[shape.ndim() - 1];
-  for d in 0..shape.ndim() {
-    if d == 0 {
-      product.push(spacing);
-    } else {
-      product.push(product[d - 1] * shape[shape.ndim() - d]);
+  if let Some(j) = idx {
+    let spacing = N / shape[shape.ndim() - 1];
+    product.push(1);
+    for d in 1..(shape.ndim() - 1) {
+      product.push(product[d - 1] * shape[shape.ndim() - 1 - d]);
     }
+    product = product.into_iter().rev().collect();
+    let left_idx = if shape.ndim() == 1 {
+      0
+    } else {
+      product.iter().enumerate().fold(0, |sum, (i, x)| *x * j[i] + sum)
+    };
+    let right_idx = j[shape.ndim() - 1] * spacing;
+    Some((left_idx, right_idx))
+  } else {
+    None
   }
-  product = product.into_iter().rev().collect();
-  idx.as_array_view().iter().enumerate().fold(0, |sum, (i, x)| *x * product[i] + sum)
 }
 
 // Construct S_sigma_j polynomial evals over N-th roots of unity
@@ -50,11 +57,18 @@ fn flat_index(shape: &IxDyn, idx: &IxDyn, N: usize) -> usize {
 // that should be the same over inputs and outputs.
 // If is_input, idxs is [(flat_idx of the input index, 0)]. Otherwise,
 // idxs is [(flat_idx of the output, flat_idx of the permuted input idx)]
-fn construct_ssig(idxs: &[(usize, usize)], N: usize, last_dim: usize, partitions: &HashMap<usize, Vec<usize>>, is_input: bool) -> Vec<Fr> {
+fn construct_ssig(
+  idxs: &[((usize, usize), Option<(usize, usize)>)],
+  N: usize,
+  last_dim: usize,
+  partitions: &HashMap<Option<(usize, usize)>, Vec<(usize, usize)>>,
+  is_input: bool,
+) -> Vec<Fr> {
+  let domain = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
   idxs
     .iter()
     .flat_map(|(idx, perm_idx)| {
-      let inp_idx = if is_input { idx } else { perm_idx };
+      let inp_idx = if is_input { Some(*idx) } else { *perm_idx };
       let sigma = {
         let partition = partitions.get(&inp_idx).ok_or_else(|| format!("Key {:?} not found in the partition", inp_idx)).unwrap();
         if let Some(pos) = partition.iter().position(|x| *x == *idx) {
@@ -64,9 +78,10 @@ fn construct_ssig(idxs: &[(usize, usize)], N: usize, last_dim: usize, partitions
         }
       };
       let sigma = sigma.unwrap();
-      let mut ssig = vec![Fr::from(sigma as i32)];
+      let mut ssig = vec![Fr::from(sigma.0 as i32 + 1) * domain.element(sigma.1)];
       // Permute each filler element to itself
-      let mut padding: Vec<_> = (1..N / last_dim).map(|i| Fr::from((i + *idx) as i32)).collect();
+      let spacing = N / last_dim;
+      let mut padding: Vec<_> = (1..spacing).map(|i| Fr::from(idx.0 as i32 + 1) * domain.element(idx.1 + i)).collect();
       ssig.append(&mut padding);
       ssig
     })
@@ -76,21 +91,26 @@ fn construct_ssig(idxs: &[(usize, usize)], N: usize, last_dim: usize, partitions
 // Permutation has the same shape as the output, and each index stores the index of the input array it equals to
 #[derive(Debug)]
 pub struct CopyConstraintBasicBlock {
-  pub permutation: ArrayD<IxDyn>,
+  pub permutation: ArrayD<Option<IxDyn>>,
   pub input_dim: IxDyn,
-  pub output_dim: IxDyn,
 }
 
 impl BasicBlock for CopyConstraintBasicBlock {
   fn run(&self, _model: &ArrayD<Fr>, inputs: &Vec<&ArrayD<Fr>>) -> Vec<ArrayD<Fr>> {
-    assert!(inputs.len() == 1);
-    assert!(Dim(self.permutation.shape()) == self.output_dim);
-    vec![ArrayD::from_shape_fn(self.permutation.shape(), |i| inputs[0][&self.permutation[i]])]
+    assert!(inputs.len() == 1 && inputs[0].dim() == self.input_dim);
+    vec![ArrayD::from_shape_fn(self.permutation.shape(), |i| {
+      if let Some(idx) = &self.permutation[i] {
+        inputs[0][idx]
+      } else {
+        Fr::zero()
+      }
+    })]
   }
 
   fn setup(&self, srs: &SRS, _model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
+    let output_dim = self.permutation.dim();
     let last_inp_dim = self.input_dim[self.input_dim.ndim() - 1];
-    let last_outp_dim = self.output_dim[self.output_dim.ndim() - 1];
+    let last_outp_dim = output_dim[output_dim.ndim() - 1];
     let N = max(last_inp_dim, last_outp_dim);
     let domain = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
     let mut L_i_x_1 = srs.X1P[..N].to_vec();
@@ -102,34 +122,42 @@ impl BasicBlock for CopyConstraintBasicBlock {
     // Offset output indices by the size of the input shape
     let mut input_dim = self.input_dim.as_array_view().to_vec().clone();
     input_dim[self.input_dim.ndim() - 1] = N;
-    let offset: usize = input_dim.iter().product();
-    let flat_outp_idxs = self.permutation.indexed_iter().map(|(i, _)| flat_index(&self.output_dim, &i, N) + offset).collect();
-    let flat_outp_idxs = ArrayD::from_shape_vec(self.output_dim.clone(), flat_outp_idxs).unwrap();
+    let offset: usize = input_dim.iter().take(self.input_dim.ndim() - 1).product();
+    let flat_outp_idxs = self
+      .permutation
+      .indexed_iter()
+      .map(|(i, _)| {
+        let idx = flat_index(&output_dim, &Some(i), N).unwrap();
+        (idx.0 + offset, idx.1)
+      })
+      .collect();
+    let flat_outp_idxs = ArrayD::from_shape_vec(output_dim.clone(), flat_outp_idxs).unwrap();
     // Indices of the input which are in each position of the permutation
     let flat_perm_idxs = self.permutation.map(|i| flat_index(&self.input_dim, i, N));
 
     // Create partitions
     let mut partitions = HashMap::new();
     for i in indices(self.input_dim.clone()).into_iter() {
-      let idx = flat_index(&self.input_dim, &i, N);
-      partitions.entry(idx).or_insert_with(|| Vec::from([idx]));
+      let idx = flat_index(&self.input_dim, &Some(i), N);
+      partitions.entry(idx).or_insert_with(|| Vec::from([idx.unwrap()]));
     }
-    for (i, _) in flat_outp_idxs.indexed_iter() {
-      let out_idx = flat_outp_idxs[&i];
-      let perm_idx = flat_perm_idxs[&i];
-      partitions.entry(perm_idx).or_insert_with(|| Vec::from([perm_idx])).push(out_idx);
+    let mut pad = vec![];
+    for (i, out_idx) in flat_outp_idxs.indexed_iter() {
+      if let Some(perm_idx) = flat_perm_idxs[&i] {
+        partitions.entry(Some(perm_idx)).or_insert_with(|| Vec::from([perm_idx])).push(*out_idx);
+      } else {
+        pad.push(*out_idx);
+      }
     }
-
-    // Calculate S_ID
-    let sid: Vec<_> = (0..N).map(|x| Fr::from(x as i32)).collect();
-    let sid_poly = DensePolynomial::from_coefficients_vec(domain.ifft(&sid));
-    let sid_x = util::msm::<G1Projective>(&srs.X1A, &sid_poly.coeffs);
+    if pad.len() > 0 {
+      partitions.insert(None, pad);
+    }
 
     // Calculate S_sigma_js
-    let inp_idxs: ArrayD<usize> = ArrayD::from_shape_fn(self.input_dim.clone(), |i| flat_index(&self.input_dim, &i, N));
-    let mut inp_arr = ArrayD::from_elem(self.input_dim.clone(), (0, 0));
+    let inp_idxs: ArrayD<(usize, usize)> = ArrayD::from_shape_fn(self.input_dim.clone(), |i| flat_index(&self.input_dim, &Some(i), N).unwrap());
+    let mut inp_arr = ArrayD::from_elem(self.input_dim.clone(), ((0, 0), None));
     Zip::from(&mut inp_arr).and(&inp_idxs).for_each(|r, &a| {
-      *r = (a, 0 as usize);
+      *r = (a, None);
     });
     let mut ssig: Vec<Vec<Fr>> = inp_arr
       .map_axis(Axis(self.input_dim.ndim() - 1), |x| {
@@ -138,27 +166,35 @@ impl BasicBlock for CopyConstraintBasicBlock {
       .into_iter()
       .collect();
 
-    let mut outp_arr = ArrayD::from_elem(self.output_dim.clone(), (0, 0));
-    let outp_idxs: ArrayD<usize> = ArrayD::from_shape_fn(self.output_dim.clone(), |i| flat_index(&self.output_dim, &i, N) + offset);
-    Zip::from(&mut outp_arr).and(&outp_idxs).and(&self.permutation).for_each(|r, &a, b| {
-      *r = (a, flat_index(&self.input_dim, &b, N));
+    let mut outp_arr = ArrayD::from_elem(output_dim.clone(), ((0, 0), None));
+    Zip::from(&mut outp_arr).and(&flat_outp_idxs).and(&self.permutation).for_each(|r, &a, b| {
+      *r = (a, flat_index(&self.input_dim, b, N));
     });
     ssig.append(
       &mut outp_arr
-        .map_axis(Axis(self.output_dim.ndim() - 1), |x| {
+        .map_axis(Axis(output_dim.ndim() - 1), |x| {
           construct_ssig(x.as_slice().unwrap(), N, last_outp_dim, &partitions, false)
         })
         .into_iter()
         .collect(),
     );
-    let mut ssig_polys: Vec<_> = ssig.iter().map(|x| DensePolynomial::from_coefficients_vec(domain.ifft(x))).collect();
+    let ssig_polys: Vec<_> = ssig.iter().map(|x| DensePolynomial::from_coefficients_vec(domain.ifft(x))).collect();
 
-    let mut proof_0 = vec![L_i_x_1[0], sid_x];
-    proof_0.append(&mut ssig_polys.iter().map(|x| util::msm::<G1Projective>(&srs.X1A, &x.coeffs)).collect());
-    let mut proof_2 = vec![sid_poly];
-    proof_2.append(&mut ssig_polys);
+    // Get Lagrange basis from first None element
+    let mut none_idx = 0;
+    for i in indices(self.permutation.shape()) {
+      let idx = i.clone();
+      if self.permutation[i].is_none() {
+        none_idx = N / last_outp_dim * idx[self.permutation.shape().len() - 1];
+        break;
+      }
+    }
 
-    return (proof_0, vec![L_i_x_2[0]], proof_2);
+    let mut ssig_xs: Vec<_> = ssig_polys.iter().map(|x| util::msm::<G1Projective>(&srs.X1A, &x.coeffs)).collect();
+    let mut proof_0 = vec![L_i_x_1[0], L_i_x_1[none_idx]];
+    proof_0.append(&mut ssig_xs);
+
+    return (proof_0, vec![L_i_x_2[0], L_i_x_2[none_idx]], ssig_polys);
   }
 
   fn prove(
@@ -173,10 +209,10 @@ impl BasicBlock for CopyConstraintBasicBlock {
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let input = inputs[0];
     let output = outputs[0];
-    let input_len = input.first().unwrap().raw.len();
-    let output_len = output.first().unwrap().raw.len();
+    let input_deg = input.first().unwrap().raw.len();
+    let output_deg = output.first().unwrap().raw.len();
 
-    let N = max(input_len, output_len);
+    let N = max(input_deg, output_deg);
     let domain = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
 
     // Round 1: quotients
@@ -184,35 +220,51 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let gamma = Fr::rand(rng);
 
     // Calculate fjs
-    let fj_polys: Vec<_> = inputs[0].iter().chain(outputs[0].iter()).map(|x| &x.poly).collect();
-    let sid_poly = &setup.2[0];
-    let ssig_polys = &setup.2[1..];
-    let beta_poly = DensePolynomial::from_coefficients_vec(vec![beta]);
-    let gamma_poly = DensePolynomial::from_coefficients_vec(vec![gamma]);
-
-    let fj1_polys: Vec<_> = fj_polys
+    let m = inputs[0].len() + outputs[0].len();
+    let mut rng2 = StdRng::from_entropy();
+    let fj_blind: Vec<_> = (0..m).map(|_| Fr::rand(&mut rng2)).collect();
+    let fj_blind1: Vec<_> = (0..m).map(|_| Fr::rand(&mut rng2)).collect();
+    let fj_blinds: Vec<_> = (0..m).map(|i| DensePolynomial::from_coefficients_vec(vec![fj_blind[i], fj_blind1[i]])).collect();
+    let fj_polys: Vec<_> = inputs[0]
       .iter()
+      .chain(outputs[0].iter())
       .enumerate()
-      .map(|(i, x)| {
-        let offset = DensePolynomial::from_coefficients_vec(vec![beta * Fr::from((i * N) as i32)]);
-        &sid_poly.mul(&beta_poly) + *x + offset + gamma_poly.clone()
-      })
+      .map(|(i, x)| &x.poly + &fj_blinds[i].mul(&DensePolynomial::from(domain.vanishing_polynomial())))
+      .collect();
+    let mut fj_xs: Vec<_> = inputs[0]
+      .iter()
+      .chain(outputs[0].iter())
+      .enumerate()
+      .map(|(i, x)| (srs.X1P[N + 1] - srs.X1P[1]) * fj_blind1[i] + (srs.X1P[N] - srs.X1P[0]) * fj_blind[i] + x.g1)
       .collect();
 
-    // Calculate gjs
-    let gj1_polys: Vec<_> = fj_polys.iter().enumerate().map(|(i, x)| &ssig_polys[i].mul(&beta_poly) + *x + gamma_poly.clone()).collect();
-
-    let f1_poly = fj1_polys.iter().fold(DensePolynomial::from_coefficients_vec(vec![Fr::one()]), |acc, x| acc.mul(x));
-    let g1_poly = gj1_polys.iter().fold(DensePolynomial::from_coefficients_vec(vec![Fr::one()]), |acc, x| acc.mul(x));
+    let ssig_polys = &setup.2[..];
+    let beta_poly = DensePolynomial::from_coefficients_vec(vec![beta]);
+    let gamma_poly = DensePolynomial::from_coefficients_vec(vec![gamma]);
 
     // Calculate Z
     let mut Z = vec![Fr::zero(); N];
     Z[0] = Fr::one();
-    for i in 1..N {
-      let o = domain.element(i - 1);
-      Z[i] = Z[i - 1] * f1_poly.evaluate(&o) * g1_poly.evaluate(&o).inverse().unwrap();
+    for j in 0..(N - 1) {
+      let o = domain.element(j);
+      let num: Fr = inputs[0]
+        .iter()
+        .chain(outputs[0].iter())
+        .enumerate()
+        .map(|(i, x)| beta * Fr::from((i + 1) as i32) * o + x.poly.evaluate(&o) + gamma)
+        .product();
+      let denom: Fr = inputs[0]
+        .iter()
+        .chain(outputs[0].iter())
+        .enumerate()
+        .map(|(i, x)| beta * ssig_polys[i].evaluate(&o) + x.poly.evaluate(&o) + gamma)
+        .product();
+      Z[j + 1] = Z[j] * num * denom.inverse().unwrap();
     }
     let Z_poly = DensePolynomial::from_coefficients_vec(domain.ifft(&Z));
+    let Z_blind: Vec<_> = (0..3).map(|_| Fr::rand(&mut rng2)).collect();
+    let Z_blind_poly = DensePolynomial::from_coefficients_vec(vec![Z_blind[0], Z_blind[1], Z_blind[2]]);
+    let Z_poly = &Z_poly + &Z_blind_poly.mul(&DensePolynomial::from(domain.vanishing_polynomial()));
     let Z_x = util::msm::<G1Projective>(&srs.X1A, &Z_poly.coeffs);
 
     // Calculate quotient for L0(X)(Z(X)-1) = 0
@@ -226,28 +278,70 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let L0Z_Q = L0Z_poly.divide_by_vanishing_poly(domain).unwrap();
     let L0Z_Q_x = util::msm::<G1Projective>(&srs.X1A, &L0Z_Q.0.coeffs);
 
+    // Calculate quotient for zero-pad check
+    let outp_ndim = self.permutation.ndim();
+    let mut has_none = false;
+    let mut none_idx = IxDyn::zeros(outp_ndim); // position in f_polys
+
+    let mut Lnone_f_Q_x = G1Projective::zero();
+    for i in indices(self.permutation.shape()) {
+      let idx = i.clone();
+      if self.permutation[i].is_none() {
+        has_none = true;
+        none_idx = idx.clone();
+        break;
+      }
+    }
+    if has_none {
+      let idx = flat_index(&self.permutation.dim(), &Some(none_idx.clone()), N).unwrap();
+      let mut Lnone_evals = vec![Fr::zero(); N];
+      Lnone_evals[idx.1] = Fr::one();
+      let Lnone_poly = DensePolynomial {
+        coeffs: domain.ifft(&Lnone_evals),
+      };
+      let fj_none_poly = &fj_polys[idx.0 + input.len()];
+      let Lnone_f_poly = &Lnone_poly.mul(fj_none_poly);
+
+      let Lnone_f_Q = Lnone_f_poly.divide_by_vanishing_poly(domain).unwrap();
+      Lnone_f_Q_x = util::msm::<G1Projective>(&srs.X1A, &Lnone_f_Q.0.coeffs).into();
+    }
+
     // Calculate quotient for Z(x)f'(x) = Z(gx)g'(x)
     let Zg_poly = DensePolynomial {
       coeffs: Z_poly.coeffs.iter().enumerate().map(|(i, x)| x * &domain.element(i)).collect(),
     };
-    let lhs = f1_poly.mul(&Z_poly);
-    let rhs = g1_poly.mul(&Zg_poly);
-    let Q = lhs.sub(&rhs).divide_by_vanishing_poly(domain).unwrap();
-    let Q_x = util::msm::<G1Projective>(&srs.X1A, &Q.0.coeffs);
+    // These have the extra beta * X + gamma etc. terms that appear in Z, t, r
+    let ft_polys: Vec<_> = fj_polys
+      .iter()
+      .enumerate()
+      .map(|(i, x)| {
+        let id_poly = DensePolynomial::from_coefficients_vec(vec![Fr::zero(), beta * Fr::from((i + 1) as i32)]);
+        x + &id_poly + gamma_poly.clone()
+      })
+      .collect();
+    let f1_poly = ft_polys.iter().fold(DensePolynomial::from_coefficients_vec(vec![Fr::one()]), |acc, x| acc.mul(x));
+    let gt_polys: Vec<_> = fj_polys.iter().enumerate().map(|(i, x)| &ssig_polys[i].mul(&beta_poly) + x + gamma_poly.clone()).collect();
+    let g1_poly = gt_polys.iter().fold(DensePolynomial::from_coefficients_vec(vec![Fr::one()]), |acc, x| acc.mul(x));
+    let t_poly = f1_poly.mul(&Z_poly).sub(&g1_poly.mul(&Zg_poly));
+
+    let t_poly = t_poly.divide_by_vanishing_poly(domain).unwrap().0;
+    let t_x = util::msm::<G1Projective>(&srs.X1A, &t_poly.coeffs);
 
     // Round 2: openings
     // Fiat-Shamir
     let mut bytes = Vec::new();
     let mut rng2 = StdRng::from_entropy();
-    let mut r: Vec<_> = (0..3).map(|_| Fr::rand(&mut rng2)).collect();
-    let proof = vec![Z_x, L0Z_Q_x, Q_x];
+    let mut r: Vec<_> = (0..4).map(|_| Fr::rand(&mut rng2)).collect();
+    let proof = vec![Z_x, L0Z_Q_x, t_x, Lnone_f_Q_x];
     let mut proof: Vec<_> = proof.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r[i]).collect();
     proof.serialize_uncompressed(&mut bytes).unwrap();
     util::add_randomness(rng, bytes);
 
+    let a = Fr::rand(rng);
+    let mut fj_as: Vec<_> = fj_polys.iter().map(|p| p.evaluate(&a)).collect();
+
     // Calculate opening argument for Z over omega * a
     let omega = domain.group_gen();
-    let a = Fr::rand(rng);
     let Z_ga = Z_poly.evaluate(&(omega * a));
     let Z_ga_poly = DensePolynomial { coeffs: vec![Z_ga] };
     let Z_V = DensePolynomial {
@@ -258,29 +352,41 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let Z_Q_x = util::msm::<G1Projective>(&srs.X1A, &Z_Q.coeffs);
 
     // Calculate opening quotient for Z(x)f'(x) = Z(gx)g'(x) check
-    let fj_poly_iter = fj_polys.iter().map(|x| *x);
-    let mut q1_evals: Vec<Fr> = once(sid_poly).chain(ssig_polys.iter()).chain(fj_poly_iter.clone()).map(|p| p.evaluate(&a)).collect();
-
-    let f1_a = f1_poly.evaluate(&a);
-    let ssig_as = &q1_evals[1..ssig_polys.len() + 1];
-    let fj_as = &q1_evals[ssig_polys.len() + 1..];
-    let gj1_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| ssig_as[i] * beta + *x + gamma).collect();
+    let mut ssig_as: Vec<_> = ssig_polys.iter().map(|p| p.evaluate(&a)).collect();
+    let ft_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| beta * Fr::from((i + 1) as i32) * a + *x + gamma).collect();
+    let gt_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| ssig_as[i] * beta + *x + gamma).collect();
     let a_pows = calc_pow(a, N);
-    let g1_a: Fr = gj1_as[..gj1_as.len() - 1].iter().product();
-    let f1_a_poly = DensePolynomial::from_coefficients_vec(vec![f1_a]);
-    let lhs = Z_poly.mul(&f1_a_poly);
-    let rhs_mul = DensePolynomial::from_coefficients_vec(vec![g1_a * Z_ga]);
+    let gt_a: Fr = gt_as[..gt_as.len() - 1].iter().product();
+    let ft_a = ft_as.iter().product();
+    let ft_a_poly = DensePolynomial::from_coefficients_vec(vec![ft_a]);
+    let lhs = Z_poly.mul(&ft_a_poly);
+    // assert!(util::msm::<G1Projective>(&srs.X1A, &lhs.coeffs) == Z_x * ft_a);
+    let rhs_mul = DensePolynomial::from_coefficients_vec(vec![gt_a * Z_ga]);
     let rhs_add = DensePolynomial::from_coefficients_vec(vec![gamma + fj_as[fj_as.len() - 1]]);
     let rhs = (&ssig_polys[ssig_polys.len() - 1].mul(&beta_poly) + &rhs_add).mul(&rhs_mul);
-    let v = DensePolynomial::from_coefficients_vec(vec![a_pows[N - 1] - Fr::one()]).mul(&Q.0);
+    // let ssig_xs = &setup.0[2..];
+    // assert!(
+    //   util::msm::<G1Projective>(&srs.X1A, &rhs.coeffs)
+    //     == (ssig_xs[ssig_xs.len() - 1] * beta + srs.X1A[0] * (fj_as[fj_as.len() - 1] + gamma)) * gt_a * Z_ga
+    // );
+    // assert!(DensePolynomial::from(domain.vanishing_polynomial()).evaluate(&a) == a_pows[N - 1] - Fr::one());
+    let v = DensePolynomial::from_coefficients_vec(vec![a_pows[N - 1] - Fr::one()]).mul(&t_poly);
+    // assert!(util::msm::<G1Projective>(&srs.X1A, &v.coeffs) == t_x * (a_pows[N - 1] - Fr::one()));
     let q1_V = DensePolynomial { coeffs: vec![-a, Fr::one()] };
-    let r_Q = &(&(&lhs - &rhs) - &v) / &q1_V;
+    let r_poly = &(&lhs - &rhs) - &v;
+    let r_Q = &r_poly / &q1_V;
     let r_Q_x = util::msm::<G1Projective>(&srs.X1A, &r_Q.coeffs);
+    // assert!(r_Q.mul(&q1_V) == (&(&lhs - &rhs) - &v));
+    // assert!(
+    //   Bn254::pairing(util::msm::<G1Projective>(&srs.X1A, &(&(&lhs - &rhs) - &v).coeffs), srs.X2P[0])
+    //     == Bn254::pairing(r_Q_x, srs.X2P[1] - srs.X2P[0] * a)
+    // );
 
-    // Calculate opening argument for fjs, sid, ssigs over a
+    // Calculate opening argument for fjs, ssigs over a
     let b = Fr::rand(rng);
-    let bs = calc_pow(b, ssig_polys.len() + fj_polys.len());
-    let q1_poly: DensePolynomial<Fr> = ssig_polys.iter().chain(fj_poly_iter).enumerate().fold(sid_poly.clone(), |acc, (i, p)| acc + p.mul(bs[i]));
+    let bs = calc_pow(b, ssig_polys.len() + ft_polys.len());
+    let q1_poly: DensePolynomial<Fr> =
+      ssig_polys.iter().chain(fj_polys.iter()).enumerate().fold(DensePolynomial::zero(), |acc, (i, p)| acc + p.mul(bs[i]));
     let q1_a = q1_poly.evaluate(&a);
     let q1_a_poly = DensePolynomial { coeffs: vec![q1_a] };
     let temp = q1_poly.sub(&q1_a_poly);
@@ -288,24 +394,26 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let q1_Q_x = util::msm::<G1Projective>(&srs.X1A, &q1_Q.coeffs);
 
     // Blinding
-    let mut rng2 = StdRng::from_entropy();
     let mut r1: Vec<_> = (0..3).map(|_| Fr::rand(&mut rng2)).collect();
     proof.append(&mut vec![q1_Q_x, Z_Q_x, r_Q_x].iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r1[i]).collect());
     r.append(&mut r1);
-    let opening_r: Fr = inputs[0].iter().chain(outputs[0].iter()).enumerate().map(|(i, x)| x.r * bs[ssig_polys.len() + i]).sum();
     let mut C: Vec<G1Projective> = vec![
       setup.0[0] * r[0] - (srs.X1P[N] - srs.X1P[0]) * r[1],
-      srs.X1P[0] * f1_a * r[0] - srs.X1P[0] * (a_pows[N - 1] - Fr::one()) * r[2] - (srs.X1P[1] - (srs.X1P[0] * a)) * r[5],
-      srs.X1P[0] * opening_r - (srs.X1P[1] - (srs.X1P[0] * a)) * r[3],
-      srs.X1P[0] * r[0] - (srs.X1P[1] - (srs.X1P[0] * a * omega)) * r[4],
+      -(srs.X1P[N] - srs.X1P[0]) * r[3],
+      srs.X1P[0] * ft_a * r[0] - srs.X1P[0] * (a_pows[N - 1] - Fr::one()) * r[2] - (srs.X1P[1] - (srs.X1P[0] * a)) * r[6],
+      -(srs.X1P[1] - (srs.X1P[0] * a)) * r[4],
+      srs.X1P[0] * r[0] - (srs.X1P[1] - (srs.X1P[0] * a * omega)) * r[5],
     ];
     proof.append(&mut C);
-    let mut s_1s = setup.0[1..].iter().map(|x| Into::<G1Projective>::into(*x)).collect();
-    proof.append(&mut s_1s);
+
+    let mut ssig_xs = setup.0[2..].iter().map(|x| Into::<G1Projective>::into(*x)).collect();
+    proof.append(&mut ssig_xs);
+    proof.append(&mut fj_xs);
 
     let mut evals = vec![Z_ga];
-    evals.append(&mut q1_evals);
-    return (proof, vec![setup.1[0].into()], evals);
+    evals.append(&mut ssig_as);
+    evals.append(&mut fj_as);
+    return (proof, vec![setup.1[0].into(), setup.1[1].into()], evals);
   }
 
   fn verify(
@@ -322,18 +430,22 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let N = max(inputs[0].first().unwrap().len, outputs[0].first().unwrap().len);
     let domain = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
     let omega = domain.group_gen();
+    let input = inputs[0];
 
-    let [Z_x, L0Z_Q_x, Q_x, q1_Q_x, Z_Q_x, r_Q_x, C1, C2, C3, C4, sid_x] = proof.0[..11] else {
+    let [Z_x, L0Z_Q_x, t_x, Lnone_f_Q_x, q1_Q_x, Z_Q_x, r_Q_x, C1, C2, C3, C4, C5] = proof.0[..12] else {
       panic!("Wrong proof format")
     };
-    let ssig_xs = &proof.0[11..];
-    let L0 = proof.1[0];
+
+    let m = inputs[0].len() + outputs[0].len();
+    let ssig_xs = &proof.0[12..m + 12];
+    let fj_xs = &proof.0[m + 12..];
+
+    let [L0, Lnone] = proof.1[..] else { panic!("Wrong proof format") };
     let Z_ga = proof.2[0];
 
     let q1_evals = &proof.2[1..];
-    let sid_a = q1_evals[0];
-    let ssig_as = &q1_evals[1..ssig_xs.len() + 1];
-    let fj_as = &q1_evals[ssig_xs.len() + 1..];
+    let ssig_as = &q1_evals[..m];
+    let fj_as = &q1_evals[m..];
 
     // Round 1 randomness
     let beta = Fr::rand(rng);
@@ -341,7 +453,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
 
     // Round 2 randomness
     let mut bytes = Vec::new();
-    vec![Z_x, L0Z_Q_x, Q_x].serialize_uncompressed(&mut bytes).unwrap();
+    vec![Z_x, L0Z_Q_x, t_x, Lnone_f_Q_x].serialize_uncompressed(&mut bytes).unwrap();
     util::add_randomness(rng, bytes);
     let a = Fr::rand(rng);
     let b = Fr::rand(rng);
@@ -353,50 +465,59 @@ impl BasicBlock for CopyConstraintBasicBlock {
       (-C1, srs.Y2A),
     ]);
 
+    // Check Lnone(x)f(x) = V(x)Q(x)
+    for i in indices(self.permutation.shape()) {
+      if self.permutation[i.clone()].is_none() {
+        let idx = flat_index(&self.permutation.dim(), &Some(i), N).unwrap();
+        let flat_none_f_idx = (idx.0 + input.len(), idx.1);
+        checks.push(vec![
+          (fj_xs[flat_none_f_idx.0], Lnone),
+          (-Lnone_f_Q_x, (srs.X2A[N] - srs.X2A[0]).into()),
+          (-C2, srs.Y2A),
+        ]);
+        break;
+      }
+    }
+
     // Check Z(x)f'(x) = Z(gx)g'(x)
-    let fj1_as: Vec<_> = fj_as
-      .iter()
-      .enumerate()
-      .map(|(i, x)| {
-        let offset = beta * Fr::from((i * N) as i32);
-        sid_a * beta + *x + offset + gamma
-      })
-      .collect();
+    let ft_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| beta * Fr::from((i + 1) as i32) * a + *x + gamma).collect();
+    let gt_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| ssig_as[i] * beta + *x + gamma).collect();
 
-    let gj1_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| ssig_as[i] * beta + *x + gamma).collect();
-
-    let f1_a: Fr = fj1_as.iter().product();
-    let g1_a: Fr = gj1_as[..gj1_as.len() - 1].iter().product();
+    let ft_a: Fr = ft_as.iter().product();
+    let gt_a: Fr = gt_as[..gt_as.len() - 1].iter().product();
     let a_pows = calc_pow(a, N);
     let V_x: G2Affine = (srs.X2P[1] - srs.X2P[0] * a).into();
     checks.push(vec![
-      (Z_x, (srs.X2A[0] * f1_a).into()),
-      (-ssig_xs[ssig_xs.len() - 1], (srs.X2A[0] * g1_a * beta * Z_ga).into()),
-      ((-srs.X1A[0] * g1_a * (fj_as[fj_as.len() - 1] + gamma) * Z_ga).into(), srs.X2A[0]),
-      ((-Q_x * (a_pows[N - 1] - Fr::one())).into(), srs.X2A[0]),
+      (Z_x, (srs.X2A[0] * ft_a).into()),
+      (
+        (-(ssig_xs[ssig_xs.len() - 1] * beta + srs.X1A[0] * (fj_as[fj_as.len() - 1] + gamma)) * gt_a * Z_ga).into(),
+        srs.X2A[0],
+      ),
+      ((-t_x * (a_pows[N - 1] - Fr::one())).into(), srs.X2A[0]),
       (-r_Q_x, V_x),
-      (-C2, srs.Y2A),
+      (-C3, srs.Y2A),
     ]);
 
     // Check opening commitments over a
-    let fj_xs: Vec<_> = inputs[0].iter().chain(outputs[0].iter()).map(|x| &x.g1).collect();
     let bs = calc_pow(b, ssig_xs.len() + fj_xs.len());
-    let fj_xs_iter = fj_xs.iter().map(|x| *x);
     let q1_x: G1Projective = ssig_xs
       .iter()
-      .chain(fj_xs_iter.clone())
+      .chain(fj_xs.iter())
       .enumerate()
-      .fold(sid_x.into(), |acc, (i, x)| acc + Into::<G1Projective>::into(*x) * bs[i]);
+      .fold(G1Projective::zero(), |acc, (i, x)| acc + Into::<G1Projective>::into(*x) * bs[i]);
 
-    let q1_a: Fr = q1_evals[1..].iter().enumerate().fold(sid_a, |acc, (i, x)| acc + *x * bs[i]);
+    let q1_a: Fr = q1_evals.iter().enumerate().fold(Fr::zero(), |acc, (i, x)| acc + *x * bs[i]);
 
-    let r_x: G1Affine = (srs.X1P[0] * q1_a).into();
-    checks.push(vec![((q1_x - r_x).into(), srs.X2A[0]), (-q1_Q_x, V_x.into()), (-C3, srs.Y2A)]);
+    checks.push(vec![
+      ((q1_x - srs.X1P[0] * q1_a).into(), srs.X2A[0]),
+      (-q1_Q_x, V_x.into()),
+      (-C4, srs.Y2A),
+    ]);
 
     // Check Z opening commitment
     let Z_ga_x: G1Affine = (srs.X1P[0] * Z_ga).into();
     let V_x: G2Affine = (srs.X2P[1] - srs.X2P[0] * omega * a).into();
-    checks.push(vec![((Z_x - Z_ga_x).into(), srs.X2A[0]), (-Z_Q_x, V_x.into()), (-C4, srs.Y2A)]);
+    checks.push(vec![((Z_x - Z_ga_x).into(), srs.X2A[0]), (-Z_Q_x, V_x.into()), (-C5, srs.Y2A)]);
     checks
   }
 }

--- a/src/basic_block/copy_constraint.rs
+++ b/src/basic_block/copy_constraint.rs
@@ -217,10 +217,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let N = max(input_deg, output_deg);
     let domain = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
 
-    // Round 1: quotients
-    let beta = Fr::rand(rng);
-    let gamma = Fr::rand(rng);
-
+    // Round 1: Commit input and output polynomials
     // Calculate fjs
     let m = inputs[0].len() + outputs[0].len();
     let mut rng2 = StdRng::from_entropy();
@@ -241,10 +238,17 @@ impl BasicBlock for CopyConstraintBasicBlock {
       .collect();
 
     let ssig_polys = &setup.2[..];
+
+    // Round 2: Commit Z
+    let mut bytes = Vec::new();
+    let mut rng2 = StdRng::from_entropy();
+    fj_xs.serialize_uncompressed(&mut bytes).unwrap();
+    util::add_randomness(rng, bytes);
+    let beta = Fr::rand(rng);
+    let gamma = Fr::rand(rng);
     let beta_poly = DensePolynomial::from_coefficients_vec(vec![beta]);
     let gamma_poly = DensePolynomial::from_coefficients_vec(vec![gamma]);
 
-    // Round 0: Calculate Z
     let mut Z = vec![Fr::zero(); N];
     Z[0] = Fr::one();
     for j in 0..(N - 1) {
@@ -269,7 +273,8 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let Z_poly = &Z_poly + &Z_blind_poly.mul(&DensePolynomial::from(domain.vanishing_polynomial()));
     let Z_x = util::msm::<G1Projective>(&srs.X1A, &Z_poly.coeffs);
 
-    // Calculate quotient for L0(X)(Z(X)-1) = 0
+    // Round 3: Commit t (batched quotient polynomial)
+    // Calculate L0(X)(Z(X)-1) polynomial
     let mut L0_evals = vec![Fr::zero(); N];
     L0_evals[0] = Fr::one();
     let L0_poly = DensePolynomial {
@@ -278,13 +283,12 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let one = DensePolynomial { coeffs: vec![Fr::one()] };
     let L0Z_poly = L0_poly.mul(&Z_poly.sub(&one));
 
-    // Calculate quotient for zero-pad check
+    // Calculate zero-pad check polynomial
     let mut fj_none_idx = 0; // position in f_polys
     let mut Lnone_poly = DensePolynomial::zero();
     for i in indices(self.permutation.shape()) {
       let idx = i.clone();
       if self.permutation[i].is_none() {
-        // has_none = true;
         let flat_none_idx = flat_index(&self.permutation.dim(), &Some(idx.clone()), N).unwrap();
         let mut Lnone_evals = vec![Fr::zero(); N];
         Lnone_evals[flat_none_idx.1] = Fr::one();
@@ -296,7 +300,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
       }
     }
 
-    // Calculate quotient for Z(x)f'(x) = Z(gx)g'(x)
+    // Calculate batched quotient for Z(x)f'(x) = Z(gx)g'(x) and above checks
     let mut bytes = Vec::new();
     let mut rng2 = StdRng::from_entropy();
     let mut r: Vec<_> = vec![Fr::rand(&mut rng2)];
@@ -329,7 +333,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     // smaller polynomials of degree <n done in the Plonk paper.
     let t_x = util::msm::<G1Projective>(&srs.X1A, &t_poly.coeffs);
 
-    // Round 2: openings
+    // Round 4: Commit opening proofs
     // Fiat-Shamir
     let mut bytes = Vec::new();
     let mut rng2 = StdRng::from_entropy();
@@ -355,7 +359,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let Z_Q: DensePolynomial<_> = &temp / &Z_V;
     let Z_Q_x = util::msm::<G1Projective>(&srs.X1A, &Z_Q.coeffs);
 
-    // Calculate opening quotient for Z(x)f'(x) = Z(gx)g'(x) check
+    // Calculate opening quotient for batched quotient check
     let mut ssig_as: Vec<_> = ssig_polys.iter().map(|p| p.evaluate(&a)).collect();
     let ft_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| beta * Fr::from((i + 1) as i32) * a + *x + gamma).collect();
     let gt_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| ssig_as[i] * beta + *x + gamma).collect();
@@ -449,36 +453,39 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let ssig_as = &q1_evals[..m];
     let fj_as = &q1_evals[m..];
 
-    // Round 1 randomness
+    // Round 2 randomness
+    let mut bytes = Vec::new();
+    fj_xs.serialize_uncompressed(&mut bytes).unwrap();
+    util::add_randomness(rng, bytes);
     let beta = Fr::rand(rng);
     let gamma = Fr::rand(rng);
 
-    // Round 2 randomness
+    // Round 3 randomness
     let mut bytes = Vec::new();
     vec![Z_x].serialize_uncompressed(&mut bytes).unwrap();
     util::add_randomness(rng, bytes);
     let alpha = Fr::rand(rng);
 
-    // randomness
+    // Round 4 randomness
     let mut bytes = Vec::new();
     vec![t_x].serialize_uncompressed(&mut bytes).unwrap();
     util::add_randomness(rng, bytes);
     let a = Fr::rand(rng);
     let b = Fr::rand(rng);
 
-    // Check Lnone(x)f(x) = V(x)Q(x)
+    // Get none index for Lnone(x)f(x) = V(x)Q(x) check
     let mut has_none = false;
-    let mut flat_none_idx = 0;
+    let mut fj_none_idx = 0;
     for i in indices(self.permutation.shape()) {
       if self.permutation[i.clone()].is_none() {
         let idx = flat_index(&self.permutation.dim(), &Some(i), N).unwrap();
-        flat_none_idx = idx.0 + input.len();
+        fj_none_idx = idx.0 + input.len();
         has_none = true;
         break;
       }
     }
 
-    // Check Z(x)f'(x) = Z(gx)g'(x)
+    // Check t polynomial batched quotient
     let ft_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| beta * Fr::from((i + 1) as i32) * a + *x + gamma).collect();
     let gt_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| ssig_as[i] * beta + *x + gamma).collect();
     let ft_a: Fr = ft_as.iter().product();
@@ -497,7 +504,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
       (-C1, srs.Y2A),
     ];
     if has_none {
-      Z_check.push(((fj_xs[flat_none_idx] * alpha * alpha * Lnone_a).into(), srs.X2A[0]));
+      Z_check.push(((fj_xs[fj_none_idx] * alpha * alpha * Lnone_a).into(), srs.X2A[0]));
     }
     checks.push(Z_check);
 
@@ -515,7 +522,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
       (-C2, srs.Y2A),
     ]);
 
-    // Check Z opening commitment
+    // Check Z opening commitment over omega * a
     let Z_ga_x: G1Affine = (srs.X1P[0] * Z_ga).into();
     let V_x: G2Affine = (srs.X2P[1] - srs.X2P[0] * omega * a).into();
     checks.push(vec![((Z_x - Z_ga_x).into(), srs.X2A[0]), (-Z_Q_x, V_x.into()), (-C3, srs.Y2A)]);

--- a/src/basic_block/copy_constraint.rs
+++ b/src/basic_block/copy_constraint.rs
@@ -90,7 +90,9 @@ fn construct_ssig(
     .collect()
 }
 
-// Permutation has the same shape as the output, and each index stores the index of the input array it equals to
+// This BasicBlock implements Plonk's copy constraint protocol over the inputs and outputs (Sec. 5.2 and 8 of https://eprint.iacr.org/2019/953.pdf) [1].
+// It additionally supports checking that elements corresponding to None are zero to support padding.
+// permutation has the same shape as the output, and each index stores the index of the input array it equals to.
 #[derive(Debug)]
 pub struct CopyConstraintBasicBlock {
   pub permutation: ArrayD<Option<IxDyn>>,
@@ -137,7 +139,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     // Indices of the input which are in each position of the permutation
     let flat_perm_idxs = self.permutation.map(|i| flat_index(&self.input_dim, i, N));
 
-    // Create partitions
+    // Create partitions (p. 22 of [1])
     let mut partitions = HashMap::new();
     for i in indices(self.input_dim.clone()).into_iter() {
       let idx = flat_index(&self.input_dim, &Some(i), N);
@@ -155,7 +157,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
       partitions.insert(None, pad);
     }
 
-    // Calculate S_sigma_js
+    // Calculate S_sigma_js (p. 27 of [1])
     let inp_idxs: ArrayD<(usize, usize)> = ArrayD::from_shape_fn(self.input_dim.clone(), |i| flat_index(&self.input_dim, &Some(i), N).unwrap());
     let mut inp_arr = ArrayD::from_elem(self.input_dim.clone(), ((0, 0), None));
     Zip::from(&mut inp_arr).and(&inp_idxs).for_each(|r, &a| {
@@ -218,7 +220,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let domain = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
 
     // Round 1: Commit input and output polynomials
-    // Calculate fjs
+    // Calculate fjs (corresponds to fjs on p. 22 and a, b, c on p. 28 of [1])
     let m = inputs[0].len() + outputs[0].len();
     let mut rng2 = StdRng::from_entropy();
     let fj_blind: Vec<_> = (0..m).map(|_| Fr::rand(&mut rng2)).collect();
@@ -239,7 +241,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
 
     let ssig_polys = &setup.2[..];
 
-    // Round 2: Commit Z
+    // Round 2: Commit Z (p. 28 of [1])
     let mut bytes = Vec::new();
     let mut rng2 = StdRng::from_entropy();
     fj_xs.serialize_uncompressed(&mut bytes).unwrap();
@@ -273,7 +275,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let Z_poly = &Z_poly + &Z_blind_poly.mul(&DensePolynomial::from(domain.vanishing_polynomial()));
     let Z_x = util::msm::<G1Projective>(&srs.X1A, &Z_poly.coeffs);
 
-    // Round 3: Commit t (batched quotient polynomial)
+    // Round 3: Commit t (batched quotient polynomial of the below polynomials, p. 29 of [1])
     // Calculate L0(X)(Z(X)-1) polynomial
     let mut L0_evals = vec![Fr::zero(); N];
     L0_evals[0] = Fr::one();
@@ -310,10 +312,11 @@ impl BasicBlock for CopyConstraintBasicBlock {
     util::add_randomness(rng, bytes);
     let alpha = Fr::rand(rng);
     let alpha_poly = DensePolynomial::from_coefficients_vec(vec![alpha]);
+    // Compute Z(omega * X) polynomial
     let Zg_poly = DensePolynomial {
       coeffs: Z_poly.coeffs.iter().enumerate().map(|(i, x)| x * &domain.element(i)).collect(),
     };
-    // These have the extra beta * X + gamma etc. terms that appear in Z, t, r
+    // These have the extra beta * X + gamma etc. terms that appear in Z, t, r (seen as terms of t on p. 29 of [1])
     let ft_polys: Vec<_> = fj_polys
       .iter()
       .enumerate()
@@ -348,7 +351,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let a = Fr::rand(rng);
     let mut fj_as: Vec<_> = fj_polys.iter().map(|p| p.evaluate(&a)).collect();
 
-    // Calculate opening argument for Z over omega * a
+    // Calculate opening argument for Z over omega * a (p. 30 of [1])
     let omega = domain.group_gen();
     let Z_ga = Z_poly.evaluate(&(omega * a));
     let Z_ga_poly = DensePolynomial { coeffs: vec![Z_ga] };
@@ -359,7 +362,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let Z_Q: DensePolynomial<_> = &temp / &Z_V;
     let Z_Q_x = util::msm::<G1Projective>(&srs.X1A, &Z_Q.coeffs);
 
-    // Calculate opening quotient for batched quotient check
+    // Calculate opening quotient for batched quotient check (containing r, fjs, ssigs on p. 30 of [1])
     let mut ssig_as: Vec<_> = ssig_polys.iter().map(|p| p.evaluate(&a)).collect();
     let ft_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| beta * Fr::from((i + 1) as i32) * a + *x + gamma).collect();
     let gt_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| ssig_as[i] * beta + *x + gamma).collect();
@@ -375,6 +378,8 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let q1_V = DensePolynomial { coeffs: vec![-a, Fr::one()] };
     let L0_a = L0_poly.evaluate(&a);
     let Lnone_a = Lnone_poly.evaluate(&a);
+
+    // Compute linearization polynomial r (p. 30 of [1])
     let r_poly = &(&lhs - &rhs) - &v
       + Z_poly.sub(&one).mul(&DensePolynomial::from_coefficients_vec(vec![alpha * L0_a]))
       + fj_polys[fj_none_idx].mul(&DensePolynomial::from_coefficients_vec(vec![alpha * alpha * Lnone_a]));

--- a/src/basic_block/copy_constraint.rs
+++ b/src/basic_block/copy_constraint.rs
@@ -346,16 +346,16 @@ impl BasicBlock for CopyConstraintBasicBlock {
     util::add_randomness(rng, bytes);
     proof.append(&mut proof_1);
 
-    let a = Fr::rand(rng);
+    let zeta = Fr::rand(rng);
     let omega = domain.group_gen();
-    let Z_ga = Z_poly.evaluate(&(omega * a));
-    let L0_a = L0_poly.evaluate(&a);
-    let Lnone_a = Lnone_poly.evaluate(&a);
-    let ssig_as: Vec<_> = ssig_polys.iter().map(|p| p.evaluate(&a)).collect();
-    let fj_as: Vec<_> = fj_polys.iter().map(|p| p.evaluate(&a)).collect();
-    let mut evals = vec![Z_ga, L0_a, Lnone_a];
-    evals.append(&mut ssig_as.clone());
-    evals.append(&mut fj_as.clone());
+    let Z_gz = Z_poly.evaluate(&(omega * zeta));
+    let L0_z = L0_poly.evaluate(&zeta);
+    let Lnone_z = Lnone_poly.evaluate(&zeta);
+    let ssig_zs: Vec<_> = ssig_polys.iter().map(|p| p.evaluate(&zeta)).collect();
+    let fj_zs: Vec<_> = fj_polys.iter().map(|p| p.evaluate(&zeta)).collect();
+    let mut evals = vec![Z_gz, L0_z, Lnone_z];
+    evals.append(&mut ssig_zs.clone());
+    evals.append(&mut fj_zs.clone());
 
     // Round 5: Commit opening proofs
     // Fiat-Shamir
@@ -364,41 +364,42 @@ impl BasicBlock for CopyConstraintBasicBlock {
     util::add_randomness(rng, bytes);
 
     // Calculate opening argument for Z over omega * a (W_zetaomega on p. 30 of [1])
-    let Z_ga_poly = DensePolynomial { coeffs: vec![Z_ga] };
+    let Z_gz_poly = DensePolynomial { coeffs: vec![Z_gz] };
     let Z_V = DensePolynomial {
-      coeffs: vec![-a * omega, Fr::one()],
+      coeffs: vec![-zeta * omega, Fr::one()],
     };
-    let temp = Z_poly.sub(&Z_ga_poly);
+    let temp = Z_poly.sub(&Z_gz_poly);
     let Z_Q: DensePolynomial<_> = &temp / &Z_V;
     let W_gx = util::msm::<G1Projective>(&srs.X1A, &Z_Q.coeffs);
 
     // Calculate opening quotient for batched quotient check (containing r, fjs, ssigs on p. 30 of [1])
-    let ft_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| beta * Fr::from((i + 1) as i32) * a + *x + gamma).collect();
-    let gt_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| ssig_as[i] * beta + *x + gamma).collect();
-    let a_pows = calc_pow(a, N);
-    let gt_a: Fr = gt_as[..gt_as.len() - 1].iter().product();
-    let ft_a = ft_as.iter().product();
-    let ft_a_poly = DensePolynomial::from_coefficients_vec(vec![ft_a]);
-    let lhs = Z_poly.mul(&ft_a_poly);
-    let rhs_mul = DensePolynomial::from_coefficients_vec(vec![gt_a * Z_ga]);
-    let rhs_add = DensePolynomial::from_coefficients_vec(vec![gamma + fj_as[fj_as.len() - 1]]);
+    let ft_zs: Vec<_> = fj_zs.iter().enumerate().map(|(i, x)| beta * Fr::from((i + 1) as i32) * zeta + *x + gamma).collect();
+    let gt_zs: Vec<_> = fj_zs.iter().enumerate().map(|(i, x)| ssig_zs[i] * beta + *x + gamma).collect();
+    let zeta_pows = calc_pow(zeta, N);
+    let gt_z: Fr = gt_zs[..gt_zs.len() - 1].iter().product();
+    let ft_z = ft_zs.iter().product();
+    let ft_z_poly = DensePolynomial::from_coefficients_vec(vec![ft_z]);
+    let lhs = Z_poly.mul(&ft_z_poly);
+    let rhs_mul = DensePolynomial::from_coefficients_vec(vec![gt_z * Z_gz]);
+    let rhs_add = DensePolynomial::from_coefficients_vec(vec![gamma + fj_zs[fj_zs.len() - 1]]);
     let rhs = (&ssig_polys[ssig_polys.len() - 1].mul(&beta_poly) + &rhs_add).mul(&rhs_mul);
-    let v = DensePolynomial::from_coefficients_vec(vec![a_pows[N - 1] - Fr::one()]).mul(&t_poly);
-    let q1_V = DensePolynomial { coeffs: vec![-a, Fr::one()] };
+    let q1_V = DensePolynomial {
+      coeffs: vec![-zeta, Fr::one()],
+    };
 
     // Compute linearization polynomial r (p. 30 of [1])
-    let r_poly = &(&lhs - &rhs) - &v
-      + Z_poly.sub(&one).mul(&DensePolynomial::from_coefficients_vec(vec![alpha * L0_a]))
-      + fj_polys[fj_none_idx].mul(&DensePolynomial::from_coefficients_vec(vec![alpha * alpha * Lnone_a]));
+    let r_poly = &(&lhs - &rhs) - &DensePolynomial::from_coefficients_vec(vec![zeta_pows[N - 1] - Fr::one()]).mul(&t_poly)
+      + Z_poly.sub(&one).mul(&DensePolynomial::from_coefficients_vec(vec![alpha * L0_z]))
+      + fj_polys[fj_none_idx].mul(&DensePolynomial::from_coefficients_vec(vec![alpha * alpha * Lnone_z]));
 
     // Calculate opening argument for W over a (W_zeta on p. 30 of [1])
-    let b = Fr::rand(rng);
-    let bs = calc_pow(b, ssig_polys.len() + ft_polys.len());
+    let v = Fr::rand(rng);
+    let vs = calc_pow(v, ssig_polys.len() + ft_polys.len());
     let q1_poly: DensePolynomial<Fr> =
-      ssig_polys.iter().chain(fj_polys.iter()).enumerate().fold(DensePolynomial::zero(), |acc, (i, p)| acc + p.mul(bs[i]));
-    let q1_a = q1_poly.evaluate(&a);
-    let q1_a_poly = DensePolynomial { coeffs: vec![q1_a] };
-    let W_poly = &(q1_poly.sub(&q1_a_poly) + r_poly) / &q1_V;
+      ssig_polys.iter().chain(fj_polys.iter()).enumerate().fold(DensePolynomial::zero(), |acc, (i, p)| acc + p.mul(vs[i]));
+    let q1_z = q1_poly.evaluate(&zeta);
+    let q1_z_poly = DensePolynomial { coeffs: vec![q1_z] };
+    let W_poly = &(q1_poly.sub(&q1_z_poly) + r_poly) / &q1_V;
     let W_x = util::msm::<G1Projective>(&srs.X1A, &W_poly.coeffs);
 
     // Round 5 end randomness
@@ -409,7 +410,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
 
     // Blinding
     proof.append(&mut vec![W_x, W_gx]);
-    proof.push(srs.X1P[0] * (r * (a_pows[N - 1] - Fr::one())));
+    proof.push(srs.X1P[0] * (r * (zeta_pows[N - 1] - Fr::one())));
 
     let mut ssig_xs = setup.0[2..].iter().map(|x| Into::<G1Projective>::into(*x)).collect();
     proof.append(&mut ssig_xs);
@@ -450,12 +451,12 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let fj_xs = &proof.0[m + 5..];
 
     // TODO: have verifier compute Lagrange basis evals
-    let [Z_ga, L0_a, Lnone_a] = proof.2[..3] else {
+    let [Z_gz, L0_z, Lnone_z] = proof.2[..3] else {
       panic!("Wrong proof format")
     };
     let q1_evals = &proof.2[3..];
-    let ssig_as = &q1_evals[..m];
-    let fj_as = &q1_evals[m..];
+    let ssig_zs = &q1_evals[..m];
+    let fj_zs = &q1_evals[m..];
 
     // Round 2 randomness
     let mut bytes = Vec::new();
@@ -474,13 +475,13 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let mut bytes = Vec::new();
     vec![t_x].serialize_uncompressed(&mut bytes).unwrap();
     util::add_randomness(rng, bytes);
-    let a = Fr::rand(rng);
+    let zeta = Fr::rand(rng);
 
     // Round 5 randomness
     let mut bytes = Vec::new();
     proof.2.serialize_uncompressed(&mut bytes).unwrap();
     util::add_randomness(rng, bytes);
-    let b = Fr::rand(rng);
+    let v = Fr::rand(rng);
 
     // Round 5 end randomness
     let mut bytes = Vec::new();
@@ -501,31 +502,31 @@ impl BasicBlock for CopyConstraintBasicBlock {
     }
 
     // Perform the batched check (p. 31 of [1])
-    let ft_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| beta * Fr::from((i + 1) as i32) * a + *x + gamma).collect();
-    let gt_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| ssig_as[i] * beta + *x + gamma).collect();
-    let ft_a: Fr = ft_as.iter().product();
+    let ft_zs: Vec<_> = fj_zs.iter().enumerate().map(|(i, x)| beta * Fr::from((i + 1) as i32) * zeta + *x + gamma).collect();
+    let gt_zs: Vec<_> = fj_zs.iter().enumerate().map(|(i, x)| ssig_zs[i] * beta + *x + gamma).collect();
+    let ft_z: Fr = ft_zs.iter().product();
     // Contains all but the last
-    let gt_a: Fr = gt_as[..gt_as.len() - 1].iter().product();
-    let a_pows = calc_pow(a, N);
+    let gt_z: Fr = gt_zs[..gt_zs.len() - 1].iter().product();
+    let zeta_pows = calc_pow(zeta, N);
 
-    let mut D = Z_x * (ft_a + alpha * L0_a + u) - ssig_xs[ssig_xs.len() - 1] * beta * gt_a * Z_ga - t_x * (a_pows[N - 1] - Fr::one());
+    let mut D = Z_x * (ft_z + alpha * L0_z + u) - ssig_xs[ssig_xs.len() - 1] * beta * gt_z * Z_gz - t_x * (zeta_pows[N - 1] - Fr::one());
     if has_none {
-      D = D + fj_xs[fj_none_idx] * alpha * alpha * Lnone_a;
+      D = D + fj_xs[fj_none_idx] * alpha * alpha * Lnone_z;
     }
 
-    let bs = calc_pow(b, ssig_xs.len() + fj_xs.len());
+    let vs = calc_pow(v, ssig_xs.len() + fj_xs.len());
     let q1_x: G1Projective = ssig_xs
       .iter()
       .chain(fj_xs.iter())
       .enumerate()
-      .fold(G1Projective::zero(), |acc, (i, x)| acc + Into::<G1Projective>::into(*x) * bs[i]);
+      .fold(G1Projective::zero(), |acc, (i, x)| acc + Into::<G1Projective>::into(*x) * vs[i]);
     let F = D + q1_x;
-    let q1_a: Fr = q1_evals.iter().enumerate().fold(Fr::zero(), |acc, (i, x)| acc + *x * bs[i]);
-    let r_0 = -L0_a * alpha - gt_a * (fj_as[fj_as.len() - 1] + gamma) * Z_ga;
-    let E = srs.X1A[0] * (-r_0 + q1_a + u * Z_ga);
+    let q1_z: Fr = q1_evals.iter().enumerate().fold(Fr::zero(), |acc, (i, x)| acc + *x * vs[i]);
+    let r_0 = -L0_z * alpha - gt_z * (fj_zs[fj_zs.len() - 1] + gamma) * Z_gz;
+    let E = srs.X1A[0] * (-r_0 + q1_z + u * Z_gz);
     checks.push(vec![
       ((W_x + W_gx * u).into(), srs.X2A[1]),
-      ((-(W_x * a + W_gx * u * omega * a + F - E)).into(), srs.X2A[0]),
+      ((-(W_x * zeta + W_gx * u * omega * zeta + F - E)).into(), srs.X2A[0]),
       (-C1, srs.Y2A),
     ]);
     checks

--- a/src/basic_block/copy_constraint.rs
+++ b/src/basic_block/copy_constraint.rs
@@ -55,7 +55,9 @@ fn flat_index(shape: &IxDyn, idx: &Option<IxDyn>, N: usize) -> Option<(usize, us
 // which encodes the permutation function
 // In a copy-constraint, the permutation should form a cycle for all elements
 // that should be the same over inputs and outputs.
-// If is_input, idxs is [(flat_idx of the input index, 0)]. Otherwise,
+// idxs tuple (i, j) refers to the jth element in the ith polynomial based on
+// the flattened input or output ArrayD
+// If is_input, idxs is [(flat_idx of the input index, (0, 0))]. Otherwise,
 // idxs is [(flat_idx of the output, flat_idx of the permuted input idx)]
 fn construct_ssig(
   idxs: &[((usize, usize), Option<(usize, usize)>)],
@@ -360,27 +362,14 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let ft_a = ft_as.iter().product();
     let ft_a_poly = DensePolynomial::from_coefficients_vec(vec![ft_a]);
     let lhs = Z_poly.mul(&ft_a_poly);
-    // assert!(util::msm::<G1Projective>(&srs.X1A, &lhs.coeffs) == Z_x * ft_a);
     let rhs_mul = DensePolynomial::from_coefficients_vec(vec![gt_a * Z_ga]);
     let rhs_add = DensePolynomial::from_coefficients_vec(vec![gamma + fj_as[fj_as.len() - 1]]);
     let rhs = (&ssig_polys[ssig_polys.len() - 1].mul(&beta_poly) + &rhs_add).mul(&rhs_mul);
-    // let ssig_xs = &setup.0[2..];
-    // assert!(
-    //   util::msm::<G1Projective>(&srs.X1A, &rhs.coeffs)
-    //     == (ssig_xs[ssig_xs.len() - 1] * beta + srs.X1A[0] * (fj_as[fj_as.len() - 1] + gamma)) * gt_a * Z_ga
-    // );
-    // assert!(DensePolynomial::from(domain.vanishing_polynomial()).evaluate(&a) == a_pows[N - 1] - Fr::one());
     let v = DensePolynomial::from_coefficients_vec(vec![a_pows[N - 1] - Fr::one()]).mul(&t_poly);
-    // assert!(util::msm::<G1Projective>(&srs.X1A, &v.coeffs) == t_x * (a_pows[N - 1] - Fr::one()));
     let q1_V = DensePolynomial { coeffs: vec![-a, Fr::one()] };
     let r_poly = &(&lhs - &rhs) - &v;
     let r_Q = &r_poly / &q1_V;
     let r_Q_x = util::msm::<G1Projective>(&srs.X1A, &r_Q.coeffs);
-    // assert!(r_Q.mul(&q1_V) == (&(&lhs - &rhs) - &v));
-    // assert!(
-    //   Bn254::pairing(util::msm::<G1Projective>(&srs.X1A, &(&(&lhs - &rhs) - &v).coeffs), srs.X2P[0])
-    //     == Bn254::pairing(r_Q_x, srs.X2P[1] - srs.X2P[0] * a)
-    // );
 
     // Calculate opening argument for fjs, ssigs over a
     let b = Fr::rand(rng);

--- a/src/basic_block/copy_constraint.rs
+++ b/src/basic_block/copy_constraint.rs
@@ -242,6 +242,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let ssig_polys = &setup.2[..];
 
     // Round 2: Commit Z (p. 28 of [1])
+    // Fiat-Shamir
     let mut bytes = Vec::new();
     let mut rng2 = StdRng::from_entropy();
     fj_xs.serialize_uncompressed(&mut bytes).unwrap();
@@ -276,6 +277,12 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let Z_x = util::msm::<G1Projective>(&srs.X1A, &Z_poly.coeffs);
 
     // Round 3: Commit t (batched quotient polynomial of the below polynomials, p. 29 of [1])
+    // Fiat-Shamir
+    let mut bytes = Vec::new();
+    let mut proof = vec![Z_x];
+    proof.serialize_uncompressed(&mut bytes).unwrap();
+    util::add_randomness(rng, bytes);
+
     // Calculate L0(X)(Z(X)-1) polynomial
     let mut L0_evals = vec![Fr::zero(); N];
     L0_evals[0] = Fr::one();
@@ -303,10 +310,6 @@ impl BasicBlock for CopyConstraintBasicBlock {
     }
 
     // Calculate batched quotient for Z(x)f'(x) = Z(gx)g'(x) and above checks
-    let mut bytes = Vec::new();
-    let mut proof = vec![Z_x];
-    proof.serialize_uncompressed(&mut bytes).unwrap();
-    util::add_randomness(rng, bytes);
     let alpha = Fr::rand(rng);
     let alpha_poly = DensePolynomial::from_coefficients_vec(vec![alpha]);
     // Compute Z(omega * X) polynomial
@@ -333,7 +336,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     // smaller polynomials of degree <n done in the Plonk paper.
     let t_x = util::msm::<G1Projective>(&srs.X1A, &t_poly.coeffs);
 
-    // Round 4: Commit opening proofs
+    // Round 4: Compute openings
     // Fiat-Shamir
     let mut bytes = Vec::new();
     let mut rng2 = StdRng::from_entropy();
@@ -344,11 +347,23 @@ impl BasicBlock for CopyConstraintBasicBlock {
     proof.append(&mut proof_1);
 
     let a = Fr::rand(rng);
-    let mut fj_as: Vec<_> = fj_polys.iter().map(|p| p.evaluate(&a)).collect();
-
-    // Calculate opening argument for Z over omega * a (p. 30 of [1])
     let omega = domain.group_gen();
     let Z_ga = Z_poly.evaluate(&(omega * a));
+    let L0_a = L0_poly.evaluate(&a);
+    let Lnone_a = Lnone_poly.evaluate(&a);
+    let ssig_as: Vec<_> = ssig_polys.iter().map(|p| p.evaluate(&a)).collect();
+    let fj_as: Vec<_> = fj_polys.iter().map(|p| p.evaluate(&a)).collect();
+    let mut evals = vec![Z_ga, L0_a, Lnone_a];
+    evals.append(&mut ssig_as.clone());
+    evals.append(&mut fj_as.clone());
+
+    // Round 5: Commit opening proofs
+    // Fiat-Shamir
+    let mut bytes = Vec::new();
+    evals.serialize_uncompressed(&mut bytes).unwrap();
+    util::add_randomness(rng, bytes);
+
+    // Calculate opening argument for Z over omega * a (W_zetaomega on p. 30 of [1])
     let Z_ga_poly = DensePolynomial { coeffs: vec![Z_ga] };
     let Z_V = DensePolynomial {
       coeffs: vec![-a * omega, Fr::one()],
@@ -358,7 +373,6 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let W_gx = util::msm::<G1Projective>(&srs.X1A, &Z_Q.coeffs);
 
     // Calculate opening quotient for batched quotient check (containing r, fjs, ssigs on p. 30 of [1])
-    let mut ssig_as: Vec<_> = ssig_polys.iter().map(|p| p.evaluate(&a)).collect();
     let ft_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| beta * Fr::from((i + 1) as i32) * a + *x + gamma).collect();
     let gt_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| ssig_as[i] * beta + *x + gamma).collect();
     let a_pows = calc_pow(a, N);
@@ -371,15 +385,13 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let rhs = (&ssig_polys[ssig_polys.len() - 1].mul(&beta_poly) + &rhs_add).mul(&rhs_mul);
     let v = DensePolynomial::from_coefficients_vec(vec![a_pows[N - 1] - Fr::one()]).mul(&t_poly);
     let q1_V = DensePolynomial { coeffs: vec![-a, Fr::one()] };
-    let L0_a = L0_poly.evaluate(&a);
-    let Lnone_a = Lnone_poly.evaluate(&a);
 
     // Compute linearization polynomial r (p. 30 of [1])
     let r_poly = &(&lhs - &rhs) - &v
       + Z_poly.sub(&one).mul(&DensePolynomial::from_coefficients_vec(vec![alpha * L0_a]))
       + fj_polys[fj_none_idx].mul(&DensePolynomial::from_coefficients_vec(vec![alpha * alpha * Lnone_a]));
 
-    // Calculate opening argument for W over a (p. 30 of [1])
+    // Calculate opening argument for W over a (W_zeta on p. 30 of [1])
     let b = Fr::rand(rng);
     let bs = calc_pow(b, ssig_polys.len() + ft_polys.len());
     let q1_poly: DensePolynomial<Fr> =
@@ -397,9 +409,6 @@ impl BasicBlock for CopyConstraintBasicBlock {
     proof.append(&mut ssig_xs);
     proof.append(&mut fj_xs);
 
-    let mut evals = vec![Z_ga, L0_a, Lnone_a];
-    evals.append(&mut ssig_as);
-    evals.append(&mut fj_as);
     return (proof, vec![setup.1[0].into(), setup.1[1].into()], evals);
   }
 
@@ -460,9 +469,14 @@ impl BasicBlock for CopyConstraintBasicBlock {
     vec![t_x].serialize_uncompressed(&mut bytes).unwrap();
     util::add_randomness(rng, bytes);
     let a = Fr::rand(rng);
-    let b = Fr::rand(rng);
 
     // Round 5 randomness
+    let mut bytes = Vec::new();
+    proof.2.serialize_uncompressed(&mut bytes).unwrap();
+    util::add_randomness(rng, bytes);
+    let b = Fr::rand(rng);
+
+    // Round 5 end randomness
     let mut bytes = Vec::new();
     vec![W_x, W_gx].serialize_uncompressed(&mut bytes).unwrap();
     util::add_randomness(rng, bytes);

--- a/src/basic_block/copy_constraint.rs
+++ b/src/basic_block/copy_constraint.rs
@@ -401,6 +401,12 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let W_poly = &(q1_poly.sub(&q1_a_poly) + r_poly) / &q1_V;
     let W_x = util::msm::<G1Projective>(&srs.X1A, &W_poly.coeffs);
 
+    // Round 5 end randomness
+    let mut bytes = Vec::new();
+    vec![W_x, W_gx].serialize_uncompressed(&mut bytes).unwrap();
+    util::add_randomness(rng, bytes);
+    let _ = Fr::rand(rng);
+
     // Blinding
     proof.append(&mut vec![W_x, W_gx]);
     proof.push(srs.X1P[0] * (r * (a_pows[N - 1] - Fr::one())));

--- a/src/basic_block/copy_constraint.rs
+++ b/src/basic_block/copy_constraint.rs
@@ -418,6 +418,13 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let N = max(inputs[0].first().unwrap().len, outputs[0].first().unwrap().len);
     let domain = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
     let omega = domain.group_gen();
+
+    // TODO: Currently the prover is insecure because it passes in
+    // inputs and outputs to the verifier which do not withstand polynomial
+    // interpolation attacks in the inputs and outputs arguments.
+    // To fix this, we have to suppport a blinding scheme
+    // that works with openings more generally and enable the Data and DataEnc
+    // constructors to use the blinding scheme when appropriate.
     let input = inputs[0];
 
     let [Z_x, L0Z_Q_x, t_x, Lnone_f_Q_x, q1_Q_x, Z_Q_x, r_Q_x, C1, C2, C3, C4, C5] = proof.0[..12] else {

--- a/src/basic_block/copy_constraint.rs
+++ b/src/basic_block/copy_constraint.rs
@@ -244,7 +244,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let beta_poly = DensePolynomial::from_coefficients_vec(vec![beta]);
     let gamma_poly = DensePolynomial::from_coefficients_vec(vec![gamma]);
 
-    // Calculate Z
+    // Round 0: Calculate Z
     let mut Z = vec![Fr::zero(); N];
     Z[0] = Fr::one();
     for j in 0..(N - 1) {
@@ -277,38 +277,35 @@ impl BasicBlock for CopyConstraintBasicBlock {
     };
     let one = DensePolynomial { coeffs: vec![Fr::one()] };
     let L0Z_poly = L0_poly.mul(&Z_poly.sub(&one));
-    let L0Z_Q = L0Z_poly.divide_by_vanishing_poly(domain).unwrap();
-    let L0Z_Q_x = util::msm::<G1Projective>(&srs.X1A, &L0Z_Q.0.coeffs);
 
     // Calculate quotient for zero-pad check
-    let outp_ndim = self.permutation.ndim();
-    let mut has_none = false;
-    let mut none_idx = IxDyn::zeros(outp_ndim); // position in f_polys
-
-    let mut Lnone_f_Q_x = G1Projective::zero();
+    let mut fj_none_idx = 0; // position in f_polys
+    let mut Lnone_poly = DensePolynomial::zero();
     for i in indices(self.permutation.shape()) {
       let idx = i.clone();
       if self.permutation[i].is_none() {
-        has_none = true;
-        none_idx = idx.clone();
+        // has_none = true;
+        let flat_none_idx = flat_index(&self.permutation.dim(), &Some(idx.clone()), N).unwrap();
+        let mut Lnone_evals = vec![Fr::zero(); N];
+        Lnone_evals[flat_none_idx.1] = Fr::one();
+        Lnone_poly = DensePolynomial {
+          coeffs: domain.ifft(&Lnone_evals),
+        };
+        fj_none_idx = flat_none_idx.0 + input.len();
         break;
       }
     }
-    if has_none {
-      let idx = flat_index(&self.permutation.dim(), &Some(none_idx.clone()), N).unwrap();
-      let mut Lnone_evals = vec![Fr::zero(); N];
-      Lnone_evals[idx.1] = Fr::one();
-      let Lnone_poly = DensePolynomial {
-        coeffs: domain.ifft(&Lnone_evals),
-      };
-      let fj_none_poly = &fj_polys[idx.0 + input.len()];
-      let Lnone_f_poly = &Lnone_poly.mul(fj_none_poly);
-
-      let Lnone_f_Q = Lnone_f_poly.divide_by_vanishing_poly(domain).unwrap();
-      Lnone_f_Q_x = util::msm::<G1Projective>(&srs.X1A, &Lnone_f_Q.0.coeffs).into();
-    }
 
     // Calculate quotient for Z(x)f'(x) = Z(gx)g'(x)
+    let mut bytes = Vec::new();
+    let mut rng2 = StdRng::from_entropy();
+    let mut r: Vec<_> = vec![Fr::rand(&mut rng2)];
+    let proof = vec![Z_x];
+    let mut proof: Vec<_> = proof.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r[i]).collect();
+    proof.serialize_uncompressed(&mut bytes).unwrap();
+    util::add_randomness(rng, bytes);
+    let alpha = Fr::rand(rng);
+    let alpha_poly = DensePolynomial::from_coefficients_vec(vec![alpha]);
     let Zg_poly = DensePolynomial {
       coeffs: Z_poly.coeffs.iter().enumerate().map(|(i, x)| x * &domain.element(i)).collect(),
     };
@@ -324,7 +321,9 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let f1_poly = ft_polys.iter().fold(DensePolynomial::from_coefficients_vec(vec![Fr::one()]), |acc, x| acc.mul(x));
     let gt_polys: Vec<_> = fj_polys.iter().enumerate().map(|(i, x)| &ssig_polys[i].mul(&beta_poly) + x + gamma_poly.clone()).collect();
     let g1_poly = gt_polys.iter().fold(DensePolynomial::from_coefficients_vec(vec![Fr::one()]), |acc, x| acc.mul(x));
-    let t_poly = f1_poly.mul(&Z_poly).sub(&g1_poly.mul(&Zg_poly));
+    let t_poly = f1_poly.mul(&Z_poly).sub(&g1_poly.mul(&Zg_poly))
+      + L0Z_poly.mul(&alpha_poly)
+      + Lnone_poly.mul(&fj_polys[fj_none_idx]).mul(&alpha_poly).mul(&alpha_poly);
     let t_poly = t_poly.divide_by_vanishing_poly(domain).unwrap().0;
     // TODO: We currently commit t entirely instead of splitting it into
     // smaller polynomials of degree <n done in the Plonk paper.
@@ -334,11 +333,13 @@ impl BasicBlock for CopyConstraintBasicBlock {
     // Fiat-Shamir
     let mut bytes = Vec::new();
     let mut rng2 = StdRng::from_entropy();
-    let mut r: Vec<_> = (0..4).map(|_| Fr::rand(&mut rng2)).collect();
-    let proof = vec![Z_x, L0Z_Q_x, t_x, Lnone_f_Q_x];
-    let mut proof: Vec<_> = proof.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r[i]).collect();
-    proof.serialize_uncompressed(&mut bytes).unwrap();
+    let mut r1: Vec<_> = vec![Fr::rand(&mut rng2)];
+    let proof_1 = vec![t_x];
+    let mut proof_1: Vec<_> = proof_1.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r1[i]).collect();
+    proof_1.serialize_uncompressed(&mut bytes).unwrap();
     util::add_randomness(rng, bytes);
+    r.append(&mut r1);
+    proof.append(&mut proof_1);
 
     let a = Fr::rand(rng);
     let mut fj_as: Vec<_> = fj_polys.iter().map(|p| p.evaluate(&a)).collect();
@@ -368,7 +369,11 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let rhs = (&ssig_polys[ssig_polys.len() - 1].mul(&beta_poly) + &rhs_add).mul(&rhs_mul);
     let v = DensePolynomial::from_coefficients_vec(vec![a_pows[N - 1] - Fr::one()]).mul(&t_poly);
     let q1_V = DensePolynomial { coeffs: vec![-a, Fr::one()] };
-    let r_poly = &(&lhs - &rhs) - &v;
+    let L0_a = L0_poly.evaluate(&a);
+    let Lnone_a = Lnone_poly.evaluate(&a);
+    let r_poly = &(&lhs - &rhs) - &v
+      + Z_poly.sub(&one).mul(&DensePolynomial::from_coefficients_vec(vec![alpha * L0_a]))
+      + fj_polys[fj_none_idx].mul(&DensePolynomial::from_coefficients_vec(vec![alpha * alpha * Lnone_a]));
     let r_Q = &r_poly / &q1_V;
     let r_Q_x = util::msm::<G1Projective>(&srs.X1A, &r_Q.coeffs);
 
@@ -388,11 +393,10 @@ impl BasicBlock for CopyConstraintBasicBlock {
     proof.append(&mut vec![q1_Q_x, Z_Q_x, r_Q_x].iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r1[i]).collect());
     r.append(&mut r1);
     let mut C: Vec<G1Projective> = vec![
-      setup.0[0] * r[0] - (srs.X1P[N] - srs.X1P[0]) * r[1],
-      -(srs.X1P[N] - srs.X1P[0]) * r[3],
-      srs.X1P[0] * ft_a * r[0] - srs.X1P[0] * (a_pows[N - 1] - Fr::one()) * r[2] - (srs.X1P[1] - (srs.X1P[0] * a)) * r[6],
-      -(srs.X1P[1] - (srs.X1P[0] * a)) * r[4],
-      srs.X1P[0] * r[0] - (srs.X1P[1] - (srs.X1P[0] * a * omega)) * r[5],
+      srs.X1P[0] * ft_a * r[0] - srs.X1P[0] * (a_pows[N - 1] - Fr::one()) * r[1] + srs.X1P[0] * r[0] * alpha * L0_a
+        - (srs.X1P[1] - (srs.X1P[0] * a)) * r[4],
+      -(srs.X1P[1] - (srs.X1P[0] * a)) * r[2],
+      srs.X1P[0] * r[0] - (srs.X1P[1] - (srs.X1P[0] * a * omega)) * r[3],
     ];
     proof.append(&mut C);
 
@@ -400,7 +404,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     proof.append(&mut ssig_xs);
     proof.append(&mut fj_xs);
 
-    let mut evals = vec![Z_ga];
+    let mut evals = vec![Z_ga, L0_a, Lnone_a];
     evals.append(&mut ssig_as);
     evals.append(&mut fj_as);
     return (proof, vec![setup.1[0].into(), setup.1[1].into()], evals);
@@ -429,18 +433,19 @@ impl BasicBlock for CopyConstraintBasicBlock {
     // constructors to use the blinding scheme when appropriate.
     let input = inputs[0];
 
-    let [Z_x, L0Z_Q_x, t_x, Lnone_f_Q_x, q1_Q_x, Z_Q_x, r_Q_x, C1, C2, C3, C4, C5] = proof.0[..12] else {
+    let [Z_x, t_x, q1_Q_x, Z_Q_x, r_Q_x, C1, C2, C3] = proof.0[..8] else {
       panic!("Wrong proof format")
     };
 
     let m = inputs[0].len() + outputs[0].len();
-    let ssig_xs = &proof.0[12..m + 12];
-    let fj_xs = &proof.0[m + 12..];
+    let ssig_xs = &proof.0[8..m + 8];
+    let fj_xs = &proof.0[m + 8..];
 
-    let [L0, Lnone] = proof.1[..] else { panic!("Wrong proof format") };
-    let Z_ga = proof.2[0];
-
-    let q1_evals = &proof.2[1..];
+    // TODO: have verifier compute Lagrange basis evals
+    let [Z_ga, L0_a, Lnone_a] = proof.2[..3] else {
+      panic!("Wrong proof format")
+    };
+    let q1_evals = &proof.2[3..];
     let ssig_as = &q1_evals[..m];
     let fj_as = &q1_evals[m..];
 
@@ -450,28 +455,25 @@ impl BasicBlock for CopyConstraintBasicBlock {
 
     // Round 2 randomness
     let mut bytes = Vec::new();
-    vec![Z_x, L0Z_Q_x, t_x, Lnone_f_Q_x].serialize_uncompressed(&mut bytes).unwrap();
+    vec![Z_x].serialize_uncompressed(&mut bytes).unwrap();
+    util::add_randomness(rng, bytes);
+    let alpha = Fr::rand(rng);
+
+    // randomness
+    let mut bytes = Vec::new();
+    vec![t_x].serialize_uncompressed(&mut bytes).unwrap();
     util::add_randomness(rng, bytes);
     let a = Fr::rand(rng);
     let b = Fr::rand(rng);
 
-    // Check L0(x)(Z(x) - 1) = V(x)Q(x)
-    checks.push(vec![
-      ((Z_x - srs.X1A[0]).into(), L0),
-      (-L0Z_Q_x, (srs.X2A[N] - srs.X2A[0]).into()),
-      (-C1, srs.Y2A),
-    ]);
-
     // Check Lnone(x)f(x) = V(x)Q(x)
+    let mut has_none = false;
+    let mut flat_none_idx = 0;
     for i in indices(self.permutation.shape()) {
       if self.permutation[i.clone()].is_none() {
         let idx = flat_index(&self.permutation.dim(), &Some(i), N).unwrap();
-        let flat_none_f_idx = (idx.0 + input.len(), idx.1);
-        checks.push(vec![
-          (fj_xs[flat_none_f_idx.0], Lnone),
-          (-Lnone_f_Q_x, (srs.X2A[N] - srs.X2A[0]).into()),
-          (-C2, srs.Y2A),
-        ]);
+        flat_none_idx = idx.0 + input.len();
+        has_none = true;
         break;
       }
     }
@@ -483,16 +485,21 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let gt_a: Fr = gt_as[..gt_as.len() - 1].iter().product();
     let a_pows = calc_pow(a, N);
     let V_x: G2Affine = (srs.X2P[1] - srs.X2P[0] * a).into();
-    checks.push(vec![
+    let mut Z_check = vec![
       (Z_x, (srs.X2A[0] * ft_a).into()),
       (
         (-(ssig_xs[ssig_xs.len() - 1] * beta + srs.X1A[0] * (fj_as[fj_as.len() - 1] + gamma)) * gt_a * Z_ga).into(),
         srs.X2A[0],
       ),
+      (((Z_x - srs.X1A[0]) * alpha * L0_a).into(), srs.X2A[0]),
       ((-t_x * (a_pows[N - 1] - Fr::one())).into(), srs.X2A[0]),
       (-r_Q_x, V_x),
-      (-C3, srs.Y2A),
-    ]);
+      (-C1, srs.Y2A),
+    ];
+    if has_none {
+      Z_check.push(((fj_xs[flat_none_idx] * alpha * alpha * Lnone_a).into(), srs.X2A[0]));
+    }
+    checks.push(Z_check);
 
     // Check opening commitments over a
     let bs = calc_pow(b, ssig_xs.len() + fj_xs.len());
@@ -505,13 +512,13 @@ impl BasicBlock for CopyConstraintBasicBlock {
     checks.push(vec![
       ((q1_x - srs.X1P[0] * q1_a).into(), srs.X2A[0]),
       (-q1_Q_x, V_x.into()),
-      (-C4, srs.Y2A),
+      (-C2, srs.Y2A),
     ]);
 
     // Check Z opening commitment
     let Z_ga_x: G1Affine = (srs.X1P[0] * Z_ga).into();
     let V_x: G2Affine = (srs.X2P[1] - srs.X2P[0] * omega * a).into();
-    checks.push(vec![((Z_x - Z_ga_x).into(), srs.X2A[0]), (-Z_Q_x, V_x.into()), (-C5, srs.Y2A)]);
+    checks.push(vec![((Z_x - Z_ga_x).into(), srs.X2A[0]), (-Z_Q_x, V_x.into()), (-C3, srs.Y2A)]);
     checks
   }
 }

--- a/src/basic_block/copy_constraint.rs
+++ b/src/basic_block/copy_constraint.rs
@@ -304,10 +304,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
 
     // Calculate batched quotient for Z(x)f'(x) = Z(gx)g'(x) and above checks
     let mut bytes = Vec::new();
-    let mut rng2 = StdRng::from_entropy();
-    let mut r: Vec<_> = vec![Fr::rand(&mut rng2)];
-    let proof = vec![Z_x];
-    let mut proof: Vec<_> = proof.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r[i]).collect();
+    let mut proof = vec![Z_x];
     proof.serialize_uncompressed(&mut bytes).unwrap();
     util::add_randomness(rng, bytes);
     let alpha = Fr::rand(rng);
@@ -340,12 +337,10 @@ impl BasicBlock for CopyConstraintBasicBlock {
     // Fiat-Shamir
     let mut bytes = Vec::new();
     let mut rng2 = StdRng::from_entropy();
-    let mut r1: Vec<_> = vec![Fr::rand(&mut rng2)];
-    let proof_1 = vec![t_x];
-    let mut proof_1: Vec<_> = proof_1.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r1[i]).collect();
+    let r = Fr::rand(&mut rng2);
+    let mut proof_1 = vec![t_x + srs.Y1P * r];
     proof_1.serialize_uncompressed(&mut bytes).unwrap();
     util::add_randomness(rng, bytes);
-    r.append(&mut r1);
     proof.append(&mut proof_1);
 
     let a = Fr::rand(rng);
@@ -395,15 +390,8 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let W_x = util::msm::<G1Projective>(&srs.X1A, &W_poly.coeffs);
 
     // Blinding
-    let u = Fr::rand(rng);
-    let mut r1: Vec<_> = (0..2).map(|_| Fr::rand(&mut rng2)).collect();
-    proof.append(&mut vec![W_x, W_gx].iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r1[i]).collect());
-    r.append(&mut r1);
-    let mut C: Vec<G1Projective> = vec![
-      srs.X1P[1] * (r[2] + r[3] * u)
-        - srs.X1P[0] * (r[2] * a + r[3] * u * omega * a + r[0] * (ft_a + alpha * L0_a + u) - r[1] * (a_pows[N - 1] - Fr::one())),
-    ];
-    proof.append(&mut C);
+    proof.append(&mut vec![W_x, W_gx]);
+    proof.push(srs.X1P[0] * (r * (a_pows[N - 1] - Fr::one())));
 
     let mut ssig_xs = setup.0[2..].iter().map(|x| Into::<G1Projective>::into(*x)).collect();
     proof.append(&mut ssig_xs);
@@ -438,7 +426,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     // constructors to use the blinding scheme when appropriate.
     let input = inputs[0];
 
-    let [Z_x, t_x, W_x, Z_Q_x, C1] = proof.0[..5] else {
+    let [Z_x, t_x, W_x, W_gx, C1] = proof.0[..5] else {
       panic!("Wrong proof format")
     };
 
@@ -473,6 +461,11 @@ impl BasicBlock for CopyConstraintBasicBlock {
     util::add_randomness(rng, bytes);
     let a = Fr::rand(rng);
     let b = Fr::rand(rng);
+
+    // Round 5 randomness
+    let mut bytes = Vec::new();
+    vec![W_x, W_gx].serialize_uncompressed(&mut bytes).unwrap();
+    util::add_randomness(rng, bytes);
     let u = Fr::rand(rng);
 
     // Get none index for Lnone(x)f(x) = V(x)Q(x) check
@@ -511,8 +504,8 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let r_0 = -L0_a * alpha - gt_a * (fj_as[fj_as.len() - 1] + gamma) * Z_ga;
     let E = srs.X1A[0] * (-r_0 + q1_a + u * Z_ga);
     checks.push(vec![
-      ((W_x + Z_Q_x * u).into(), srs.X2A[1]),
-      ((-(W_x * a + Z_Q_x * u * omega * a + F - E)).into(), srs.X2A[0]),
+      ((W_x + W_gx * u).into(), srs.X2A[1]),
+      ((-(W_x * a + W_gx * u * omega * a + F - E)).into(), srs.X2A[0]),
       (-C1, srs.Y2A),
     ]);
     checks

--- a/src/basic_block/copy_constraint.rs
+++ b/src/basic_block/copy_constraint.rs
@@ -360,7 +360,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     };
     let temp = Z_poly.sub(&Z_ga_poly);
     let Z_Q: DensePolynomial<_> = &temp / &Z_V;
-    let Z_Q_x = util::msm::<G1Projective>(&srs.X1A, &Z_Q.coeffs);
+    let W_gx = util::msm::<G1Projective>(&srs.X1A, &Z_Q.coeffs);
 
     // Calculate opening quotient for batched quotient check (containing r, fjs, ssigs on p. 30 of [1])
     let mut ssig_as: Vec<_> = ssig_polys.iter().map(|p| p.evaluate(&a)).collect();
@@ -383,29 +383,25 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let r_poly = &(&lhs - &rhs) - &v
       + Z_poly.sub(&one).mul(&DensePolynomial::from_coefficients_vec(vec![alpha * L0_a]))
       + fj_polys[fj_none_idx].mul(&DensePolynomial::from_coefficients_vec(vec![alpha * alpha * Lnone_a]));
-    let r_Q = &r_poly / &q1_V;
-    let r_Q_x = util::msm::<G1Projective>(&srs.X1A, &r_Q.coeffs);
 
-    // Calculate opening argument for fjs, ssigs over a
+    // Calculate opening argument for W over a (p. 30 of [1])
     let b = Fr::rand(rng);
     let bs = calc_pow(b, ssig_polys.len() + ft_polys.len());
     let q1_poly: DensePolynomial<Fr> =
       ssig_polys.iter().chain(fj_polys.iter()).enumerate().fold(DensePolynomial::zero(), |acc, (i, p)| acc + p.mul(bs[i]));
     let q1_a = q1_poly.evaluate(&a);
     let q1_a_poly = DensePolynomial { coeffs: vec![q1_a] };
-    let temp = q1_poly.sub(&q1_a_poly);
-    let q1_Q = &temp / &q1_V;
-    let q1_Q_x = util::msm::<G1Projective>(&srs.X1A, &q1_Q.coeffs);
+    let W_poly = &(q1_poly.sub(&q1_a_poly) + r_poly) / &q1_V;
+    let W_x = util::msm::<G1Projective>(&srs.X1A, &W_poly.coeffs);
 
     // Blinding
-    let mut r1: Vec<_> = (0..3).map(|_| Fr::rand(&mut rng2)).collect();
-    proof.append(&mut vec![q1_Q_x, Z_Q_x, r_Q_x].iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r1[i]).collect());
+    let u = Fr::rand(rng);
+    let mut r1: Vec<_> = (0..2).map(|_| Fr::rand(&mut rng2)).collect();
+    proof.append(&mut vec![W_x, W_gx].iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r1[i]).collect());
     r.append(&mut r1);
     let mut C: Vec<G1Projective> = vec![
-      srs.X1P[0] * ft_a * r[0] - srs.X1P[0] * (a_pows[N - 1] - Fr::one()) * r[1] + srs.X1P[0] * r[0] * alpha * L0_a
-        - (srs.X1P[1] - (srs.X1P[0] * a)) * r[4],
-      -(srs.X1P[1] - (srs.X1P[0] * a)) * r[2],
-      srs.X1P[0] * r[0] - (srs.X1P[1] - (srs.X1P[0] * a * omega)) * r[3],
+      srs.X1P[1] * (r[2] + r[3] * u)
+        - srs.X1P[0] * (r[2] * a + r[3] * u * omega * a + r[0] * (ft_a + alpha * L0_a + u) - r[1] * (a_pows[N - 1] - Fr::one())),
     ];
     proof.append(&mut C);
 
@@ -442,13 +438,13 @@ impl BasicBlock for CopyConstraintBasicBlock {
     // constructors to use the blinding scheme when appropriate.
     let input = inputs[0];
 
-    let [Z_x, t_x, q1_Q_x, Z_Q_x, r_Q_x, C1, C2, C3] = proof.0[..8] else {
+    let [Z_x, t_x, W_x, Z_Q_x, C1] = proof.0[..5] else {
       panic!("Wrong proof format")
     };
 
     let m = inputs[0].len() + outputs[0].len();
-    let ssig_xs = &proof.0[8..m + 8];
-    let fj_xs = &proof.0[m + 8..];
+    let ssig_xs = &proof.0[5..m + 5];
+    let fj_xs = &proof.0[m + 5..];
 
     // TODO: have verifier compute Lagrange basis evals
     let [Z_ga, L0_a, Lnone_a] = proof.2[..3] else {
@@ -477,6 +473,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     util::add_randomness(rng, bytes);
     let a = Fr::rand(rng);
     let b = Fr::rand(rng);
+    let u = Fr::rand(rng);
 
     // Get none index for Lnone(x)f(x) = V(x)Q(x) check
     let mut has_none = false;
@@ -490,47 +487,34 @@ impl BasicBlock for CopyConstraintBasicBlock {
       }
     }
 
-    // Check t polynomial batched quotient
+    // Perform the batched check (p. 31 of [1])
     let ft_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| beta * Fr::from((i + 1) as i32) * a + *x + gamma).collect();
     let gt_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| ssig_as[i] * beta + *x + gamma).collect();
     let ft_a: Fr = ft_as.iter().product();
+    // Contains all but the last
     let gt_a: Fr = gt_as[..gt_as.len() - 1].iter().product();
     let a_pows = calc_pow(a, N);
-    let V_x: G2Affine = (srs.X2P[1] - srs.X2P[0] * a).into();
-    let mut Z_check = vec![
-      (Z_x, (srs.X2A[0] * ft_a).into()),
-      (
-        (-(ssig_xs[ssig_xs.len() - 1] * beta + srs.X1A[0] * (fj_as[fj_as.len() - 1] + gamma)) * gt_a * Z_ga).into(),
-        srs.X2A[0],
-      ),
-      (((Z_x - srs.X1A[0]) * alpha * L0_a).into(), srs.X2A[0]),
-      ((-t_x * (a_pows[N - 1] - Fr::one())).into(), srs.X2A[0]),
-      (-r_Q_x, V_x),
-      (-C1, srs.Y2A),
-    ];
-    if has_none {
-      Z_check.push(((fj_xs[fj_none_idx] * alpha * alpha * Lnone_a).into(), srs.X2A[0]));
-    }
-    checks.push(Z_check);
 
-    // Check opening commitments over a
+    let mut D = Z_x * (ft_a + alpha * L0_a + u) - ssig_xs[ssig_xs.len() - 1] * beta * gt_a * Z_ga - t_x * (a_pows[N - 1] - Fr::one());
+    if has_none {
+      D = D + fj_xs[fj_none_idx] * alpha * alpha * Lnone_a;
+    }
+
     let bs = calc_pow(b, ssig_xs.len() + fj_xs.len());
     let q1_x: G1Projective = ssig_xs
       .iter()
       .chain(fj_xs.iter())
       .enumerate()
       .fold(G1Projective::zero(), |acc, (i, x)| acc + Into::<G1Projective>::into(*x) * bs[i]);
+    let F = D + q1_x;
     let q1_a: Fr = q1_evals.iter().enumerate().fold(Fr::zero(), |acc, (i, x)| acc + *x * bs[i]);
+    let r_0 = -L0_a * alpha - gt_a * (fj_as[fj_as.len() - 1] + gamma) * Z_ga;
+    let E = srs.X1A[0] * (-r_0 + q1_a + u * Z_ga);
     checks.push(vec![
-      ((q1_x - srs.X1P[0] * q1_a).into(), srs.X2A[0]),
-      (-q1_Q_x, V_x.into()),
-      (-C2, srs.Y2A),
+      ((W_x + Z_Q_x * u).into(), srs.X2A[1]),
+      ((-(W_x * a + Z_Q_x * u * omega * a + F - E)).into(), srs.X2A[0]),
+      (-C1, srs.Y2A),
     ]);
-
-    // Check Z opening commitment over omega * a
-    let Z_ga_x: G1Affine = (srs.X1P[0] * Z_ga).into();
-    let V_x: G2Affine = (srs.X2P[1] - srs.X2P[0] * omega * a).into();
-    checks.push(vec![((Z_x - Z_ga_x).into(), srs.X2A[0]), (-Z_Q_x, V_x.into()), (-C3, srs.Y2A)]);
     checks
   }
 }

--- a/src/basic_block/copy_constraint.rs
+++ b/src/basic_block/copy_constraint.rs
@@ -326,6 +326,8 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let g1_poly = gt_polys.iter().fold(DensePolynomial::from_coefficients_vec(vec![Fr::one()]), |acc, x| acc.mul(x));
     let t_poly = f1_poly.mul(&Z_poly).sub(&g1_poly.mul(&Zg_poly));
     let t_poly = t_poly.divide_by_vanishing_poly(domain).unwrap().0;
+    // TODO: We currently commit t entirely instead of splitting it into
+    // smaller polynomials of degree <n done in the Plonk paper.
     let t_x = util::msm::<G1Projective>(&srs.X1A, &t_poly.coeffs);
 
     // Round 2: openings

--- a/src/basic_block/copy_constraint.rs
+++ b/src/basic_block/copy_constraint.rs
@@ -325,7 +325,6 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let gt_polys: Vec<_> = fj_polys.iter().enumerate().map(|(i, x)| &ssig_polys[i].mul(&beta_poly) + x + gamma_poly.clone()).collect();
     let g1_poly = gt_polys.iter().fold(DensePolynomial::from_coefficients_vec(vec![Fr::one()]), |acc, x| acc.mul(x));
     let t_poly = f1_poly.mul(&Z_poly).sub(&g1_poly.mul(&Zg_poly));
-
     let t_poly = t_poly.divide_by_vanishing_poly(domain).unwrap().0;
     let t_x = util::msm::<G1Projective>(&srs.X1A, &t_poly.coeffs);
 
@@ -471,7 +470,6 @@ impl BasicBlock for CopyConstraintBasicBlock {
     // Check Z(x)f'(x) = Z(gx)g'(x)
     let ft_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| beta * Fr::from((i + 1) as i32) * a + *x + gamma).collect();
     let gt_as: Vec<_> = fj_as.iter().enumerate().map(|(i, x)| ssig_as[i] * beta + *x + gamma).collect();
-
     let ft_a: Fr = ft_as.iter().product();
     let gt_a: Fr = gt_as[..gt_as.len() - 1].iter().product();
     let a_pows = calc_pow(a, N);
@@ -494,9 +492,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
       .chain(fj_xs.iter())
       .enumerate()
       .fold(G1Projective::zero(), |acc, (i, x)| acc + Into::<G1Projective>::into(*x) * bs[i]);
-
     let q1_a: Fr = q1_evals.iter().enumerate().fold(Fr::zero(), |acc, (i, x)| acc + *x * bs[i]);
-
     checks.push(vec![
       ((q1_x - srs.X1P[0] * q1_a).into(), srs.X2A[0]),
       (-q1_Q_x, V_x.into()),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -44,6 +44,8 @@ fn testBasicBlock<BB: BasicBlock>(mut basic_block: BB, srs: &SRS, model: &ArrayD
   let pairings = pairings.iter().map(|x| x).collect();
   let pairings = util::combine_pairing_checks(&pairings);
   assert_eq!(Bn254::multi_pairing(pairings.0.iter(), pairings.1.iter()), PairingOutput::zero());
+  // Check that prove and verify end with the same rng state
+  assert_eq!(Fr::rand(&mut rng), Fr::rand(&mut rng2));
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -95,12 +95,25 @@ fn testBasicBlocks() {
 fn test_copy_constraint() {
   let srs = &ptau::load_file("challenge", 7, 7);
   let empty = ArrayD::zeros(IxDyn(&[0]));
-  // output dim padding
+  // reverse
   testBasicBlock(
     CopyConstraintBasicBlock {
-      permutation: ArrayD::from_shape_vec(vec![2, 2], vec![IxDyn(&[1, 1]), IxDyn(&[1, 0]), IxDyn(&[1, 0]), IxDyn(&[0, 0])]).unwrap(),
+      permutation: ArrayD::from_shape_vec(vec![4], vec![Some(IxDyn(&[3])), Some(IxDyn(&[2])), Some(IxDyn(&[1])), Some(IxDyn(&[0]))]).unwrap(),
+      input_dim: IxDyn(&[4]),
+    },
+    srs,
+    &empty,
+    &vec![&ArrayD::from_shape_vec(vec![4], (1..5).map(|x| Fr::from(x)).collect()).unwrap()],
+  );
+  // transpose
+  testBasicBlock(
+    CopyConstraintBasicBlock {
+      permutation: ArrayD::from_shape_vec(
+        vec![2, 2],
+        vec![Some(IxDyn(&[1, 1])), Some(IxDyn(&[1, 0])), Some(IxDyn(&[0, 1])), Some(IxDyn(&[0, 0]))],
+      )
+      .unwrap(),
       input_dim: IxDyn(&[2, 2]),
-      output_dim: IxDyn(&[2, 2]),
     },
     srs,
     &empty,
@@ -112,54 +125,79 @@ fn test_copy_constraint() {
       permutation: ArrayD::from_shape_vec(
         vec![2, 2, 4],
         vec![
-          IxDyn(&[1, 1]),
-          IxDyn(&[2, 0]),
-          IxDyn(&[3, 1]),
-          IxDyn(&[0, 0]),
-          IxDyn(&[1, 1]),
-          IxDyn(&[2, 0]),
-          IxDyn(&[3, 1]),
-          IxDyn(&[0, 0]),
-          IxDyn(&[1, 1]),
-          IxDyn(&[2, 0]),
-          IxDyn(&[3, 1]),
-          IxDyn(&[0, 0]),
-          IxDyn(&[1, 1]),
-          IxDyn(&[2, 0]),
-          IxDyn(&[3, 1]),
-          IxDyn(&[0, 0]),
+          Some(IxDyn(&[1, 1])),
+          Some(IxDyn(&[2, 0])),
+          Some(IxDyn(&[3, 1])),
+          Some(IxDyn(&[0, 0])),
+          Some(IxDyn(&[1, 1])),
+          Some(IxDyn(&[2, 0])),
+          Some(IxDyn(&[3, 1])),
+          Some(IxDyn(&[0, 0])),
+          Some(IxDyn(&[1, 1])),
+          Some(IxDyn(&[2, 0])),
+          Some(IxDyn(&[3, 1])),
+          Some(IxDyn(&[0, 0])),
+          Some(IxDyn(&[1, 1])),
+          Some(IxDyn(&[2, 0])),
+          Some(IxDyn(&[3, 1])),
+          Some(IxDyn(&[0, 0])),
         ],
       )
       .unwrap(),
       input_dim: IxDyn(&[4, 2]),
-      output_dim: IxDyn(&[2, 2, 4]),
     },
     srs,
     &empty,
     &vec![&ArrayD::from_shape_vec(vec![4, 2], (1..9).map(|x| Fr::from(x)).collect()).unwrap()],
   );
-  // 3d -> 2d
+  // 3d -> 2d with padding
   testBasicBlock(
     CopyConstraintBasicBlock {
       permutation: ArrayD::from_shape_vec(
-        vec![4, 2],
+        vec![4, 4],
         vec![
-          IxDyn(&[1, 1, 0]),
-          IxDyn(&[1, 0, 1]),
-          IxDyn(&[0, 1, 0]),
-          IxDyn(&[0, 0, 0]),
-          IxDyn(&[0, 1, 0]),
-          IxDyn(&[1, 1, 0]),
-          IxDyn(&[0, 1, 1]),
-          IxDyn(&[0, 0, 0]),
+          Some(IxDyn(&[1, 1, 0])),
+          Some(IxDyn(&[1, 0, 1])),
+          Some(IxDyn(&[0, 1, 0])),
+          None,
+          Some(IxDyn(&[0, 0, 0])),
+          Some(IxDyn(&[0, 1, 0])),
+          Some(IxDyn(&[1, 1, 0])),
+          None,
+          Some(IxDyn(&[0, 1, 1])),
+          Some(IxDyn(&[0, 0, 0])),
+          Some(IxDyn(&[1, 0, 1])),
+          None,
+          None,
+          None,
+          None,
+          None,
         ],
       )
       .unwrap(),
       input_dim: IxDyn(&[2, 2, 4]),
-      output_dim: IxDyn(&[4, 2]),
     },
     srs,
     &empty,
     &vec![&ArrayD::from_shape_vec(vec![2, 2, 4], (1..17).map(|x| Fr::from(x)).collect()).unwrap()],
+  );
+  // slice
+  testBasicBlock(
+    CopyConstraintBasicBlock {
+      permutation: ArrayD::from_shape_vec(
+        vec![1, 1, 4],
+        vec![
+          Some(IxDyn(&[0, 0, 0])),
+          Some(IxDyn(&[0, 0, 1])),
+          Some(IxDyn(&[0, 0, 2])),
+          Some(IxDyn(&[0, 0, 3])),
+        ],
+      )
+      .unwrap(),
+      input_dim: IxDyn(&[2, 1, 4]),
+    },
+    srs,
+    &empty,
+    &vec![&ArrayD::from_shape_vec(vec![2, 1, 4], (1..9).map(|x| Fr::from(x)).collect()).unwrap()],
   );
 }


### PR DESCRIPTION
Includes the padding support from #43 and implements the missing blinding for the input, output, and Z polynomials from #45. 

In order to do the latter, we change the terms in input, output, Z, t, r polynomials to match those found in Section 8 of the Plonk paper, but for now t and r only contain terms relevant to the f'(x)Z(x) = g'(x)(Zwx) check and will match the paper once we fully implement quotient batching. Batching will be completed in another commit or PR.

Would appreciate suggestions for tests based on other shape operations we need.