### PR TITLE
Print out layer names

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -22,6 +22,7 @@ pub struct Node {
 #[derive(Debug)]
 pub struct Graph {
   pub basic_blocks: Vec<Box<dyn BasicBlock>>,
+  pub layer_names: Vec<String>,
   pub nodes: Vec<Node>,
   pub outputs: Vec<(i32, usize)>,
 }
@@ -30,7 +31,7 @@ impl Graph {
   pub fn run(&self, inputs: &Vec<&ArrayD<Fr>>, models: &Vec<&ArrayD<Fr>>) -> Vec<Vec<ArrayD<Fr>>> {
     let mut outputs = vec![vec![]; self.nodes.len()];
     self.nodes.iter().enumerate().for_each(|(i, n)| {
-      println!("running {i} {:?}", self.basic_blocks[n.basic_block]);
+      println!("{} | running {i} {:?}", self.layer_names[i], self.basic_blocks[n.basic_block]);
       let myInputs = n
         .inputs
         .iter()
@@ -59,7 +60,7 @@ impl Graph {
   ) -> Vec<Vec<ArrayD<Data>>> {
     let mut outputsEnc = vec![vec![]; self.nodes.len()];
     self.nodes.iter().enumerate().for_each(|(i, n)| {
-      let encode_id = format!("encoding node {i} {:?}", self.basic_blocks[n.basic_block]);
+      let encode_id = format!("{} | encoding node {i} {:?}", self.layer_names[i], self.basic_blocks[n.basic_block]);
       println!("{}", encode_id);
       let myInputs = n
         .inputs
@@ -111,7 +112,7 @@ impl Graph {
       .iter()
       .enumerate()
       .map(|(i, n)| {
-        let prove_id = format!("proving {i} {:?}", self.basic_blocks[n.basic_block]);
+        let prove_id = format!("{} | proving {i} {:?}", self.layer_names[i], self.basic_blocks[n.basic_block]);
         println!("{}", prove_id);
         let myInputs = n
           .inputs
@@ -166,7 +167,7 @@ impl Graph {
       .iter()
       .enumerate()
       .map(|(i, n)| {
-        println!("verifying {i} {:?}", self.basic_blocks[n.basic_block]);
+        println!("{} | verifying {i} {:?}", self.layer_names[i], self.basic_blocks[n.basic_block]);
         let myInputs = n
           .inputs
           .iter()
@@ -235,6 +236,7 @@ impl Graph {
   pub fn new() -> Self {
     Graph {
       basic_blocks: vec![],
+      layer_names: vec![],
       nodes: vec![],
       outputs: vec![],
     }
@@ -250,6 +252,7 @@ impl Graph {
       basic_block: basic_block,
       inputs: inputs,
     });
+    self.layer_names.push("Precomputation".to_string());
     (self.nodes.len() - 1) as i32
   }
 }

--- a/src/onnx.rs
+++ b/src/onnx.rs
@@ -115,6 +115,7 @@ fn create_output_indices<'a>(
       basic_block: graph.basic_blocks.len(),
       inputs: vec![],
     });
+    graph.layer_names.push(format!("Const {}", name.to_string()));
     graph.basic_blocks.push(Box::new(ConstBasicBlock {}));
   }
 
@@ -238,6 +239,7 @@ fn update_graph_w_local_graph(
         })
         .collect(),
     });
+    graph.layer_names.push(format!("Op {}", node.name.clone()));
   }
   // tracking output_idx of local_graph
   for (i, output) in node.output.iter().enumerate() {
@@ -262,6 +264,7 @@ fn process_node(
 ) {
   // match onnx operation
   let op = node.op_type.as_str();
+  println!("Compiling ONNX node: {op}");
   let input_shapes: Vec<_> = node.input.iter().map(|x| shapes.get(x)).collect();
   let input_shapes = input_shapes.into_iter().filter_map(|x| x).collect::<Vec<_>>(); // hack: we ignore optional inputs
   let node_constants = node.input.iter().map(|x| passed_constants.get(x).or(constants_hashmap.get(x).map(|&y| &models[y]))).collect();
@@ -277,11 +280,10 @@ fn process_node(
       .output
       .iter()
       .zip(local_graph.outputs.iter())
-      .zip(output_shapes.clone())
-      .for_each(|((output_str, &(nodeX, nodeY)), output_shape)| {
+      .for_each(|(output_str, &(nodeX, nodeY))| {
         passed_constants.insert(
           output_str.to_string(),
-          util::slice_nd_array(outputs[nodeX as usize][nodeY].clone(), &output_shape),
+          util::pad_to_pow_of_two(&outputs[nodeX as usize][nodeY].clone(), &Fr::zero()),
         );
       });
   }
@@ -291,9 +293,10 @@ fn process_node(
 
   // handle a special case (op == "Shape")
   if op == "Shape" {
+    let shape = arr1(&input_shapes[0].iter().map(|&x| Fr::from(x as i32)).collect::<Vec<_>>()).into_dyn();
     passed_constants.insert(
       (&node.output[0]).to_string(),
-      arr1(&input_shapes[0].iter().map(|&x| Fr::from(x as i32)).collect::<Vec<_>>()).into_dyn(),
+      util::pad_to_pow_of_two(&shape, &Fr::zero()),
     );
   }
 
@@ -315,6 +318,7 @@ pub fn load_file(filename: &str) -> (Graph, Vec<ArrayD<Fr>>) {
 
   let mut graph = Graph {
     basic_blocks: vec![],
+    layer_names: vec![],
     nodes: vec![],
     outputs: vec![],
   };

--- a/src/onnx.rs
+++ b/src/onnx.rs
@@ -264,7 +264,7 @@ fn process_node(
 ) {
   // match onnx operation
   let op = node.op_type.as_str();
-  println!("Compiling ONNX node: {op}");
+  println!("Compiling ONNX node: {}", op.name);
   let input_shapes: Vec<_> = node.input.iter().map(|x| shapes.get(x)).collect();
   let input_shapes = input_shapes.into_iter().filter_map(|x| x).collect::<Vec<_>>(); // hack: we ignore optional inputs
   let node_constants = node.input.iter().map(|x| passed_constants.get(x).or(constants_hashmap.get(x).map(|&y| &models[y]))).collect();

--- a/src/onnx.rs
+++ b/src/onnx.rs
@@ -264,7 +264,7 @@ fn process_node(
 ) {
   // match onnx operation
   let op = node.op_type.as_str();
-  println!("Compiling ONNX node: {}", op.name);
+  println!("Compiling ONNX node: {}", node.name);
   let input_shapes: Vec<_> = node.input.iter().map(|x| shapes.get(x)).collect();
   let input_shapes = input_shapes.into_iter().filter_map(|x| x).collect::<Vec<_>>(); // hack: we ignore optional inputs
   let node_constants = node.input.iter().map(|x| passed_constants.get(x).or(constants_hashmap.get(x).map(|&y| &models[y]))).collect();


### PR DESCRIPTION
We didn't print layer names during running, proving, and verifying, which made it difficult to debug when running large models (we only printed the names of basicblocks). This PR implements this feature so that we can check it on netron when a layer fails