### PR TITLE
Convert copy-constraint padding partitions into an enum

### DIFF
--- a/src/basic_block/copy_constraint.rs
+++ b/src/basic_block/copy_constraint.rs
@@ -22,6 +22,7 @@ use rayon::prelude::*;
 use std::{
   cmp::{max, min},
   collections::{BTreeMap, HashMap},
+  default,
   iter::{once, repeat, Map},
 };
 
@@ -89,7 +90,7 @@ fn construct_ssig(
 }
 
 // Returns the padding_partitions field for CopyConstraintBasicBlock when the given permutation padding elements are 0
-pub fn zero_padding_partition(permutation: &ArrayD<Option<IxDyn>>) -> HashMap<Fr, Vec<IxDyn>> {
+fn zero_padding_partition(permutation: &ArrayD<Option<IxDyn>>) -> HashMap<Fr, Vec<IxDyn>> {
   let mut partition = vec![];
   for (i, _) in permutation.indexed_iter() {
     if permutation[&i] == None {
@@ -103,16 +104,56 @@ pub fn zero_padding_partition(permutation: &ArrayD<Option<IxDyn>>) -> HashMap<Fr
   padding_partition
 }
 
-// Checks that padding partition corresponds to None values in permutation
-fn check_padding_partition(permutation: &ArrayD<Option<IxDyn>>, padding_partitions: &HashMap<Fr, Vec<IxDyn>>) -> bool {
-  for (_, p) in padding_partitions.iter() {
-    for idx in p {
-      if permutation[idx] != None {
-        return false;
+// Returns the padding partition where the non-zero padding value consists of all pad indices such that the last-axis subview containing it contains non-pad elements, and the zero padding value consists of all pad indices part of a last-axis subview containing only pad elements.
+// If val is 0, then these will instead be combined.
+fn max_padding_partitions(permutation: &ArrayD<Option<IxDyn>>, val: Fr) -> HashMap<Fr, Vec<IxDyn>> {
+  let mut zero_indices = vec![];
+  let mut nonzero_indices = vec![];
+  for (i, subview) in permutation.axis_iter(Axis(permutation.ndim() - 1)).enumerate() {
+    if subview.iter().all(|x| x.is_none()) {
+      for (idx, _) in subview.indexed_iter() {
+        let mut full_idx = idx.as_array_view().to_vec();
+        full_idx.push(i);
+        zero_indices.push(IxDyn(&full_idx));
+      }
+    } else {
+      for (idx, val) in subview.indexed_iter() {
+        if val.is_none() {
+          let mut full_idx = idx.as_array_view().to_vec();
+          full_idx.push(i);
+          nonzero_indices.push(IxDyn(&full_idx));
+        }
       }
     }
   }
-  true
+  let mut partitions = HashMap::new();
+  if val == Fr::zero() {
+    zero_indices.append(&mut nonzero_indices);
+  } else {
+    if nonzero_indices.len() > 0 {
+      partitions.insert(val, nonzero_indices);
+    }
+  }
+  if zero_indices.len() > 0 {
+    partitions.insert(Fr::zero(), zero_indices);
+  }
+  partitions
+}
+
+// Determines the scheme for padding partitions: pairs of (padding value, list of indices in the output containing that pad value)
+#[derive(Debug, Default)]
+pub enum PaddingEnum {
+  #[default]
+  Zero,
+  Max(Fr),
+}
+
+// Gets padding partition based on the enum value
+fn get_padding_partition(permutation: &ArrayD<Option<IxDyn>>, pad_type: &PaddingEnum) -> HashMap<Fr, Vec<IxDyn>> {
+  match pad_type {
+    PaddingEnum::Zero => zero_padding_partition(permutation),
+    PaddingEnum::Max(val) => max_padding_partitions(permutation, *val),
+  }
 }
 
 // This BasicBlock implements Plonk's copy constraint protocol over the inputs and outputs (Sec. 5.2 and 8 of https://eprint.iacr.org/2019/953.pdf) [1].
@@ -122,14 +163,14 @@ fn check_padding_partition(permutation: &ArrayD<Option<IxDyn>>, padding_partitio
 pub struct CopyConstraintBasicBlock {
   pub permutation: ArrayD<Option<IxDyn>>,
   pub input_dim: IxDyn,
-  pub padding_partitions: HashMap<Fr, Vec<IxDyn>>,
+  pub padding_partition: PaddingEnum,
 }
 
 impl BasicBlock for CopyConstraintBasicBlock {
   fn run(&self, _model: &ArrayD<Fr>, inputs: &Vec<&ArrayD<Fr>>) -> Vec<ArrayD<Fr>> {
     assert!(inputs.len() == 1 && inputs[0].dim() == self.input_dim);
-    assert!(check_padding_partition(&self.permutation, &self.padding_partitions));
-    let tmp_hashmap: HashMap<IxDyn, Fr> = self.padding_partitions.iter().flat_map(|(k, v)| v.iter().map(|x| (x.clone(), *k))).collect();
+    let padding_partitions = get_padding_partition(&self.permutation, &self.padding_partition);
+    let tmp_hashmap: HashMap<IxDyn, Fr> = padding_partitions.iter().flat_map(|(k, v)| v.iter().map(|x| (x.clone(), *k))).collect();
     vec![ArrayD::from_shape_fn(self.permutation.shape(), |i| {
       if let Some(idx) = &self.permutation[&i] {
         inputs[0][idx]
@@ -181,10 +222,11 @@ impl BasicBlock for CopyConstraintBasicBlock {
     }
     // Add padding partitions to partition
     let mut pad_partitions = vec![];
-    let mut padding_values = self.padding_partitions.keys().collect::<Vec<_>>();
+    let padding_partitions = get_padding_partition(&self.permutation, &self.padding_partition);
+    let mut padding_values = padding_partitions.keys().collect::<Vec<_>>();
     padding_values.sort();
     for v in padding_values.iter() {
-      let p = self.padding_partitions.get(v).unwrap();
+      let p = padding_partitions.get(v).unwrap();
       let flat_idxs: Vec<_> = p.iter().map(|i| flat_outp_idxs[i]).collect();
       if flat_idxs.len() > 0 {
         pad_partitions.push(flat_idxs);
@@ -332,10 +374,11 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let mut pad_vals = vec![];
     let mut fj_none_idxs = vec![]; // position in f_polys
     let mut Lnone_polys = vec![];
-    let mut padding_values = self.padding_partitions.keys().cloned().collect::<Vec<_>>();
+    let padding_partitions = get_padding_partition(&self.permutation, &self.padding_partition);
+    let mut padding_values = padding_partitions.keys().cloned().collect::<Vec<_>>();
     padding_values.sort();
     for val in padding_values.iter() {
-      let partition = &self.padding_partitions[val];
+      let partition = &padding_partitions[val];
       let idx = &partition[0];
       let flat_none_idx = flat_index(&self.permutation.dim(), &Some(idx.clone()), N).unwrap();
       let mut Lnone = vec![Fr::zero(); N];
@@ -500,7 +543,8 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let fj_xs = &proof.0[m + 5..];
 
     // TODO: have verifier compute Lagrange basis evals
-    let mut padding_values = self.padding_partitions.keys().cloned().collect::<Vec<_>>();
+    let padding_partitions = get_padding_partition(&self.permutation, &self.padding_partition);
+    let mut padding_values = padding_partitions.keys().cloned().collect::<Vec<_>>();
     padding_values.sort();
     let [Z_gz, L0_z] = proof.2[..2] else { panic!("Wrong proof format") };
     let none_len = padding_values.len();
@@ -544,7 +588,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     let mut pad_vals = vec![];
     let mut fj_none_idxs = vec![];
     for val in padding_values.iter() {
-      let partition = self.padding_partitions.get(val).unwrap();
+      let partition = padding_partitions.get(val).unwrap();
       let idx = &partition[0];
       let flat_idx = flat_index(&self.permutation.dim(), &Some(idx.clone()), N).unwrap();
       fj_none_idxs.push(flat_idx.0 + input.len());

--- a/src/layer/concat.rs
+++ b/src/layer/concat.rs
@@ -3,7 +3,6 @@ use crate::graph::*;
 use crate::layer::Layer;
 use crate::util;
 use ark_bn254::Fr;
-use copy_constraint::zero_padding_partition;
 use ndarray::{ArrayD, IxDyn};
 use tract_onnx::pb::AttributeProto;
 
@@ -53,11 +52,10 @@ impl Layer for ConcatLayer {
       let mut cc_basicblocks = vec![];
       for i in 0..input_shapes.len() {
         let padded_input_shape: Vec<usize> = input_shapes[i].iter().map(|&x| util::next_pow(x as u32) as usize).collect();
-        let padding_partitions = zero_padding_partition(&permutations[i]);
         let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
           permutation: permutations[i].clone(),
           input_dim: IxDyn(&padded_input_shape),
-          padding_partitions,
+          padding_partition: copy_constraint::PaddingEnum::Zero,
         }));
         cc_basicblocks.push(cc);
       }

--- a/src/layer/conv.rs
+++ b/src/layer/conv.rs
@@ -4,7 +4,6 @@ use crate::layer::Layer;
 use crate::onnx;
 use crate::util;
 use ark_bn254::Fr;
-use copy_constraint::zero_padding_partition;
 use ndarray::indices;
 use ndarray::Dim;
 use ndarray::Dimension;
@@ -177,22 +176,20 @@ macro_rules! create_conv_layer {
         let permutation = splat_input(&input_shapes[0], &strides, &pads, ci, &ch_dims, $is_transpose);
         let permutation_padded = splat_pad(&permutation);
         let input_shape_padded: Vec<_> = input_shapes[0].iter().map(|i| i.next_power_of_two()).collect();
-        let padding_partitions = zero_padding_partition(&permutation_padded);
         let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
           permutation: permutation_padded,
           input_dim: IxDyn(&input_shape_padded),
-          padding_partitions,
+          padding_partition: copy_constraint::PaddingEnum::Zero,
         }));
 
         // TODO: change to CQLin and commit splatted weights
         let weights_splatted = splat_weights(&weight_shape, $is_transpose);
         let weights_padded = splat_pad(&weights_splatted);
         let weight_shape_padded: Vec<_> = weight_shape.iter().map(|i| i.next_power_of_two()).collect();
-        let padding_partitions = zero_padding_partition(&weights_padded);
         let cc1 = graph.addBB(Box::new(CopyConstraintBasicBlock {
           permutation: weights_padded,
           input_dim: IxDyn(&weight_shape_padded),
-          padding_partitions,
+          padding_partition: copy_constraint::PaddingEnum::Zero,
         }));
         let matmul = graph.addBB(Box::new(MatMulBasicBlock {}));
 
@@ -228,11 +225,10 @@ macro_rules! create_conv_layer {
         let mut output_shape = vec![1, cout];
         output_shape.append(&mut out_dims);
         let reshape_permutation = util::get_reshape_indices(vec![permutation.len(), weights_splatted.len()], output_shape.clone());
-        let padding_partitions = zero_padding_partition(&reshape_permutation);
         let cc2 = graph.addBB(Box::new(CopyConstraintBasicBlock {
           permutation: reshape_permutation,
           input_dim: IxDyn(&[permutation.len().next_power_of_two(), weights_splatted.len().next_power_of_two()]),
-          padding_partitions,
+          padding_partition: copy_constraint::PaddingEnum::Zero,
         }));
 
         let cc_output = graph.addNode(cc, vec![(-1, 0)]);

--- a/src/layer/flatten.rs
+++ b/src/layer/flatten.rs
@@ -3,7 +3,6 @@ use crate::graph::*;
 use crate::layer::Layer;
 use crate::util;
 use ark_bn254::Fr;
-use copy_constraint::zero_padding_partition;
 use ndarray::{ArrayD, IxDyn};
 use tract_onnx::pb::AttributeProto;
 
@@ -37,11 +36,10 @@ impl Layer for FlattenLayer {
 
     let (permutation, output_shape) = get_permutation(&input_shapes[0], axis);
 
-    let padding_partitions = zero_padding_partition(&permutation);
     let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
       permutation: permutation,
       input_dim: IxDyn(&padded_input_shape),
-      padding_partitions,
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     }));
 
     let output = graph.addNode(cc, vec![(-1, 0)]);

--- a/src/layer/gathernd.rs
+++ b/src/layer/gathernd.rs
@@ -4,7 +4,6 @@ use crate::layer::Layer;
 use crate::util;
 use ark_bn254::Fr;
 use ark_std::iterable::Iterable;
-use copy_constraint::zero_padding_partition;
 use ndarray::Dimension;
 use ndarray::{ArrayD, Axis, IxDyn};
 use tract_onnx::pb::AttributeProto;
@@ -86,12 +85,11 @@ impl Layer for GatherNDLayer {
     let padded_data_shape: Vec<_> = data_shape.iter().map(|&x| util::next_pow(x as u32) as usize).collect();
 
     let (permutation, output_shape) = get_gathernd_masks(&data_shape, &indices, batch_dims);
-    let padding = zero_padding_partition(&permutation);
 
     let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
-      permutation: permutation,
+      permutation,
       input_dim: IxDyn(&padded_data_shape),
-      padding_partitions: padding,
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     }));
 
     let output = graph.addNode(cc, vec![(-1, 0)]);

--- a/src/layer/max.rs
+++ b/src/layer/max.rs
@@ -4,9 +4,7 @@ use crate::layer::Layer;
 use crate::onnx;
 use crate::util;
 use ark_bn254::Fr;
-use copy_constraint::zero_padding_partition;
 use ndarray::{concatenate, indices, ArrayD, Axis, Dim, Dimension, IxDyn};
-use std::collections::HashMap;
 use tract_onnx::pb::AttributeProto;
 
 // Returns the splat needed to pass into MaxProofBasicBlock. This produces a (product of input dims X 2) permutation where the first column corresponds to the input elements and the second column contains cmp_val
@@ -28,11 +26,10 @@ impl Layer for MaxLayer {
       let constant = constants[1].unwrap().first().unwrap();
       let permutation = splat_input(&input_shapes[0], None);
       let input_shape_padded: Vec<_> = input_shapes[0].iter().map(|i| i.next_power_of_two()).collect();
-      let padding_partitions = util::max_padding_partitions(&permutation, *constant);
       let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
         permutation,
         input_dim: IxDyn(&input_shape_padded),
-        padding_partitions,
+        padding_partition: copy_constraint::PaddingEnum::Max(*constant),
       }));
       let max = graph.addBB(Box::new(RepeaterBasicBlock {
         basic_block: Box::new(MaxProofBasicBlock {}),
@@ -40,12 +37,11 @@ impl Layer for MaxLayer {
       }));
       let reshape_shape = &vec![input_shapes[0].iter().product(), 1];
       let reshape_permutation = util::get_reshape_indices(reshape_shape.clone(), input_shapes[0].clone());
-      let padding_partitions = zero_padding_partition(&reshape_permutation);
       let reshape_shape_pad: Vec<_> = reshape_shape.iter().map(|i| i.next_power_of_two()).collect();
       let cc1 = graph.addBB(Box::new(CopyConstraintBasicBlock {
         permutation: reshape_permutation,
         input_dim: IxDyn(&reshape_shape_pad),
-        padding_partitions,
+        padding_partition: copy_constraint::PaddingEnum::Zero,
       }));
 
       let cc_output = graph.addNode(cc, vec![(-1, 0)]);
@@ -78,7 +74,7 @@ impl Layer for MinLayer {
       let extend_second_input = graph.addBB(Box::new(CopyConstraintBasicBlock {
         permutation: extended_second_input,
         input_dim: IxDyn(&[1]),
-        padding_partitions: HashMap::new(),
+        padding_partition: copy_constraint::PaddingEnum::Zero,
       }));
 
       let concat_inputs = graph.addBB(Box::new(ConcatBasicBlock { axis: 0 }));
@@ -94,7 +90,7 @@ impl Layer for MinLayer {
       let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
         permutation,
         input_dim: IxDyn(&concat_shape),
-        padding_partitions: HashMap::new(),
+        padding_partition: copy_constraint::PaddingEnum::Zero,
       }));
 
       let neg = graph.addBB(Box::new(RepeaterBasicBlock {
@@ -112,12 +108,11 @@ impl Layer for MinLayer {
 
       let reshape_shape = &vec![input_shapes[0].iter().product(), 1];
       let reshape_permutation = util::get_reshape_indices(reshape_shape.clone(), input_shapes[0].clone());
-      let padding_partitions = zero_padding_partition(&reshape_permutation);
       let reshape_shape_pad: Vec<_> = reshape_shape.iter().map(|i| i.next_power_of_two()).collect();
       let cc1 = graph.addBB(Box::new(CopyConstraintBasicBlock {
         permutation: reshape_permutation,
         input_dim: IxDyn(&reshape_shape_pad),
-        padding_partitions,
+        padding_partition: copy_constraint::PaddingEnum::Zero,
       }));
 
       let second_input = graph.addNode(extend_second_input, vec![(-2, 0)]);

--- a/src/layer/norm.rs
+++ b/src/layer/norm.rs
@@ -4,7 +4,6 @@ use crate::layer::Layer;
 use crate::onnx;
 use crate::util;
 use ark_bn254::Fr;
-use copy_constraint::zero_padding_partition;
 use ndarray::{arr1, Array1, ArrayD, IxDyn};
 use tract_onnx::pb::AttributeProto;
 use util::copy_constraint::get_reshape_indices;
@@ -253,11 +252,10 @@ impl Layer for InstanceNormLayer {
     ];
     let permutation = get_reshape_indices(X_shape.to_vec(), x_shape_for_mean);
     let padded_input_shape: Vec<_> = X_shape.iter().map(|x| util::next_pow(*x as u32) as usize).collect();
-    let padding_partitions = zero_padding_partition(&permutation);
     let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
       permutation,
       input_dim: IxDyn(&padded_input_shape),
-      padding_partitions,
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     }));
 
     let sum = graph.addBB(Box::new(RepeaterBasicBlock {

--- a/src/layer/pool.rs
+++ b/src/layer/pool.rs
@@ -5,7 +5,6 @@ use crate::layer::Layer;
 use crate::onnx;
 use crate::util;
 use ark_bn254::Fr;
-use copy_constraint::zero_padding_partition;
 use ndarray::{arr1, indices, ArrayD, Dim, Dimension, IxDyn};
 use tract_onnx::pb::AttributeProto;
 
@@ -67,11 +66,10 @@ impl Layer for MaxPoolLayer {
     let permutation = splat_input(&input_shapes[0], &strides, &pads, ch, &kernel_shape);
     let permutation_padded = splat_pad(&permutation);
     let input_shape_padded: Vec<_> = input_shapes[0].iter().map(|i| i.next_power_of_two()).collect();
-    let padding_partitions = util::max_padding_partitions(&permutation_padded, Fr::from(onnx::CQ_RANGE_LOWER));
     let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
       permutation: permutation_padded,
       input_dim: IxDyn(&input_shape_padded),
-      padding_partitions,
+      padding_partition: copy_constraint::PaddingEnum::Max(Fr::from(onnx::CQ_RANGE_LOWER)),
     }));
 
     // Prove max over each row
@@ -90,11 +88,10 @@ impl Layer for MaxPoolLayer {
     let reshape_inp_shape = vec![output_shape.iter().fold(1, |acc, &x| acc * x), 1];
     let reshape_permutation = util::get_reshape_indices(reshape_inp_shape.clone(), output_shape.clone());
     let reshape_inp_padded: Vec<_> = reshape_inp_shape.iter().map(|x| x.next_power_of_two()).collect();
-    let padding_partitions = zero_padding_partition(&reshape_permutation);
     let cc1 = graph.addBB(Box::new(CopyConstraintBasicBlock {
       permutation: reshape_permutation,
       input_dim: IxDyn(&reshape_inp_padded),
-      padding_partitions,
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     }));
 
     let r: Vec<_> = (0..-onnx::CQ_RANGE_LOWER).map(Fr::from).collect();

--- a/src/layer/reshape.rs
+++ b/src/layer/reshape.rs
@@ -3,7 +3,6 @@ use crate::graph::*;
 use crate::layer::{squeeze::UnsqueezeBasicBlock, Layer};
 use crate::util::{self, get_reshape_indices};
 use ark_bn254::Fr;
-use copy_constraint::zero_padding_partition;
 use ndarray::{ArrayD, IxDyn};
 use tract_onnx::pb::AttributeProto;
 
@@ -38,7 +37,7 @@ impl Layer for ReshapeLayer {
       let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
         permutation: permutation.clone(),
         input_dim: IxDyn(&startShape),
-        padding_partitions: zero_padding_partition(&permutation),
+        padding_partition: copy_constraint::PaddingEnum::Zero,
       }));
       let output = graph.addNode(cc, vec![(-1, 0)]);
       graph.outputs.push((output, 0));

--- a/src/layer/resize.rs
+++ b/src/layer/resize.rs
@@ -4,7 +4,6 @@ use crate::layer::Layer;
 use crate::onnx;
 use crate::util;
 use ark_bn254::Fr;
-use copy_constraint::zero_padding_partition;
 use ndarray::Dimension;
 use ndarray::{ArrayD, IxDyn};
 use tract_onnx::pb::AttributeProto;
@@ -74,11 +73,10 @@ impl Layer for ResizeLayer {
     let permutation = util::pad_to_pow_of_two(&permutation, &None);
 
     let input_shape_padded: Vec<_> = input_shapes[0].iter().map(|i| i.next_power_of_two()).collect();
-    let padding_partitions = zero_padding_partition(&permutation);
     let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
       permutation,
       input_dim: IxDyn(&input_shape_padded),
-      padding_partitions,
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     }));
     let cc_output = graph.addNode(cc, vec![(-1, 0)]);
     graph.outputs.push((cc_output, 0));

--- a/src/layer/scatternd.rs
+++ b/src/layer/scatternd.rs
@@ -3,7 +3,6 @@ use crate::graph::*;
 use crate::layer::Layer;
 use crate::util;
 use ark_bn254::Fr;
-use copy_constraint::zero_padding_partition;
 use ndarray::{ArrayD, Dim, IxDyn};
 use tract_onnx::pb::AttributeProto;
 
@@ -50,17 +49,15 @@ impl Layer for ScatterNDLayer {
     let indices = constants[1].unwrap();
 
     let (permutation_preserve, permutation_update) = get_masks(&input_shapes[0], &indices);
-    let padding_preserve = zero_padding_partition(&permutation_preserve);
-    let padding_update = zero_padding_partition(&permutation_update);
     let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
       permutation: permutation_preserve,
       input_dim: IxDyn(&input_shapes[0]),
-      padding_partitions: padding_preserve,
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     }));
     let cc1 = graph.addBB(Box::new(CopyConstraintBasicBlock {
       permutation: permutation_update,
       input_dim: IxDyn(&input_shapes[1]),
-      padding_partitions: padding_update,
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     }));
     let add = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(AddBasicBlock {}),

--- a/src/layer/slice.rs
+++ b/src/layer/slice.rs
@@ -132,7 +132,7 @@ impl Layer for SliceLayer {
     let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
       permutation,
       input_dim: IxDyn(&input_shape_pad),
-      padding_partitions: HashMap::new(),
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     }));
     let slice_output = graph.addNode(cc, vec![(-1, 0)]);
     graph.outputs.push((slice_output, 0));

--- a/src/layer/squeeze.rs
+++ b/src/layer/squeeze.rs
@@ -3,7 +3,6 @@ use crate::graph::*;
 use crate::layer::Layer;
 use crate::util::{self, get_reshape_indices};
 use ark_bn254::Fr;
-use copy_constraint::zero_padding_partition;
 use ndarray::{ArrayD, Axis, IxDyn};
 use tract_onnx::pb::AttributeProto;
 
@@ -44,7 +43,7 @@ impl Layer for SqueezeLayer {
       let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
         permutation: permutation.clone(),
         input_dim: IxDyn(&startShape),
-        padding_partitions: zero_padding_partition(&permutation),
+        padding_partition: copy_constraint::PaddingEnum::Zero,
       }));
       let output = graph.addNode(cc, vec![(-1, 0)]);
       graph.outputs.push((output, 0));

--- a/src/layer/tile.rs
+++ b/src/layer/tile.rs
@@ -3,7 +3,6 @@ use crate::graph::*;
 use crate::layer::{squeeze::UnsqueezeBasicBlock, Layer};
 use crate::util;
 use ark_bn254::Fr;
-use copy_constraint::zero_padding_partition;
 use ndarray::{concatenate, ArrayD, Axis, IxDyn};
 use tract_onnx::pb::AttributeProto;
 
@@ -60,11 +59,10 @@ impl Layer for TileLayer {
 
     let padded_output_shape = permutation.shape().to_vec();
     let padded_input_shape: Vec<_> = input_shapes[0].iter().map(|x| util::next_pow(*x as u32) as usize).collect();
-    let padding_partitions = zero_padding_partition(&permutation);
     let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
       permutation,
       input_dim: IxDyn(&padded_input_shape),
-      padding_partitions,
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     }));
     let tiled_output = graph.addNode(cc, vec![(input_index, 0)]);
     graph.outputs.push((tiled_output, 0));

