### PR TITLE
Handle special-case shape issues using Mul

### DIFF
--- a/src/layer/mul.rs
+++ b/src/layer/mul.rs
@@ -36,7 +36,20 @@ impl Layer for MulLayer {
       }),
       N: 1,
     }));
-    let mul_output = graph.addNode(if input_shapes[1].len() == 0 { mul_scalar } else { mul }, vec![(-1, 0), (-2, 0)]);
+    // If any of the inputs are scalars, use the scalar version of the mul basic block.
+    let mul_basicblock = if input_shapes[1].len() == 0 || input_shapes[0].len() == 0 {
+      mul_scalar
+    // otherwise, use the normal version of the mul basic block.
+    } else {
+      mul
+    };
+    // If the first input is a scalar, swap the inputs, because the mul scalar basic block expects the scalar to be the second input.
+    let mul_output = if input_shapes[0].len() == 0 {
+      graph.addNode(mul_basicblock, vec![(-2, 0), (-1, 0)])
+    } else {
+      graph.addNode(mul_basicblock, vec![(-1, 0), (-2, 0)])
+    };
+
     let change_SF_output = graph.addNode(change_SF, vec![(mul_output, 0)]);
     let _ = graph.addNode(change_SF_check, vec![(mul_output, 0), (change_SF_output, 0)]);
     graph.outputs.push((change_SF_output, 0));

--- a/src/layer/where.rs
+++ b/src/layer/where.rs
@@ -32,13 +32,9 @@ impl Layer for WhereLayer {
     }));
 
     let one_output = graph.addNode(one, vec![]);
-    let mul1_output = if input_shapes[1].len() == 0 {
-      graph.addNode(mul_scalar, vec![(-1, 0), (-2, 0)])
-    } else {
-      graph.addNode(mul, vec![(-1, 0), (-2, 0)])
-    };
+    let mul1_output = graph.addNode(if input_shapes[1].len() == 0 { mul_scalar } else { mul }, vec![(-1, 0), (-2, 0)]);
     let sub_output = graph.addNode(sub, vec![(one_output, 0), (-1, 0)]);
-    let mul2_output = graph.addNode(mul, vec![(sub_output, 0), (-3, 0)]);
+    let mul2_output = graph.addNode(if input_shapes[2].len() == 0 { mul_scalar } else { mul }, vec![(sub_output, 0), (-3, 0)]);
     let add_output = graph.addNode(add, vec![(mul1_output, 0), (mul2_output, 0)]);
     graph.outputs.push((add_output, 0));
     (graph, vec![input_shapes[0].clone()])


### PR DESCRIPTION
ONNX Mul accepts two inputs `a` and `b`, and returns `a*b`. It performs broadcasting for inputs when the shapes don't match.
We used MulBasicBlock when `a` and `b` are both 1-dimensional arrays and used MulScalarBasicBlock when `b` is a scalar. However, we didn't consider the case that `a` might also be a scalar in Mul and Where layers. 
This PR addressed these issues.