### PR TITLE
Handle a special-case shape issue for SubBB

### DIFF
--- a/src/basic_block/sub.rs
+++ b/src/basic_block/sub.rs
@@ -9,7 +9,10 @@ impl BasicBlock for SubBasicBlock {
   fn run(&self, _model: &ArrayD<Fr>, inputs: &Vec<&ArrayD<Fr>>) -> Vec<ArrayD<Fr>> {
     assert!(inputs.len() == 2 && inputs[0].ndim() <= 1 && inputs[1].ndim() <= 1);
     let mut r = ArrayD::zeros(IxDyn(&[std::cmp::max(inputs[0].len(), inputs[1].len())]));
-    if inputs[0].len() == 1 {
+    if inputs[0].len() == 1 && inputs[1].ndim() == 0 {
+      // speicial case: [1] - []
+      r = inputs[0].map(|x| x - inputs[1].first().unwrap());
+    } else if inputs[0].len() == 1 {
       azip!((r in &mut r, &y in inputs[1]) *r = *inputs[0].first().unwrap() - y);
     } else if inputs[1].len() == 1 {
       azip!((r in &mut r, &x in inputs[0]) *r = x - *inputs[1].first().unwrap());

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -74,6 +74,7 @@ fn testBasicBlocks() {
   testBasicBlock(AddBasicBlock {}, srs, &empty, &vec![&b, &a_0]);
   testBasicBlock(SubBasicBlock {}, srs, &empty, &vec![&a_0, &b]);
   testBasicBlock(SubBasicBlock {}, srs, &empty, &vec![&b, &a_0]);
+  testBasicBlock(SubBasicBlock {}, srs, &empty, &vec![&a_0, &a_0]);
   testBasicBlock(
     CQBasicBlock {
       setup: a.clone().into_dimensionality::<ndarray::Ix1>().unwrap(),


### PR DESCRIPTION
Our `SubBasicBlock` accept two inputs. When input[0].len()=1, we assumed that input[1].len() will not be 1. This PR included the case that we didn't consider before.