--- a/src/layer/topk.rs
+++ b/src/layer/topk.rs
@@ -4,7 +4,6 @@ use crate::layer::Layer;
 use crate::onnx;
 use crate::util;
 use ark_bn254::Fr;
-use copy_constraint::zero_padding_partition;
 use ndarray::{arr1, ArrayD, IxDyn};
 use tract_onnx::pb::AttributeProto;
 
@@ -72,19 +71,17 @@ impl Layer for TopKLayer {
     let padded_sorted_data_shape: Vec<_> = sorted_data_shape.iter().map(|x| util::next_pow(*x as u32) as usize).collect();
 
     let permutation = get_topk_indices(sorted_data_shape.clone(), k);
-    let padding_partitions = zero_padding_partition(&permutation);
     let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
       permutation: permutation.clone(),
       input_dim: IxDyn(&padded_sorted_data_shape),
-      padding_partitions,
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     }));
 
     let permutation_for_ordered_check = get_topk_indices(sorted_data_shape, data_len - 1);
-    let padding_partitions = zero_padding_partition(&permutation_for_ordered_check);
     let cc1 = graph.addBB(Box::new(CopyConstraintBasicBlock {
       permutation: permutation_for_ordered_check.clone(),
       input_dim: IxDyn(&padded_sorted_data_shape),
-      padding_partitions,
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     }));
 
     if axis != input_shapes[0].len() - 1 {
@@ -135,10 +132,7 @@ impl Layer for ArgMaxLayer {
     }));
     let data_len = input_shapes[0][axis];
     let sort = graph.addBB(Box::new(RepeaterBasicBlock {
-      basic_block: Box::new(SortBasicBlock {
-        descending: descending,
-        len: data_len,
-      }),
+      basic_block: Box::new(SortBasicBlock { descending, len: data_len }),
       N: 1,
     }));
     let one_to_one = graph.addBB(Box::new(RepeaterBasicBlock {
@@ -159,19 +153,17 @@ impl Layer for ArgMaxLayer {
     let padded_sorted_data_shape: Vec<_> = sorted_data_shape.iter().map(|x| util::next_pow(*x as u32) as usize).collect();
 
     let permutation = get_topk_indices(sorted_data_shape.clone(), 1);
-    let padding_partitions = zero_padding_partition(&permutation);
     let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
-      permutation: permutation.clone(),
+      permutation,
       input_dim: IxDyn(&padded_sorted_data_shape),
-      padding_partitions: padding_partitions,
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     }));
 
     let permutation_for_ordered_check = get_topk_indices(sorted_data_shape, data_len - 1);
-    let padding_partitions = zero_padding_partition(&permutation_for_ordered_check);
     let cc1 = graph.addBB(Box::new(CopyConstraintBasicBlock {
-      permutation: permutation_for_ordered_check.clone(),
+      permutation: permutation_for_ordered_check,
       input_dim: IxDyn(&padded_sorted_data_shape),
-      padding_partitions: padding_partitions,
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     }));
 
     if axis != input_shapes[0].len() - 1 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,8 +145,8 @@ fn main() {
   // please export RUST_LOG=debug; the debug logs for timing will be printed
   env_logger::init();
 
-  let srs = &ptau::load_file("challenge14", 14, 14);
-  let onnx_file_name = "convtranspose.onnx";
+  let srs = &ptau::load_file("challenge", 7, 7);
+  let onnx_file_name = "sample.onnx";
   let (mut graph, models) = onnx::load_file(onnx_file_name);
   let fake_inputs = util::generate_fake_inputs_for_onnx(onnx_file_name);
   let inputs = fake_inputs.iter().map(|x| x).collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,8 +145,8 @@ fn main() {
   // please export RUST_LOG=debug; the debug logs for timing will be printed
   env_logger::init();
 
-  let srs = &ptau::load_file("challenge", 7, 7);
-  let onnx_file_name = "sample.onnx";
+  let srs = &ptau::load_file("challenge14", 14, 14);
+  let onnx_file_name = "convtranspose.onnx";
   let (mut graph, models) = onnx::load_file(onnx_file_name);
   let fake_inputs = util::generate_fake_inputs_for_onnx(onnx_file_name);
   let inputs = fake_inputs.iter().map(|x| x).collect();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,7 +5,6 @@ use ark_ec::pairing::{Pairing, PairingOutput};
 use ark_poly::univariate::DensePolynomial;
 use ark_std::UniformRand;
 use ark_std::{One, Zero};
-use copy_constraint::zero_padding_partition;
 use ndarray::{arr0, concatenate, s, ArrayD, Axis, IxDyn};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::collections::HashMap;
@@ -156,7 +155,7 @@ fn test_copy_constraint() {
     CopyConstraintBasicBlock {
       permutation,
       input_dim: IxDyn(&[4]),
-      padding_partitions: HashMap::new(),
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     },
     srs,
     &empty,
@@ -172,7 +171,7 @@ fn test_copy_constraint() {
     CopyConstraintBasicBlock {
       permutation,
       input_dim: IxDyn(&[2, 2]),
-      padding_partitions: HashMap::new(),
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     },
     srs,
     &empty,
@@ -201,12 +200,11 @@ fn test_copy_constraint() {
     ],
   )
   .unwrap();
-  let padding_partitions = zero_padding_partition(&permutation);
   testBasicBlock(
     CopyConstraintBasicBlock {
       permutation,
       input_dim: IxDyn(&[4, 2]),
-      padding_partitions: padding_partitions,
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     },
     srs,
     &empty,
@@ -238,10 +236,7 @@ fn test_copy_constraint() {
       )
       .unwrap(),
       input_dim: IxDyn(&[2, 2, 4]),
-      padding_partitions: HashMap::from([
-        (Fr::zero(), vec![IxDyn(&[3, 0]), IxDyn(&[3, 1]), IxDyn(&[3, 2]), IxDyn(&[3, 3])]),
-        (Fr::one(), vec![IxDyn(&[0, 3]), IxDyn(&[1, 3]), IxDyn(&[2, 3])]),
-      ]),
+      padding_partition: copy_constraint::PaddingEnum::Max(Fr::one()),
     },
     srs,
     &empty,
@@ -261,7 +256,7 @@ fn test_copy_constraint() {
       )
       .unwrap(),
       input_dim: IxDyn(&[2, 1, 4]),
-      padding_partitions: HashMap::new(),
+      padding_partition: copy_constraint::PaddingEnum::Zero,
     },
     srs,
     &empty,

--- a/src/util/copy_constraint.rs
+++ b/src/util/copy_constraint.rs
@@ -9,42 +9,6 @@ use ark_std::Zero;
 use ndarray::{ArrayD, Axis, Dimension, IxDyn};
 use std::collections::HashMap;
 
-// Returns the padding partition where the non-zero padding value consists of all pad indices such that the last-axis subview containing it contains non-pad elements, and the zero padding value consists of all pad indices part of a last-axis subview containing only pad elements.
-// If val is 0, then these will instead be combined.
-pub fn max_padding_partitions(permutation: &ArrayD<Option<IxDyn>>, val: Fr) -> HashMap<Fr, Vec<IxDyn>> {
-  let mut zero_indices = vec![];
-  let mut nonzero_indices = vec![];
-  for (i, subview) in permutation.axis_iter(Axis(permutation.ndim() - 1)).enumerate() {
-    if subview.iter().all(|x| x.is_none()) {
-      for (idx, _) in subview.indexed_iter() {
-        let mut full_idx = idx.as_array_view().to_vec();
-        full_idx.push(i);
-        zero_indices.push(IxDyn(&full_idx));
-      }
-    } else {
-      for (idx, val) in subview.indexed_iter() {
-        if val.is_none() {
-          let mut full_idx = idx.as_array_view().to_vec();
-          full_idx.push(i);
-          nonzero_indices.push(IxDyn(&full_idx));
-        }
-      }
-    }
-  }
-  let mut partitions = HashMap::new();
-  if val == Fr::zero() {
-    zero_indices.append(&mut nonzero_indices);
-  } else {
-    if nonzero_indices.len() > 0 {
-      partitions.insert(val, nonzero_indices);
-    }
-  }
-  if zero_indices.len() > 0 {
-    partitions.insert(Fr::zero(), zero_indices);
-  }
-  partitions
-}
-
 // Helper function to get the indices of the reshaped tensor
 // Note that the input_shape and output_shape are non-padded
 pub fn get_reshape_indices(input_shape: Vec<usize>, output_shape: Vec<usize>) -> ArrayD<Option<IxDyn>> {


### PR DESCRIPTION
There are currently only two modes of cc padding partitions used, so we can convert it into an enum to reduce memory