### PR TITLE
Refactor onnx

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -30,13 +30,13 @@ impl Graph {
       let myInputs = n
         .inputs
         .iter()
-        .map(|&(j, k)| {
-          if j < 0 {
+        .map(|(basicblock_idx, output_idx)| {
+          if *basicblock_idx < 0 {
             // We currently support two types of indexing for the inputs, one is (-1,0),(-1,1),(-1,2),...
             // and the other is (-1,0),(-2,0),(-3,0),... In the future we will make this more standardized.
-            inputs[k + (-j - 1) as usize]
+            inputs[*output_idx + (-basicblock_idx - 1) as usize]
           } else {
-            &(outputs[j as usize][k])
+            &(outputs[*basicblock_idx as usize][*output_idx])
           }
         })
         .collect();
@@ -55,7 +55,17 @@ impl Graph {
     let mut outputsEnc = vec![vec![]; self.nodes.len()];
     self.nodes.iter().enumerate().for_each(|(i, n)| {
       println!("encoding {i} {:?}", self.basic_blocks[n.basic_block]);
-      let myInputs = n.inputs.iter().map(|(j, k)| if *j < 0 { inputs[*k] } else { &(outputsEnc[*j as usize][*k]) }).collect();
+      let myInputs = n
+        .inputs
+        .iter()
+        .map(|(basicblock_idx, output_idx)| {
+          if *basicblock_idx < 0 {
+            inputs[*output_idx + (-basicblock_idx - 1) as usize]
+          } else {
+            &(outputsEnc[*basicblock_idx as usize][*output_idx])
+          }
+        })
+        .collect();
       outputsEnc[i] = self.basic_blocks[n.basic_block].encodeOutputs(srs, &models[n.basic_block], &myInputs, outputs[i]);
     });
     return outputsEnc;
@@ -90,7 +100,17 @@ impl Graph {
       .enumerate()
       .map(|(i, n)| {
         println!("proving {i} {:?}", self.basic_blocks[n.basic_block]);
-        let myInputs: Vec<&ArrayD<Data>> = n.inputs.iter().map(|(j, k)| if *j < 0 { inputs[*k] } else { &(outputs[*j as usize][*k]) }).collect();
+        let myInputs = n
+          .inputs
+          .iter()
+          .map(|(basicblock_idx, output_idx)| {
+            if *basicblock_idx < 0 {
+              inputs[*output_idx + (-basicblock_idx - 1) as usize]
+            } else {
+              &(outputs[*basicblock_idx as usize][*output_idx])
+            }
+          })
+          .collect();
         let proof = self.basic_blocks[n.basic_block].prove(srs, setups[n.basic_block], models[n.basic_block], &myInputs, outputs[i], rng, &mut cache);
         let proof: (Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>) = (
           proof.0.iter().map(|x| (*x).into()).collect(),
@@ -121,7 +141,17 @@ impl Graph {
       .enumerate()
       .map(|(i, n)| {
         println!("verifying {i} {:?}", self.basic_blocks[n.basic_block]);
-        let myInputs = n.inputs.iter().map(|(j, k)| if *j < 0 { inputs[*k] } else { &(outputs[*j as usize][*k]) }).collect();
+        let myInputs = n
+          .inputs
+          .iter()
+          .map(|(basicblock_idx, output_idx)| {
+            if *basicblock_idx < 0 {
+              inputs[*output_idx + (-basicblock_idx - 1) as usize]
+            } else {
+              &(outputs[*basicblock_idx as usize][*output_idx])
+            }
+          })
+          .collect();
         let pairings = self.basic_blocks[n.basic_block].verify(srs, models[n.basic_block], &myInputs, outputs[i], proofs[i], rng, &mut cache);
         let mut bytes = Vec::new();
         let temp: (Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>) = (proofs[i].0.clone(), proofs[i].1.clone(), proofs[i].2.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use ark_poly::univariate::DensePolynomial;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use basic_block::*;
 use ndarray::ArrayD;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, SeedableRng};
 use rayon::prelude::*;
 use sha3::{Digest, Keccak256};
 use std::fs::{self, File};
@@ -109,11 +109,8 @@ fn verify(srs: &SRS, graph: &Graph) {
 
 fn main() {
   let srs = &ptau::load_file("challenge", 7, 7);
-  let (mut graph, models) = onnx::load_file("sample.onnx");
-  let mut rng = StdRng::from_entropy();
-  let input: Vec<Fr> = (0..4).map(|_| Fr::from(rng.gen_range(-4..4))).collect();
-  let input = ArrayD::from_shape_vec(vec![1, 4], input).unwrap();
-  let inputs = vec![&input];
+  let (mut graph, models, fake_inputs) = onnx::load_file("sample.onnx");
+  let inputs = fake_inputs.iter().map(|x| x).collect();
   let models = models.iter().map(|x| x).collect();
   prove(&srs, &inputs, &mut graph, &models);
   verify(&srs, &graph);

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,9 @@ fn verify(srs: &SRS, graph: &Graph) {
 
 fn main() {
   let srs = &ptau::load_file("challenge", 7, 7);
-  let (mut graph, models, fake_inputs) = onnx::load_file("sample.onnx");
+  let onnx_file_name = "sample.onnx";
+  let (mut graph, models) = onnx::load_file(onnx_file_name);
+  let fake_inputs = util::generate_fake_inputs_for_onnx(onnx_file_name);
   let inputs = fake_inputs.iter().map(|x| x).collect();
   let models = models.iter().map(|x| x).collect();
   prove(&srs, &inputs, &mut graph, &models);

--- a/src/onnx.rs
+++ b/src/onnx.rs
@@ -4,7 +4,10 @@ use crate::layer::*;
 use crate::util;
 use ark_bn254::Fr;
 use ndarray::{arr1, ArrayD};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::collections::HashMap;
+use tract_onnx::pb;
+use tract_onnx::pb::AttributeProto;
 use tract_onnx::prelude::{DatumType, Framework};
 use tract_onnx::tensor::load_tensor;
 
@@ -14,12 +17,11 @@ pub const SF_FLOAT: f32 = (1 << SF_LOG) as f32;
 pub const CQ_RANGE: usize = 1 << 6; //12
 pub const CQ_RANGE_LOWER: i32 = -(1 << 5);
 
-pub fn load_file(filename: &str) -> (Graph, Vec<ArrayD<Fr>>) {
-  let onnx = tract_onnx::onnx();
-  let onnx_graph = onnx.proto_model_for_path(filename).unwrap().graph.unwrap();
-
+// This function is used for parsing the inputs of onnx models
+fn parse_onnx_inputs(onnx_graph: &pb::GraphProto) -> (HashMap<String, usize>, HashMap<String, Vec<usize>>) {
   let mut input_idx = HashMap::new();
   let mut shapes = HashMap::new();
+
   for (idx, i) in onnx_graph.input.iter().enumerate() {
     input_idx.insert(i.name.clone(), idx);
     let tract_onnx::pb::type_proto::Value::TensorType(t) = i.r#type.as_ref().unwrap().value.as_ref().unwrap();
@@ -31,25 +33,29 @@ pub fn load_file(filename: &str) -> (Graph, Vec<ArrayD<Fr>>) {
         .dim
         .iter()
         .map(|x| {
-          let tract_onnx::pb::tensor_shape_proto::dimension::Value::DimValue(x) = x.value.as_ref().unwrap() else {
-            panic!("unknown dimension")
-          };
-          *x as usize
+          if let tract_onnx::pb::tensor_shape_proto::dimension::Value::DimValue(x) = x.value.as_ref().unwrap() {
+            *x as usize
+          } else {
+            panic!("Unknown dimension") // we currently can only support constant dimensions
+          }
         })
         .collect::<Vec<_>>(),
     );
   }
 
-  let mut graph = Graph {
-    basic_blocks: vec![],
-    nodes: vec![],
-    outputs: vec![],
-  };
-  let mut basic_blocks_idx: HashMap<String, usize> = HashMap::new(); // BasicBlock to graph.basic_blocks index
-  let mut outputs_idx: HashMap<String, Vec<(i32, usize)>> = HashMap::new(); // Graph node name to graph.nodes outputs
-  let mut setups = vec![];
+  (input_idx, shapes)
+}
 
-  let mut idx = 0;
+// This function is used for parsing the constants of onnx models
+fn parse_onnx_constants<'a>(
+  onnx_graph: &'a pb::GraphProto,
+  shapes: &mut HashMap<String, Vec<usize>>,
+) -> (
+  impl Iterator<Item = (String, &'a pb::TensorProto)> + 'a,
+  HashMap<String, usize>,
+  Vec<ArrayD<Fr>>,
+) {
+  let onnx = tract_onnx::onnx();
   let constants = onnx_graph.initializer.iter().map(|tensor| (tensor.name.clone(), tensor)).chain(
     onnx_graph
       .node
@@ -57,20 +63,19 @@ pub fn load_file(filename: &str) -> (Graph, Vec<ArrayD<Fr>>) {
       .filter(|node| node.op_type == "Constant")
       .map(|node| (node.output[0].clone(), node.attribute[0].t.as_ref().unwrap())),
   );
+
   let mut constants_hashmap = HashMap::new();
-  for (name, tensor) in constants {
+  let mut setups = Vec::new();
+  let mut idx = 0;
+
+  for (name, tensor) in constants.clone() {
     let tensor = load_tensor(&*onnx.provider, tensor, None).unwrap();
     let tensor = match tensor.datum_type() {
       DatumType::F32 => {
         let tensor = tensor.into_array::<f32>().unwrap();
         Ok(tensor.map(|x| {
           let mut y = (*x * SF_FLOAT).round();
-          if y < -(1 << 15) as f32 {
-            y = -(1 << 15) as f32;
-          }
-          if y > (1 << 15) as f32 {
-            y = (1 << 15) as f32;
-          }
+          y = y.clamp(-(1 << 15) as f32, (1 << 15) as f32);
           Fr::from(y as i32)
         }))
       }
@@ -81,108 +86,240 @@ pub fn load_file(filename: &str) -> (Graph, Vec<ArrayD<Fr>>) {
       _ => Err(format!("Unsupported constant type: {:?}", tensor.datum_type())),
     }
     .unwrap();
+
     shapes.insert(name.clone(), tensor.shape().to_vec());
     let tensor = util::pad(&tensor);
+    constants_hashmap.insert(name.clone(), idx);
+    setups.push(tensor);
+    idx += 1;
+  }
+
+  (constants, constants_hashmap, setups)
+}
+
+// This function is used for creating the output indices for constants of onnx models
+fn create_output_indices<'a>(
+  constants: impl Iterator<Item = (String, &'a pb::TensorProto)>,
+  graph: &mut Graph,
+) -> HashMap<String, Vec<(i32, usize)>> {
+  let mut outputs_idx = HashMap::new();
+
+  for (name, _) in constants {
     outputs_idx.insert(name.clone(), vec![(graph.basic_blocks.len() as i32, 0)]);
     graph.nodes.push(Node {
       basic_block: graph.basic_blocks.len(),
       inputs: vec![],
     });
-    // We are currently have a ConstBasicBlock followed by a MatMulBasicBlock.
-    // In the future, we can prune the Graph so that this is replaced by one CQLinBasicBlock.
     graph.basic_blocks.push(Box::new(ConstBasicBlock {}));
-    setups.push(tensor);
-    constants_hashmap.insert(name, idx);
-    idx += 1;
   }
+
+  outputs_idx
+}
+
+// This function is used for generating fake inputs for onnx models
+// It is only for testing purposes
+fn generate_fake_inputs_for_onnx(onnx_graph: &pb::GraphProto) -> Vec<ArrayD<Fr>> {
+  let mut rng = StdRng::from_entropy();
+
+  let mut inputs = vec![];
+
+  for onnx_input in onnx_graph.input.iter() {
+    let tract_onnx::pb::type_proto::Value::TensorType(t) = onnx_input.r#type.as_ref().unwrap().value.as_ref().unwrap();
+    let shape = t
+      .shape
+      .as_ref()
+      .unwrap()
+      .dim
+      .iter()
+      .map(|x| {
+        if let tract_onnx::pb::tensor_shape_proto::dimension::Value::DimValue(x) = x.value.as_ref().unwrap() {
+          *x as usize
+        } else {
+          panic!("Unknown dimension")
+        }
+      })
+      .collect::<Vec<_>>();
+    let val_num = &shape.iter().fold(1, |acc, x| acc * x);
+
+    let input: Vec<Fr> = (0..*val_num).map(|_| Fr::from(rng.gen_range(-2..2))).collect();
+    let input = ArrayD::from_shape_vec(shape, input).unwrap();
+    let input = util::pad(&input);
+    inputs.push(input);
+  }
+  inputs
+}
+
+// This function is used for getting the local graph for each layer
+fn get_local_graph(
+  op: &str,
+  input_shapes: &Vec<&Vec<usize>>,
+  my_constants: &Vec<Option<&ArrayD<Fr>>>,
+  my_attributes: Vec<&AttributeProto>,
+) -> (Graph, Vec<Vec<usize>>) {
+  match op {
+    "Add" => Ok(AddLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Mul" => Ok(MulLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Cast" => Ok(CastLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Sub" => Ok(SubLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "MatMul" => Ok(MatMulLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Relu" => Ok(ReLULayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Gather" => Ok(GatherLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "ReduceMean" => Ok(ReduceMeanLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Pow" => Ok(PowLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Div" => Ok(DivLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Sqrt" => Ok(SqrtLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Reshape" => Ok(ReshapeLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Transpose" => Ok(TransposeLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Shape" => Ok(ShapeLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Equal" => Ok(EqualLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Where" => Ok(WhereLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Expand" => Ok(ExpandLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Softmax" => Ok(SoftmaxLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Erf" => Ok(ErfLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    _ => Err(format!("Unsupported onnx operation: {op}")),
+  }
+  .unwrap()
+}
+
+// This function is used for updating the graph of onnx after creating the local graph
+fn update_graph(
+  graph: &mut Graph,
+  local_graph: Graph,
+  node: &pb::NodeProto,
+  input_idx: &HashMap<String, usize>,
+  outputs_idx: &mut HashMap<String, Vec<(i32, usize)>>,
+  basic_blocks_idx: &mut HashMap<String, usize>,
+  setups: &mut Vec<ArrayD<Fr>>,
+) {
+  let mut local_block_idx = vec![];
+  let temp = local_graph.basic_blocks;
+  for basic_block in temp.into_iter() {
+    let name = format!("{basic_block:?}");
+    let idx = *basic_blocks_idx.entry(name).or_insert_with(|| graph.basic_blocks.len());
+    local_block_idx.push(idx);
+    if idx == graph.basic_blocks.len() {
+      setups.push(basic_block.genModel());
+      graph.basic_blocks.push(basic_block);
+    }
+  }
+  let start_idx = graph.nodes.len() as i32;
+  for local_node in local_graph.nodes.iter() {
+    // filter out node input that are ""
+    let node_input = &node.input.iter().filter(|x| x as &str != "").collect::<Vec<_>>();
+    graph.nodes.push(Node {
+      basic_block: local_block_idx[local_node.basic_block],
+      inputs: local_node
+        .inputs
+        .iter()
+        .map(|(x, y)| {
+          if x < &0 {
+            let input_tag = node_input[(-x - 1) as usize];
+            if input_idx.contains_key(input_tag) {
+              (-(*input_idx.get(input_tag).unwrap() as i32) - 1, *y)
+            } else {
+              outputs_idx[input_tag][*y]
+            }
+          } else {
+            (start_idx + *x, *y)
+          }
+        })
+        .collect(),
+    });
+  }
+  for (i, output) in node.output.iter().enumerate() {
+    let local_output = local_graph.outputs[i];
+    outputs_idx.insert(output.clone(), vec![(start_idx + local_output.0, local_output.1)]);
+  }
+}
+
+// This function is used for processing a layer of onnx models
+fn process_node(
+  node: &pb::NodeProto,
+  graph: &mut Graph,
+  shapes: &mut HashMap<String, Vec<usize>>,
+  constants_hashmap: &HashMap<String, usize>,
+  setups: &mut Vec<ArrayD<Fr>>,
+  passed_constants: &mut HashMap<String, ArrayD<Fr>>,
+  input_idx: &HashMap<String, usize>,
+  outputs_idx: &mut HashMap<String, Vec<(i32, usize)>>,
+  basic_blocks_idx: &mut HashMap<String, usize>,
+) {
+  // match onnx operation
+  let op = node.op_type.as_str();
+  let input_shapes: Vec<_> = node.input.iter().map(|x| shapes.get(x)).collect();
+  let input_shapes = input_shapes.into_iter().filter_map(|x| x).collect::<Vec<_>>(); // hack: we ignore optional inputs
+  let my_constants = node.input.iter().map(|x| passed_constants.get(x).or(constants_hashmap.get(x).map(|&y| &setups[y]))).collect();
+  let my_attributes = node.attribute.iter().map(|x| x).collect();
+  let (local_graph, output_shapes) = get_local_graph(op, &input_shapes, &my_constants, my_attributes);
+
+  // compute precomputable constants
+  if my_constants.iter().all(|&x| x.is_some()) {
+    let my_inputs: Vec<_> = my_constants.iter().map(|&x| x.unwrap().clone()).collect();
+    let my_inputs = my_inputs.iter().map(|x| x).collect();
+    let outputs = local_graph.run(&my_inputs, &vec![&arr1(&[]).into_dyn(); local_graph.basic_blocks.len()]);
+    node
+      .output
+      .iter()
+      .zip(local_graph.outputs.iter())
+      .zip(output_shapes.clone())
+      .for_each(|((output_str, &(nodeX, nodeY)), output_shape)| {
+        passed_constants.insert(
+          output_str.to_string(),
+          util::slice_nd_array(outputs[nodeX as usize][nodeY].clone(), &output_shape), // no need to pad for precomputable constants
+        );
+      });
+  }
+
+  // update graph with local graph
+  update_graph(graph, local_graph, node, &input_idx, outputs_idx, basic_blocks_idx, setups);
+
+  // handle a special case (op == "Shape")
+  if op == "Shape" {
+    passed_constants.insert(
+      (&node.output[0]).to_string(),
+      arr1(&input_shapes[0].iter().map(|&x| Fr::from(x as i32)).collect::<Vec<_>>()).into_dyn(),
+    );
+  }
+
+  // update shapes
+  node.output.iter().zip(output_shapes).for_each(|(output, shape)| {
+    shapes.insert(output.clone(), shape);
+  });
+}
+
+// This function is used for loading onnx models and returning the graph, setups, and fake inputs
+pub fn load_file(filename: &str) -> (Graph, Vec<ArrayD<Fr>>, Vec<ArrayD<Fr>>) {
+  let onnx = tract_onnx::onnx();
+  let onnx_graph = onnx.proto_model_for_path(filename).unwrap().graph.unwrap();
+
+  let (input_idx, mut shapes) = parse_onnx_inputs(&onnx_graph);
+  let (constants, constants_hashmap, mut setups) = parse_onnx_constants(&onnx_graph, &mut shapes);
+
+  let mut graph = Graph {
+    basic_blocks: vec![],
+    nodes: vec![],
+    outputs: vec![],
+  };
+  let mut outputs_idx = create_output_indices(constants, &mut graph);
+
+  let mut basic_blocks_idx = HashMap::new();
   let mut passed_constants = HashMap::new();
 
   for node in onnx_graph.node.iter().filter(|node| node.op_type.as_str() != "Constant") {
-    let op = node.op_type.as_str();
-    let input_shapes: Vec<_> = node.input.iter().map(|x| &shapes[x]).collect();
-    let my_constants = node.input.iter().map(|x| passed_constants.get(x).or(constants_hashmap.get(x).map(|&y| &setups[y]))).collect();
-    let my_attributes = node.attribute.iter().map(|x| x).collect();
-    let (mut local_graph, output_shapes) = match op {
-      "Add" => Ok(AddLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "Mul" => Ok(MulLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "Cast" => Ok(CastLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "Sub" => Ok(SubLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "MatMul" => Ok(MatMulLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "Relu" => Ok(ReLULayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "Gather" => Ok(GatherLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "ReduceMean" => Ok(ReduceMeanLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "Pow" => Ok(PowLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "Div" => Ok(DivLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "Sqrt" => Ok(SqrtLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "Reshape" => Ok(ReshapeLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "Transpose" => Ok(TransposeLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "Shape" => Ok(ShapeLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "Equal" => Ok(EqualLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "Where" => Ok(WhereLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "Expand" => Ok(ExpandLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "Softmax" => Ok(SoftmaxLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      "Erf" => Ok(ErfLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-      _ => Err(format!("Unsupported onnx operation: {op}")),
-    }
-    .unwrap();
-
-    if my_constants.iter().all(|&x| x.is_some()) {
-      let my_inputs: Vec<_> = my_constants.iter().map(|&x| x.unwrap().clone()).collect();
-      let my_inputs = my_inputs.iter().map(|x| x).collect();
-      let outputs = local_graph.run(&my_inputs, &vec![&arr1(&[]).into_dyn(); local_graph.basic_blocks.len()]);
-      node.output.iter().zip(local_graph.outputs.iter()).for_each(|(output_str, &(nodeX, nodeY))| {
-        passed_constants.insert(output_str, outputs[nodeX as usize][nodeY].clone());
-      });
-    }
-
-    let mut local_block_idx = vec![];
-    let temp = local_graph.basic_blocks;
-    local_graph.basic_blocks = vec![];
-    for basic_block in temp.into_iter() {
-      let name = format!("{basic_block:?}");
-      let idx = *basic_blocks_idx.entry(name).or_insert_with(|| graph.basic_blocks.len());
-      local_block_idx.push(idx);
-      if idx == graph.basic_blocks.len() {
-        setups.push(basic_block.genModel());
-        graph.basic_blocks.push(basic_block);
-      }
-    }
-    let start_idx = graph.nodes.len() as i32;
-    for local_node in local_graph.nodes.iter() {
-      graph.nodes.push(Node {
-        basic_block: local_block_idx[local_node.basic_block],
-        inputs: local_node
-          .inputs
-          .iter()
-          .map(|(x, y)| {
-            if x < &0 {
-              let input_tag = &node.input[(-x - 1) as usize];
-              if input_idx.contains_key(input_tag) {
-                (-(*input_idx.get(input_tag).unwrap() as i32) - 1, *y)
-              } else {
-                outputs_idx[input_tag][*y]
-              }
-            } else {
-              (start_idx + *x, *y)
-            }
-          })
-          .collect(),
-      });
-    }
-    outputs_idx.insert(
-      node.output[0].clone(),
-      local_graph.outputs.iter().map(|(x, y)| (start_idx + x, *y)).collect(),
+    process_node(
+      node,
+      &mut graph,
+      &mut shapes,
+      &constants_hashmap,
+      &mut setups,
+      &mut passed_constants,
+      &input_idx,
+      &mut outputs_idx,
+      &mut basic_blocks_idx,
     );
-    if op == "Shape" {
-      passed_constants.insert(
-        &node.output[0],
-        arr1(&input_shapes[0].iter().map(|&x| Fr::from(x as i32)).collect::<Vec<_>>()).into_dyn(),
-      );
-    }
-    node.output.iter().zip(output_shapes).for_each(|(output, shape)| {
-      shapes.insert(output.clone(), shape);
-    });
   }
 
-  (graph, setups)
+  let fake_inputs = generate_fake_inputs_for_onnx(&onnx_graph);
+
+  (graph, setups, fake_inputs)
 }

--- a/src/onnx.rs
+++ b/src/onnx.rs
@@ -4,10 +4,8 @@ use crate::layer::*;
 use crate::util;
 use ark_bn254::Fr;
 use ndarray::{arr1, ArrayD};
-use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::collections::HashMap;
 use tract_onnx::pb;
-use tract_onnx::pb::tensor_proto::DataType;
 use tract_onnx::pb::AttributeProto;
 use tract_onnx::prelude::{DatumType, Framework};
 use tract_onnx::tensor::load_tensor;
@@ -117,48 +115,6 @@ fn create_output_indices<'a>(
   outputs_idx
 }
 
-// This function is used for generating fake inputs for onnx models
-// Fake inputs are random field (i.e., Fr) elements whose shapes and types match those described in the input tensors of an ONNX model.
-// Generating these when loading an ONNX file saves us from creating different input tensors ourselves when testing new ONNX.
-// It is only for testing purposes
-fn generate_fake_inputs_for_onnx(onnx_graph: &pb::GraphProto) -> Vec<ArrayD<Fr>> {
-  let mut rng = StdRng::from_entropy();
-
-  let mut inputs = vec![];
-
-  for onnx_input in onnx_graph.input.iter() {
-    let tract_onnx::pb::type_proto::Value::TensorType(t) = onnx_input.r#type.as_ref().unwrap().value.as_ref().unwrap();
-    let shape = t
-      .shape
-      .as_ref()
-      .unwrap()
-      .dim
-      .iter()
-      .map(|x| {
-        if let tract_onnx::pb::tensor_shape_proto::dimension::Value::DimValue(x) = x.value.as_ref().unwrap() {
-          *x as usize
-        } else {
-          panic!("Unknown dimension")
-        }
-      })
-      .collect::<Vec<_>>();
-    let val_num = &shape.iter().fold(1, |acc, x| acc * x);
-
-    let input = match t.elem_type() {
-      DataType::Float | DataType::Float16 | DataType::Double => (0..*val_num).map(|_| Fr::from(rng.gen_range(-2..2))).collect(),
-      DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => (0..*val_num).map(|_| Fr::from(1)).collect(),
-      DataType::Uint8 | DataType::Uint16 | DataType::Uint32 | DataType::Uint64 => (0..*val_num).map(|_| Fr::from(1)).collect(),
-      _ => panic!("Unsupported constant type: {:?}", t.elem_type()),
-    };
-
-    //let input: Vec<Fr> = (0..*val_num).map(|_| Fr::from(rng.gen_range(-1..1))).collect();
-    let input = ArrayD::from_shape_vec(shape, input).unwrap();
-    let input = util::pad(&input);
-    inputs.push(input);
-  }
-  inputs
-}
-
 // This function is used for getting the local graph for each layer
 fn get_local_graph(
   op: &str,
@@ -191,8 +147,8 @@ fn get_local_graph(
   .unwrap()
 }
 
-// This function is used for updating the graph of onnx after creating the local graph
-fn update_graph(
+// This function is used for updating the graph of onnx after creating a local graph
+fn update_graph_w_local_graph(
   graph: &mut Graph,
   local_graph: Graph,
   node: &pb::NodeProto,
@@ -201,6 +157,7 @@ fn update_graph(
   basic_blocks_idx: &mut HashMap<String, usize>,
   models: &mut Vec<ArrayD<Fr>>,
 ) {
+  // Pushing basicblocks and models in a local graph to update graph.basic_blocks and models
   let mut local_block_idx = vec![];
   let temp = local_graph.basic_blocks;
   for basic_block in temp.into_iter() {
@@ -212,6 +169,7 @@ fn update_graph(
       graph.basic_blocks.push(basic_block);
     }
   }
+  // Pushing nodes in a local graph to update graph.nodes
   let start_idx = graph.nodes.len() as i32;
   for local_node in local_graph.nodes.iter() {
     // filter out node input that are ""
@@ -236,13 +194,16 @@ fn update_graph(
         .collect(),
     });
   }
+  // tracking output_idx of local_graph
   for (i, output) in node.output.iter().enumerate() {
     let local_output = local_graph.outputs[i];
     outputs_idx.insert(output.clone(), vec![(start_idx + local_output.0, local_output.1)]);
   }
 }
 
-// This function is used for processing a layer of onnx models
+// This function is used for processing a layer of onnx models.
+// It matches each ONNX operation as a local graph, which can
+// then be used to update the overall graph for zk proving.
 fn process_node(
   node: &pb::NodeProto,
   graph: &mut Graph,
@@ -281,7 +242,7 @@ fn process_node(
   }
 
   // update graph with local graph
-  update_graph(graph, local_graph, node, &input_idx, outputs_idx, basic_blocks_idx, models);
+  update_graph_w_local_graph(graph, local_graph, node, &input_idx, outputs_idx, basic_blocks_idx, models);
 
   // handle a special case (op == "Shape")
   if op == "Shape" {
@@ -301,7 +262,7 @@ fn process_node(
 // - Graph: the graph of zk-torch BasicBlocks after parsing the onnx layers
 // - Models: input tensors required for generating a setup for each BasicBlock
 // - Fake inputs: random field (i.e., Fr) elements whose shapes and types match those described in the input tensors of an ONNX model
-pub fn load_file(filename: &str) -> (Graph, Vec<ArrayD<Fr>>, Vec<ArrayD<Fr>>) {
+pub fn load_file(filename: &str) -> (Graph, Vec<ArrayD<Fr>>) {
   let onnx = tract_onnx::onnx();
   let onnx_graph = onnx.proto_model_for_path(filename).unwrap().graph.unwrap();
 
@@ -332,7 +293,5 @@ pub fn load_file(filename: &str) -> (Graph, Vec<ArrayD<Fr>>, Vec<ArrayD<Fr>>) {
     );
   }
 
-  let fake_inputs = generate_fake_inputs_for_onnx(&onnx_graph);
-
-  (graph, models, fake_inputs)
+  (graph, models)
 }

--- a/src/onnx.rs
+++ b/src/onnx.rs
@@ -157,7 +157,7 @@ fn update_graph_w_local_graph(
   basic_blocks_idx: &mut HashMap<String, usize>,
   models: &mut Vec<ArrayD<Fr>>,
 ) {
-  // Pushing basicblocks and models in a local graph to update graph.basic_blocks and models
+  // pushing basicblocks and models in a local graph to update graph.basic_blocks and models
   let mut local_block_idx = vec![];
   let temp = local_graph.basic_blocks;
   for basic_block in temp.into_iter() {
@@ -169,7 +169,7 @@ fn update_graph_w_local_graph(
       graph.basic_blocks.push(basic_block);
     }
   }
-  // Pushing nodes in a local graph to update graph.nodes
+  // pushing nodes in a local graph to update graph.nodes
   let start_idx = graph.nodes.len() as i32;
   for local_node in local_graph.nodes.iter() {
     // filter out node input that are ""
@@ -202,8 +202,8 @@ fn update_graph_w_local_graph(
 }
 
 // This function is used for processing a layer of onnx models.
-// It matches each ONNX operation as a local graph, which can
-// then be used to update the overall graph for zk proving.
+// It matches each onnx operation as a local graph. Then, it
+// update the overall graph by adding the local graph.
 fn process_node(
   node: &pb::NodeProto,
   graph: &mut Graph,
@@ -258,10 +258,9 @@ fn process_node(
   });
 }
 
-// This function is used for loading onnx models and returning the graph, models, and fake inputs
+// This function is used for loading onnx models and returning the graph and models
 // - Graph: the graph of zk-torch BasicBlocks after parsing the onnx layers
 // - Models: input tensors required for generating a setup for each BasicBlock
-// - Fake inputs: random field (i.e., Fr) elements whose shapes and types match those described in the input tensors of an ONNX model
 pub fn load_file(filename: &str) -> (Graph, Vec<ArrayD<Fr>>) {
   let onnx = tract_onnx::onnx();
   let onnx_graph = onnx.proto_model_for_path(filename).unwrap().graph.unwrap();

--- a/src/onnx.rs
+++ b/src/onnx.rs
@@ -7,6 +7,7 @@ use ndarray::{arr1, ArrayD};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::collections::HashMap;
 use tract_onnx::pb;
+use tract_onnx::pb::tensor_proto::DataType;
 use tract_onnx::pb::AttributeProto;
 use tract_onnx::prelude::{DatumType, Framework};
 use tract_onnx::tensor::load_tensor;
@@ -65,7 +66,7 @@ fn parse_onnx_constants<'a>(
   );
 
   let mut constants_hashmap = HashMap::new();
-  let mut setups = Vec::new();
+  let mut models = Vec::new();
   let mut idx = 0;
 
   for (name, tensor) in constants.clone() {
@@ -90,11 +91,11 @@ fn parse_onnx_constants<'a>(
     shapes.insert(name.clone(), tensor.shape().to_vec());
     let tensor = util::pad(&tensor);
     constants_hashmap.insert(name.clone(), idx);
-    setups.push(tensor);
+    models.push(tensor);
     idx += 1;
   }
 
-  (constants, constants_hashmap, setups)
+  (constants, constants_hashmap, models)
 }
 
 // This function is used for creating the output indices for constants of onnx models
@@ -117,6 +118,8 @@ fn create_output_indices<'a>(
 }
 
 // This function is used for generating fake inputs for onnx models
+// Fake inputs are random field (i.e., Fr) elements whose shapes and types match those described in the input tensors of an ONNX model.
+// Generating these when loading an ONNX file saves us from creating different input tensors ourselves when testing new ONNX.
 // It is only for testing purposes
 fn generate_fake_inputs_for_onnx(onnx_graph: &pb::GraphProto) -> Vec<ArrayD<Fr>> {
   let mut rng = StdRng::from_entropy();
@@ -141,7 +144,14 @@ fn generate_fake_inputs_for_onnx(onnx_graph: &pb::GraphProto) -> Vec<ArrayD<Fr>>
       .collect::<Vec<_>>();
     let val_num = &shape.iter().fold(1, |acc, x| acc * x);
 
-    let input: Vec<Fr> = (0..*val_num).map(|_| Fr::from(rng.gen_range(-2..2))).collect();
+    let input = match t.elem_type() {
+      DataType::Float | DataType::Float16 | DataType::Double => (0..*val_num).map(|_| Fr::from(rng.gen_range(-2..2))).collect(),
+      DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => (0..*val_num).map(|_| Fr::from(1)).collect(),
+      DataType::Uint8 | DataType::Uint16 | DataType::Uint32 | DataType::Uint64 => (0..*val_num).map(|_| Fr::from(1)).collect(),
+      _ => panic!("Unsupported constant type: {:?}", t.elem_type()),
+    };
+
+    //let input: Vec<Fr> = (0..*val_num).map(|_| Fr::from(rng.gen_range(-1..1))).collect();
     let input = ArrayD::from_shape_vec(shape, input).unwrap();
     let input = util::pad(&input);
     inputs.push(input);
@@ -153,29 +163,29 @@ fn generate_fake_inputs_for_onnx(onnx_graph: &pb::GraphProto) -> Vec<ArrayD<Fr>>
 fn get_local_graph(
   op: &str,
   input_shapes: &Vec<&Vec<usize>>,
-  my_constants: &Vec<Option<&ArrayD<Fr>>>,
-  my_attributes: Vec<&AttributeProto>,
+  node_constants: &Vec<Option<&ArrayD<Fr>>>,
+  node_attributes: Vec<&AttributeProto>,
 ) -> (Graph, Vec<Vec<usize>>) {
   match op {
-    "Add" => Ok(AddLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "Mul" => Ok(MulLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "Cast" => Ok(CastLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "Sub" => Ok(SubLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "MatMul" => Ok(MatMulLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "Relu" => Ok(ReLULayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "Gather" => Ok(GatherLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "ReduceMean" => Ok(ReduceMeanLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "Pow" => Ok(PowLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "Div" => Ok(DivLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "Sqrt" => Ok(SqrtLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "Reshape" => Ok(ReshapeLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "Transpose" => Ok(TransposeLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "Shape" => Ok(ShapeLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "Equal" => Ok(EqualLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "Where" => Ok(WhereLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "Expand" => Ok(ExpandLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "Softmax" => Ok(SoftmaxLayer::graph(&input_shapes, &my_constants, &my_attributes)),
-    "Erf" => Ok(ErfLayer::graph(&input_shapes, &my_constants, &my_attributes)),
+    "Add" => Ok(AddLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Mul" => Ok(MulLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Cast" => Ok(CastLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Sub" => Ok(SubLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "MatMul" => Ok(MatMulLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Relu" => Ok(ReLULayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Gather" => Ok(GatherLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "ReduceMean" => Ok(ReduceMeanLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Pow" => Ok(PowLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Div" => Ok(DivLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Sqrt" => Ok(SqrtLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Reshape" => Ok(ReshapeLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Transpose" => Ok(TransposeLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Shape" => Ok(ShapeLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Equal" => Ok(EqualLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Where" => Ok(WhereLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Expand" => Ok(ExpandLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Softmax" => Ok(SoftmaxLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Erf" => Ok(ErfLayer::graph(&input_shapes, &node_constants, &node_attributes)),
     _ => Err(format!("Unsupported onnx operation: {op}")),
   }
   .unwrap()
@@ -189,7 +199,7 @@ fn update_graph(
   input_idx: &HashMap<String, usize>,
   outputs_idx: &mut HashMap<String, Vec<(i32, usize)>>,
   basic_blocks_idx: &mut HashMap<String, usize>,
-  setups: &mut Vec<ArrayD<Fr>>,
+  models: &mut Vec<ArrayD<Fr>>,
 ) {
   let mut local_block_idx = vec![];
   let temp = local_graph.basic_blocks;
@@ -198,7 +208,7 @@ fn update_graph(
     let idx = *basic_blocks_idx.entry(name).or_insert_with(|| graph.basic_blocks.len());
     local_block_idx.push(idx);
     if idx == graph.basic_blocks.len() {
-      setups.push(basic_block.genModel());
+      models.push(basic_block.genModel());
       graph.basic_blocks.push(basic_block);
     }
   }
@@ -211,16 +221,16 @@ fn update_graph(
       inputs: local_node
         .inputs
         .iter()
-        .map(|(x, y)| {
-          if x < &0 {
-            let input_tag = node_input[(-x - 1) as usize];
+        .map(|(basicblock_idx, output_idx)| {
+          if basicblock_idx < &0 {
+            let input_tag = node_input[(-basicblock_idx - 1) as usize];
             if input_idx.contains_key(input_tag) {
-              (-(*input_idx.get(input_tag).unwrap() as i32) - 1, *y)
+              (-(*input_idx.get(input_tag).unwrap() as i32) - 1, *output_idx)
             } else {
-              outputs_idx[input_tag][*y]
+              outputs_idx[input_tag][*output_idx]
             }
           } else {
-            (start_idx + *x, *y)
+            (start_idx + *basicblock_idx, *output_idx)
           }
         })
         .collect(),
@@ -238,7 +248,7 @@ fn process_node(
   graph: &mut Graph,
   shapes: &mut HashMap<String, Vec<usize>>,
   constants_hashmap: &HashMap<String, usize>,
-  setups: &mut Vec<ArrayD<Fr>>,
+  models: &mut Vec<ArrayD<Fr>>,
   passed_constants: &mut HashMap<String, ArrayD<Fr>>,
   input_idx: &HashMap<String, usize>,
   outputs_idx: &mut HashMap<String, Vec<(i32, usize)>>,
@@ -248,15 +258,15 @@ fn process_node(
   let op = node.op_type.as_str();
   let input_shapes: Vec<_> = node.input.iter().map(|x| shapes.get(x)).collect();
   let input_shapes = input_shapes.into_iter().filter_map(|x| x).collect::<Vec<_>>(); // hack: we ignore optional inputs
-  let my_constants = node.input.iter().map(|x| passed_constants.get(x).or(constants_hashmap.get(x).map(|&y| &setups[y]))).collect();
-  let my_attributes = node.attribute.iter().map(|x| x).collect();
-  let (local_graph, output_shapes) = get_local_graph(op, &input_shapes, &my_constants, my_attributes);
+  let node_constants = node.input.iter().map(|x| passed_constants.get(x).or(constants_hashmap.get(x).map(|&y| &models[y]))).collect();
+  let node_attributes = node.attribute.iter().map(|x| x).collect();
+  let (local_graph, output_shapes) = get_local_graph(op, &input_shapes, &node_constants, node_attributes);
 
-  // compute precomputable constants
-  if my_constants.iter().all(|&x| x.is_some()) {
-    let my_inputs: Vec<_> = my_constants.iter().map(|&x| x.unwrap().clone()).collect();
-    let my_inputs = my_inputs.iter().map(|x| x).collect();
-    let outputs = local_graph.run(&my_inputs, &vec![&arr1(&[]).into_dyn(); local_graph.basic_blocks.len()]);
+  // compute precomputable constants (these are constants that can be computed without proving)
+  if node_constants.iter().all(|&x| x.is_some()) {
+    let node_inputs: Vec<_> = node_constants.iter().map(|&x| x.unwrap().clone()).collect();
+    let node_inputs = node_inputs.iter().map(|x| x).collect();
+    let outputs = local_graph.run(&node_inputs, &vec![&arr1(&[]).into_dyn(); local_graph.basic_blocks.len()]);
     node
       .output
       .iter()
@@ -265,13 +275,13 @@ fn process_node(
       .for_each(|((output_str, &(nodeX, nodeY)), output_shape)| {
         passed_constants.insert(
           output_str.to_string(),
-          util::slice_nd_array(outputs[nodeX as usize][nodeY].clone(), &output_shape), // no need to pad for precomputable constants
+          util::slice_nd_array(outputs[nodeX as usize][nodeY].clone(), &output_shape),
         );
       });
   }
 
   // update graph with local graph
-  update_graph(graph, local_graph, node, &input_idx, outputs_idx, basic_blocks_idx, setups);
+  update_graph(graph, local_graph, node, &input_idx, outputs_idx, basic_blocks_idx, models);
 
   // handle a special case (op == "Shape")
   if op == "Shape" {
@@ -287,13 +297,16 @@ fn process_node(
   });
 }
 
-// This function is used for loading onnx models and returning the graph, setups, and fake inputs
+// This function is used for loading onnx models and returning the graph, models, and fake inputs
+// - Graph: the graph of zk-torch BasicBlocks after parsing the onnx layers
+// - Models: input tensors required for generating a setup for each BasicBlock
+// - Fake inputs: random field (i.e., Fr) elements whose shapes and types match those described in the input tensors of an ONNX model
 pub fn load_file(filename: &str) -> (Graph, Vec<ArrayD<Fr>>, Vec<ArrayD<Fr>>) {
   let onnx = tract_onnx::onnx();
   let onnx_graph = onnx.proto_model_for_path(filename).unwrap().graph.unwrap();
 
   let (input_idx, mut shapes) = parse_onnx_inputs(&onnx_graph);
-  let (constants, constants_hashmap, mut setups) = parse_onnx_constants(&onnx_graph, &mut shapes);
+  let (constants, constants_hashmap, mut models) = parse_onnx_constants(&onnx_graph, &mut shapes);
 
   let mut graph = Graph {
     basic_blocks: vec![],
@@ -311,7 +324,7 @@ pub fn load_file(filename: &str) -> (Graph, Vec<ArrayD<Fr>>, Vec<ArrayD<Fr>>) {
       &mut graph,
       &mut shapes,
       &constants_hashmap,
-      &mut setups,
+      &mut models,
       &mut passed_constants,
       &input_idx,
       &mut outputs_idx,
@@ -321,5 +334,5 @@ pub fn load_file(filename: &str) -> (Graph, Vec<ArrayD<Fr>>, Vec<ArrayD<Fr>>) {
 
   let fake_inputs = generate_fake_inputs_for_onnx(&onnx_graph);
 
-  (graph, setups, fake_inputs)
+  (graph, models, fake_inputs)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -25,6 +25,17 @@ fn bitreverse(mut n: u32, l: u64) -> u32 {
   r
 }
 
+pub fn slice_nd_array(arr: ArrayD<Fr>, indices: &[usize]) -> ArrayD<Fr> {
+  // Create slices from the indices
+  let slices: Vec<_> = indices.iter().map(|&i| (0..i).into()).collect();
+
+  // Convert slices into a SliceInfo instance
+  let slice_info = unsafe { SliceInfo::<_, IxDyn, IxDyn>::new(slices).unwrap() };
+
+  // Slice the array
+  arr.slice_move(slice_info)
+}
+
 pub fn fft_helper<G: ScalarMul + std::ops::MulAssign<Fr>>(a: &mut Vec<G>, domain: GeneralEvaluationDomain<Fr>, inv: bool) {
   let n = a.len();
   let log_size = domain.log_size_of_group();

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,11 +10,57 @@ use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{UniformRand, Zero};
 use ndarray::{arr0, concatenate, Array1, ArrayD, Axis, IxDyn, SliceInfo, SliceInfoElem};
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, RngCore, SeedableRng, Rng};
 use rayon::prelude::*;
 use sha3::{Digest, Keccak256};
 use std::collections::HashMap;
 use std::collections::{BTreeSet, HashSet};
+use tract_onnx::pb::tensor_proto::DataType;
+use tract_onnx::prelude::Framework;
+
+// This function is used for generating fake inputs for onnx models
+// Fake inputs are random field (i.e., Fr) elements whose shapes and types match those described in the input tensors of an ONNX model.
+// Generating these when loading an ONNX file saves us from creating different input tensors ourselves when testing new ONNX.
+// It is only for testing purposes
+pub fn generate_fake_inputs_for_onnx(filename: &str) -> Vec<ArrayD<Fr>> {
+  let onnx = tract_onnx::onnx();
+  let onnx_graph = onnx.proto_model_for_path(filename).unwrap().graph.unwrap();
+  let mut rng = StdRng::from_entropy();
+
+  let mut inputs = vec![];
+
+  for onnx_input in onnx_graph.input.iter() {
+    let tract_onnx::pb::type_proto::Value::TensorType(t) = onnx_input.r#type.as_ref().unwrap().value.as_ref().unwrap();
+    let shape = t
+      .shape
+      .as_ref()
+      .unwrap()
+      .dim
+      .iter()
+      .map(|x| {
+        if let tract_onnx::pb::tensor_shape_proto::dimension::Value::DimValue(x) = x.value.as_ref().unwrap() {
+          *x as usize
+        } else {
+          panic!("Unknown dimension")
+        }
+      })
+      .collect::<Vec<_>>();
+    let val_num = &shape.iter().fold(1, |acc, x| acc * x);
+
+    let input = match t.elem_type() {
+      DataType::Float | DataType::Float16 | DataType::Double => (0..*val_num).map(|_| Fr::from(rng.gen_range(-2..2))).collect(),
+      DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => (0..*val_num).map(|_| Fr::from(1)).collect(),
+      DataType::Uint8 | DataType::Uint16 | DataType::Uint32 | DataType::Uint64 => (0..*val_num).map(|_| Fr::from(1)).collect(),
+      _ => panic!("Unsupported constant type: {:?}", t.elem_type()),
+    };
+
+    //let input: Vec<Fr> = (0..*val_num).map(|_| Fr::from(rng.gen_range(-1..1))).collect();
+    let input = ArrayD::from_shape_vec(shape, input).unwrap();
+    let input = pad(&input);
+    inputs.push(input);
+  }
+  inputs
+}
 
 fn bitreverse(mut n: u32, l: u64) -> u32 {
   let mut r = 0;


### PR DESCRIPTION
This PR refactors `onnx.rs`, adding the following features:
- Improved readability
- Ignored optional input fields of ONNX layers
- Computed precomputable constants without padding (which might cause problems for layers like `Concat`)
- Returned `fake_input` to facilitate testing the Graph (this tool spares us the effort of creating inputs for various ONNX files)
