### PR TITLE
Save cq/cq2 setups for nonlinearities and load config

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Build
       run: cargo build
     - name: Run
-      run: cargo run
+      run: cargo run -- config.yaml
     - name: Test
       run: cargo test
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ outputsEnc
 proofs
 setups
 models
-layer_setup/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ inputsEnc
 modelsEnc
 outputsEnc
 proofs
+setups
+models
+layer_setup/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ ark-poly = {version = "0.4", features = ["parallel"]}
 ark-bn254 = "0.4"
 ark-serialize = { version = "0.4", features = ["derive"] }
 serde = { version = "1.0.201", features = ["derive"] }
+serde_yaml = "0.9"
+once_cell = "1.15"
 log = { version = "0.4.14", default-features = false }
 env_logger = { version = "0.10" }
 plonky2 = { version = "0.2.2", features = ["timing"]}

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,25 @@
+task: "sample"
+onnx: 
+  model_path: "sample.onnx"
+  input_path: "not_implemented_yet"
+ptau:
+  ptau_path: "challenge"
+  pow_len_log: 7
+  loaded_pow_len_log: 7
+sf:
+  scale_factor_log: 3
+  cq_range_log: 6
+  cq_range_lower_log: 5
+prover:
+  model_path: "models"
+  setup_path: "setups"
+  enc_model_path: "modelsEnc"
+  enc_input_path: "inputsEnc"
+  enc_output_path: "outputsEnc"
+  proof_path: "proofs"
+  enable_layer_setup: true
+verifier:
+  enc_model_path: "modelsEnc"
+  enc_input_path: "inputsEnc"
+  enc_output_path: "outputsEnc"
+  proof_path: "proofs"

--- a/layer_setup/.gitignore
+++ b/layer_setup/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -1,11 +1,11 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use crate::onnx;
 use crate::util;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
 use ark_poly::{evaluations::univariate::Evaluations, univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain};
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{
   ops::{Mul, Sub},
   One, UniformRand, Zero,
@@ -27,15 +27,6 @@ impl BasicBlock for CQBasicBlock {
   }
 
   fn setup(&self, srs: &SRS, model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
-    let file_name = format!("{}.setup", util::hash_str(&format!("{self:?}")));
-    let file_path = format!("layer_setup/{}", file_name);
-    if util::file_exists(&file_path) {
-      println!("CQ: Loading layer setup from file: {}", file_path);
-      let setups =
-        Vec::<(Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>)>::deserialize_uncompressed(File::open(&file_path).unwrap()).unwrap();
-      return setups.first().unwrap().clone();
-    }
-
     assert!(model.len() == 1);
     let model = &model.first().unwrap();
     let N = model.raw.len();
@@ -64,9 +55,7 @@ impl BasicBlock for CQBasicBlock {
     let mut setup = Q_i_x_1;
     setup.extend(L_i_x_1);
     setup.extend(L_i_0_x_1);
-    let setups = vec![(setup, vec![T_x_2], Vec::new())];
-    setups.serialize_uncompressed(File::create(file_path).unwrap()).unwrap();
-    return setups.first().unwrap().clone();
+    return (setup, vec![T_x_2], Vec::new());
   }
 
   fn prove(

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -1,7 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
-use crate::onnx;
 use crate::util;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
@@ -14,7 +13,6 @@ use ndarray::{Array1, ArrayD};
 use rand::{rngs::StdRng, SeedableRng};
 use rayon::prelude::*;
 use std::collections::HashMap;
-use std::fs::File;
 
 #[derive(Debug)]
 pub struct CQBasicBlock {

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -5,6 +5,7 @@ use crate::util;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
 use ark_poly::{evaluations::univariate::Evaluations, univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{
   ops::{Mul, Sub},
   One, UniformRand, Zero,
@@ -13,6 +14,7 @@ use ndarray::{Array1, ArrayD};
 use rand::{rngs::StdRng, SeedableRng};
 use rayon::prelude::*;
 use std::collections::HashMap;
+use std::fs::File;
 
 #[derive(Debug)]
 pub struct CQBasicBlock {
@@ -25,6 +27,15 @@ impl BasicBlock for CQBasicBlock {
   }
 
   fn setup(&self, srs: &SRS, model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
+    let file_name = format!("{}.setup", util::hash_str(&format!("{self:?}")));
+    let file_path = format!("layer_setup/{}", file_name);
+    if util::file_exists(&file_path) {
+      println!("CQ: Loading layer setup from file: {}", file_path);
+      let setups =
+        Vec::<(Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>)>::deserialize_uncompressed(File::open(&file_path).unwrap()).unwrap();
+      return setups.first().unwrap().clone();
+    }
+
     assert!(model.len() == 1);
     let model = &model.first().unwrap();
     let N = model.raw.len();
@@ -53,7 +64,9 @@ impl BasicBlock for CQBasicBlock {
     let mut setup = Q_i_x_1;
     setup.extend(L_i_x_1);
     setup.extend(L_i_0_x_1);
-    return (setup, vec![T_x_2], Vec::new());
+    let setups = vec![(setup, vec![T_x_2], Vec::new())];
+    setups.serialize_uncompressed(File::create(file_path).unwrap()).unwrap();
+    return setups.first().unwrap().clone();
   }
 
   fn prove(

--- a/src/basic_block/cq2.rs
+++ b/src/basic_block/cq2.rs
@@ -31,15 +31,6 @@ impl BasicBlock for CQ2BasicBlock {
   }
 
   fn setup(&self, srs: &SRS, model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
-    let file_name = format!("{}.setup", util::hash_str(&format!("{self:?}")));
-    let file_path = format!("layer_setup/{}", file_name);
-    if util::file_exists(&file_path) {
-      println!("CQ2: Loading layer setup from file: {}", file_path);
-      let setups =
-        Vec::<(Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>)>::deserialize_uncompressed(File::open(&file_path).unwrap()).unwrap();
-      return setups.first().unwrap().clone();
-    }
-
     assert!(model.ndim() == 1 && model.len() == 2);
     let N = model[0].raw.len();
     let domain_2N = GeneralEvaluationDomain::<Fr>::new(2 * N).unwrap();
@@ -72,9 +63,7 @@ impl BasicBlock for CQ2BasicBlock {
 
     setup.extend(L_i_x_1);
     setup.extend(L_i_0_x_1);
-    let setups = vec![(setup, setup2, Vec::new())];
-    setups.serialize_uncompressed(File::create(file_path).unwrap()).unwrap();
-    return setups.first().unwrap().clone();
+    return (setup, setup2, Vec::new());
   }
 
   fn prove(

--- a/src/basic_block/cq2.rs
+++ b/src/basic_block/cq2.rs
@@ -5,7 +5,6 @@ use crate::util;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
 use ark_poly::{evaluations::univariate::Evaluations, univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain};
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{
   ops::{Mul, Sub},
   One, UniformRand, Zero,
@@ -14,7 +13,6 @@ use ndarray::ArrayD;
 use rand::{rngs::StdRng, SeedableRng};
 use rayon::prelude::*;
 use std::collections::HashMap;
-use std::fs::File;
 
 #[derive(Debug)]
 pub struct CQ2BasicBlock {

--- a/src/basic_block/cq2.rs
+++ b/src/basic_block/cq2.rs
@@ -5,6 +5,7 @@ use crate::util;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
 use ark_poly::{evaluations::univariate::Evaluations, univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{
   ops::{Mul, Sub},
   One, UniformRand, Zero,
@@ -13,6 +14,7 @@ use ndarray::ArrayD;
 use rand::{rngs::StdRng, SeedableRng};
 use rayon::prelude::*;
 use std::collections::HashMap;
+use std::fs::File;
 
 #[derive(Debug)]
 pub struct CQ2BasicBlock {
@@ -29,6 +31,15 @@ impl BasicBlock for CQ2BasicBlock {
   }
 
   fn setup(&self, srs: &SRS, model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
+    let file_name = format!("{}.setup", util::hash_str(&format!("{self:?}")));
+    let file_path = format!("layer_setup/{}", file_name);
+    if util::file_exists(&file_path) {
+      println!("CQ2: Loading layer setup from file: {}", file_path);
+      let setups =
+        Vec::<(Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>)>::deserialize_uncompressed(File::open(&file_path).unwrap()).unwrap();
+      return setups.first().unwrap().clone();
+    }
+
     assert!(model.ndim() == 1 && model.len() == 2);
     let N = model[0].raw.len();
     let domain_2N = GeneralEvaluationDomain::<Fr>::new(2 * N).unwrap();
@@ -61,7 +72,9 @@ impl BasicBlock for CQ2BasicBlock {
 
     setup.extend(L_i_x_1);
     setup.extend(L_i_0_x_1);
-    return (setup, setup2, Vec::new());
+    let setups = vec![(setup, setup2, Vec::new())];
+    setups.serialize_uncompressed(File::create(file_path).unwrap()).unwrap();
+    return setups.first().unwrap().clone();
   }
 
   fn prove(

--- a/src/basic_block/max.rs
+++ b/src/basic_block/max.rs
@@ -31,16 +31,18 @@ impl BasicBlock for MaxBasicBlock {
 }
 
 #[derive(Debug)]
-pub struct MaxProofBasicBlock;
+pub struct MaxProofBasicBlock {
+  pub cq_range_lower: i32,
+}
 
 // This max includes a proof. The first output is the max and second output is a vector of max - x for all input values x. The second output is needed because it is necessary to perform a range check on the second output.
 impl BasicBlock for MaxProofBasicBlock {
   // Returns the max of the input and max - x for all x in input
   fn run(&self, _model: &ArrayD<Fr>, inputs: &Vec<&ArrayD<Fr>>) -> Vec<ArrayD<Fr>> {
     assert!(inputs.len() == 1 && inputs[0].ndim() == 1);
-    let cq_max = Fr::from(-onnx::CQ_RANGE_LOWER);
+    let cq_max = Fr::from(-self.cq_range_lower);
     let max_arr = inputs[0]
-      .fold_axis(Axis(0), Fr::from(onnx::CQ_RANGE_LOWER), |max, y| {
+      .fold_axis(Axis(0), Fr::from(self.cq_range_lower), |max, y| {
         if (*y < cq_max && *y > *max) || (*max > cq_max && *y < cq_max) || (*y > cq_max && *max > cq_max && *y > *max) {
           *y
         } else {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,16 +1,18 @@
 #![allow(dead_code)]
 use crate::basic_block::*;
 use crate::util;
+use crate::{CONFIG, LAYER_SETUP_DIR};
 use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::bn::Bn;
 use ark_ec::pairing::{Pairing, PairingOutput};
 use ark_poly::univariate::DensePolynomial;
-use ark_serialize::CanonicalSerialize;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::Zero;
 use ndarray::ArrayD;
 use plonky2::{timed, util::timing::TimingTree};
 use rand::rngs::StdRng;
 use std::collections::HashMap;
+use std::fs::File;
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug)]
@@ -90,7 +92,27 @@ impl Graph {
       .enumerate()
       .map(|(i, (b, m))| {
         println!("setting up {:?} {:?}", i, b);
-        b.setup(srs, *m)
+        let bb_name = format!("{b:?}");
+        let save_cq_layer_setup = CONFIG.prover.enable_layer_setup && (bb_name.contains("CQ2BasicBlock") || bb_name.contains("CQBasicBlock"));
+        if save_cq_layer_setup {
+          let file_name = format!("{}.setup", util::hash_str(&format!("{bb_name:?}")));
+          let file_path = format!("{}/{}", *LAYER_SETUP_DIR, file_name);
+          if util::file_exists(&file_path) {
+            println!("CQ setup exists: Loading layer setup from file: {}", file_path);
+            let setups =
+              Vec::<(Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>)>::deserialize_uncompressed(File::open(&file_path).unwrap())
+                .unwrap();
+            return setups.first().unwrap().clone();
+          }
+        }
+        let setup = b.setup(srs, *m);
+        let setups = vec![setup];
+        if save_cq_layer_setup {
+          let file_name = format!("{}.setup", util::hash_str(&format!("{bb_name:?}")));
+          let file_path = format!("{}/{}", *LAYER_SETUP_DIR, file_name);
+          setups.serialize_uncompressed(File::create(file_path).unwrap()).unwrap();
+        }
+        return setups.first().unwrap().clone();
       })
       .collect()
   }

--- a/src/layer/clip.rs
+++ b/src/layer/clip.rs
@@ -18,7 +18,7 @@ impl Layer for ClipLayer {
     let clip_output = graph.addNode(clip, vec![(-1, 0)]);
     let clip_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
-        setup: Some((Box::new(ClipBasicBlock { min: min, max: max }), onnx::CQ_RANGE_LOWER, onnx::CQ_RANGE)),
+        setup: Some((Box::new(ClipBasicBlock { min: min, max: max }), *onnx::CQ_RANGE_LOWER, *onnx::CQ_RANGE)),
       }),
       N: 1,
     }));

--- a/src/layer/conv.rs
+++ b/src/layer/conv.rs
@@ -197,12 +197,12 @@ macro_rules! create_conv_layer {
         let matmul = graph.addBB(Box::new(MatMulBasicBlock {}));
 
         let change_SF = graph.addBB(Box::new(ChangeSFBasicBlock {
-          input_SF: onnx::SF_LOG * 2,
-          output_SF: onnx::SF_LOG,
+          input_SF: *onnx::SF_LOG * 2,
+          output_SF: *onnx::SF_LOG,
         }));
         let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
           basic_block: Box::new(CQBasicBlock {
-            setup: Array1::from_iter(onnx::CQ_RANGE_LOWER..-onnx::CQ_RANGE_LOWER).map(|x| Fr::from(*x)),
+            setup: Array1::from_iter(*onnx::CQ_RANGE_LOWER..-*onnx::CQ_RANGE_LOWER).map(|x| Fr::from(*x)),
           }),
           N: 1,
         }));

--- a/src/layer/div.rs
+++ b/src/layer/div.rs
@@ -29,7 +29,7 @@ macro_rules! create_division_layer {
 
           // Convert the constant to a floating-point number
           let c_value = util::fr_to_int(*c.first().unwrap()) as f32;
-          let c_value = if $output_idx == 0 { c_value / onnx::SF_FLOAT as f32 } else { c_value };
+          let c_value = if $output_idx == 0 { c_value / *onnx::SF_FLOAT as f32 } else { c_value };
 
           // Add a basic block for division/modulo by a constant
           let const_block = graph.addBB(Box::new($const_block { c: c_value as _ }));
@@ -37,7 +37,7 @@ macro_rules! create_division_layer {
           // Add a basic block for range checking with custom setup
           let const_check = graph.addBB(Box::new(RepeaterBasicBlock {
             basic_block: Box::new(CQ2BasicBlock {
-              setup: Some((Box::new($const_block { c: c_value as _ }), onnx::CQ_RANGE_LOWER, onnx::CQ_RANGE)),
+              setup: Some((Box::new($const_block { c: c_value as _ }), *onnx::CQ_RANGE_LOWER, *onnx::CQ_RANGE)),
             }),
             N: 1,
           }));
@@ -60,21 +60,21 @@ macro_rules! create_division_layer {
 
         // Create a basic block for division with scalar values
         let div = graph.addBB(Box::new(RepeaterBasicBlock {
-          basic_block: Box::new(DivScalarBasicBlock { output_SF: onnx::SF }),
+          basic_block: Box::new(DivScalarBasicBlock { output_SF: *onnx::SF }),
           N: 1,
         }));
 
         // Add a range check basic block for ensuring the remainder is non-negative
         let range_check = graph.addBB(Box::new(RepeaterBasicBlock {
           basic_block: Box::new(CQBasicBlock {
-            setup: Array1::from_iter(0..-onnx::CQ_RANGE_LOWER).map(|x| Fr::from(*x as i32)),
+            setup: Array1::from_iter(0..-*onnx::CQ_RANGE_LOWER).map(|x| Fr::from(*x as i32)),
           }),
           N: 1,
         }));
 
         // Create basic blocks for multiplication by constants and scalars
         let mul_SF2 = graph.addBB(Box::new(RepeaterBasicBlock {
-          basic_block: Box::new(MulConstBasicBlock { c: onnx::SF * 2 }),
+          basic_block: Box::new(MulConstBasicBlock { c: *onnx::SF * 2 }),
           N: 1,
         }));
 

--- a/src/layer/einsum.rs
+++ b/src/layer/einsum.rs
@@ -65,18 +65,18 @@ fn vector_outer_product(graph: &mut Graph, input_shapes: &Vec<&Vec<usize>>) -> V
     N: 1,
   }));
   let change_SF = graph.addBB(Box::new(ChangeSFBasicBlock {
-    input_SF: onnx::SF_LOG * 2,
-    output_SF: onnx::SF_LOG,
+    input_SF: *onnx::SF_LOG * 2,
+    output_SF: *onnx::SF_LOG,
   }));
   let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
     basic_block: Box::new(CQ2BasicBlock {
       setup: Some((
         Box::new(ChangeSFBasicBlock {
-          input_SF: onnx::SF_LOG * 2,
-          output_SF: onnx::SF_LOG,
+          input_SF: *onnx::SF_LOG * 2,
+          output_SF: *onnx::SF_LOG,
         }),
-        onnx::CQ_RANGE_LOWER,
-        onnx::CQ_RANGE,
+        *onnx::CQ_RANGE_LOWER,
+        *onnx::CQ_RANGE,
       )),
     }),
     N: 1,
@@ -114,18 +114,18 @@ fn vector_inner_product(graph: &mut Graph, _input_shapes: &Vec<&Vec<usize>>) -> 
     N: 1,
   }));
   let change_SF = graph.addBB(Box::new(ChangeSFBasicBlock {
-    input_SF: onnx::SF_LOG * 2,
-    output_SF: onnx::SF_LOG,
+    input_SF: *onnx::SF_LOG * 2,
+    output_SF: *onnx::SF_LOG,
   }));
   let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
     basic_block: Box::new(CQ2BasicBlock {
       setup: Some((
         Box::new(ChangeSFBasicBlock {
-          input_SF: onnx::SF_LOG * 2,
-          output_SF: onnx::SF_LOG,
+          input_SF: *onnx::SF_LOG * 2,
+          output_SF: *onnx::SF_LOG,
         }),
-        onnx::CQ_RANGE_LOWER,
-        onnx::CQ_RANGE,
+        *onnx::CQ_RANGE_LOWER,
+        *onnx::CQ_RANGE,
       )),
     }),
     N: 1,

--- a/src/layer/equal.rs
+++ b/src/layer/equal.rs
@@ -35,7 +35,7 @@ impl Layer for EqualLayer {
       N: 1,
     }));
 
-    let r: Vec<_> = (onnx::CQ_RANGE_LOWER..-onnx::CQ_RANGE_LOWER + 1).filter(|&x| x != 0).map(Fr::from).collect();
+    let r: Vec<_> = (*onnx::CQ_RANGE_LOWER..-*onnx::CQ_RANGE_LOWER + 1).filter(|&x| x != 0).map(Fr::from).collect();
     let nonzero_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQBasicBlock { setup: arr1(&r) }),
       N: 1,

--- a/src/layer/gemm.rs
+++ b/src/layer/gemm.rs
@@ -64,27 +64,27 @@ impl Layer for GemmLayer {
       N: 2,
     }));
     let change_SF = graph.addBB(Box::new(ChangeSFBasicBlock {
-      input_SF: onnx::SF_LOG * 2,
-      output_SF: onnx::SF_LOG,
+      input_SF: *onnx::SF_LOG * 2,
+      output_SF: *onnx::SF_LOG,
     }));
     let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
         setup: Some((
           Box::new(ChangeSFBasicBlock {
-            input_SF: onnx::SF_LOG * 2,
-            output_SF: onnx::SF_LOG,
+            input_SF: *onnx::SF_LOG * 2,
+            output_SF: *onnx::SF_LOG,
           }),
-          onnx::CQ_RANGE_LOWER,
-          onnx::CQ_RANGE,
+          *onnx::CQ_RANGE_LOWER,
+          *onnx::CQ_RANGE,
         )),
       }),
       N: 1,
     }));
     let alpha = graph.addBB(Box::new(Const2BasicBlock {
-      c: arr1(&vec![Fr::from((alpha * onnx::SF_FLOAT) as i64)]).into_dyn(),
+      c: arr1(&vec![Fr::from((alpha * *onnx::SF_FLOAT) as i64)]).into_dyn(),
     }));
     let beta = graph.addBB(Box::new(Const2BasicBlock {
-      c: arr1(&vec![Fr::from((beta * onnx::SF_FLOAT) as i64)]).into_dyn(),
+      c: arr1(&vec![Fr::from((beta * *onnx::SF_FLOAT) as i64)]).into_dyn(),
     }));
 
     let M_pad = util::next_pow(M as u32) as usize;

--- a/src/layer/less.rs
+++ b/src/layer/less.rs
@@ -34,12 +34,12 @@ impl Layer for LessLayer {
       basic_block: Box::new(SubBasicBlock {}),
       N: 1,
     }));
-    let r1: Vec<_> = (onnx::CQ_RANGE_LOWER..0).map(Fr::from).collect();
+    let r1: Vec<_> = (*onnx::CQ_RANGE_LOWER..0).map(Fr::from).collect();
     let negative_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQBasicBlock { setup: arr1(&r1) }),
       N: 1,
     }));
-    let r2: Vec<_> = (0..-onnx::CQ_RANGE_LOWER).map(Fr::from).collect();
+    let r2: Vec<_> = (0..-*onnx::CQ_RANGE_LOWER).map(Fr::from).collect();
     let non_negative_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQBasicBlock { setup: arr1(&r2) }),
       N: 1,

--- a/src/layer/lstm.rs
+++ b/src/layer/lstm.rs
@@ -113,18 +113,18 @@ impl Layer for LSTMLayer {
         N: 2,
       }));
       let change_SF = graph.addBB(Box::new(ChangeSFBasicBlock {
-        input_SF: onnx::SF_LOG * 2,
-        output_SF: onnx::SF_LOG,
+        input_SF: *onnx::SF_LOG * 2,
+        output_SF: *onnx::SF_LOG,
       }));
       let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
         basic_block: Box::new(CQ2BasicBlock {
           setup: Some((
             Box::new(ChangeSFBasicBlock {
-              input_SF: onnx::SF_LOG * 2,
-              output_SF: onnx::SF_LOG,
+              input_SF: *onnx::SF_LOG * 2,
+              output_SF: *onnx::SF_LOG,
             }),
-            onnx::CQ_RANGE_LOWER,
-            onnx::CQ_RANGE,
+            *onnx::CQ_RANGE_LOWER,
+            *onnx::CQ_RANGE,
           )),
         }),
         N: 1,
@@ -190,18 +190,18 @@ impl Layer for LSTMLayer {
 
       // sublayer 11: Sigmoid for input gate
       let sigmoid = graph.addBB(Box::new(SigmoidBasicBlock {
-        input_SF: onnx::SF_LOG * 2,
-        output_SF: onnx::SF_LOG,
+        input_SF: *onnx::SF_LOG * 2,
+        output_SF: *onnx::SF_LOG,
       }));
       let sigmoid_check = graph.addBB(Box::new(RepeaterBasicBlock {
         basic_block: Box::new(CQ2BasicBlock {
           setup: Some((
             Box::new(SigmoidBasicBlock {
-              input_SF: onnx::SF_LOG * 2,
-              output_SF: onnx::SF_LOG,
+              input_SF: *onnx::SF_LOG * 2,
+              output_SF: *onnx::SF_LOG,
             }),
-            onnx::CQ_RANGE_LOWER,
-            onnx::CQ_RANGE,
+            *onnx::CQ_RANGE_LOWER,
+            *onnx::CQ_RANGE,
           )),
         }),
         N: 1,
@@ -219,18 +219,18 @@ impl Layer for LSTMLayer {
 
       // sublayer 14: Tanh for candidate memory
       let tanh = graph.addBB(Box::new(TanhBasicBlock {
-        input_SF: onnx::SF_LOG * 2,
-        output_SF: onnx::SF_LOG,
+        input_SF: *onnx::SF_LOG * 2,
+        output_SF: *onnx::SF_LOG,
       }));
       let tanh_check = graph.addBB(Box::new(RepeaterBasicBlock {
         basic_block: Box::new(CQ2BasicBlock {
           setup: Some((
             Box::new(TanhBasicBlock {
-              input_SF: onnx::SF_LOG * 2,
-              output_SF: onnx::SF_LOG,
+              input_SF: *onnx::SF_LOG * 2,
+              output_SF: *onnx::SF_LOG,
             }),
-            onnx::CQ_RANGE_LOWER,
-            onnx::CQ_RANGE,
+            *onnx::CQ_RANGE_LOWER,
+            *onnx::CQ_RANGE,
           )),
         }),
         N: 1,

--- a/src/layer/matmul.rs
+++ b/src/layer/matmul.rs
@@ -26,18 +26,18 @@ impl Layer for MatMulLayer {
       N: 2,
     }));
     let change_SF = graph.addBB(Box::new(ChangeSFBasicBlock {
-      input_SF: onnx::SF_LOG * 2,
-      output_SF: onnx::SF_LOG,
+      input_SF: *onnx::SF_LOG * 2,
+      output_SF: *onnx::SF_LOG,
     }));
     let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
         setup: Some((
           Box::new(ChangeSFBasicBlock {
-            input_SF: onnx::SF_LOG * 2,
-            output_SF: onnx::SF_LOG,
+            input_SF: *onnx::SF_LOG * 2,
+            output_SF: *onnx::SF_LOG,
           }),
-          onnx::CQ_RANGE_LOWER,
-          onnx::CQ_RANGE,
+          *onnx::CQ_RANGE_LOWER,
+          *onnx::CQ_RANGE,
         )),
       }),
       N: 1,

--- a/src/layer/max.rs
+++ b/src/layer/max.rs
@@ -35,7 +35,9 @@ impl Layer for MaxLayer {
         padding_partitions,
       }));
       let max = graph.addBB(Box::new(RepeaterBasicBlock {
-        basic_block: Box::new(MaxProofBasicBlock {}),
+        basic_block: Box::new(MaxProofBasicBlock {
+          cq_range_lower: *onnx::CQ_RANGE_LOWER,
+        }),
         N: 1,
       }));
       let reshape_shape = &vec![input_shapes[0].iter().product(), 1];
@@ -99,14 +101,16 @@ impl Layer for MinLayer {
 
       let neg = graph.addBB(Box::new(RepeaterBasicBlock {
         basic_block: Box::new(NegBasicBlock {
-          input_SF: onnx::SF,
-          output_SF: onnx::SF,
+          input_SF: *onnx::SF,
+          output_SF: *onnx::SF,
         }),
         N: 1,
       }));
 
       let max = graph.addBB(Box::new(RepeaterBasicBlock {
-        basic_block: Box::new(MaxProofBasicBlock {}),
+        basic_block: Box::new(MaxProofBasicBlock {
+          cq_range_lower: *onnx::CQ_RANGE_LOWER,
+        }),
         N: 1,
       }));
 

--- a/src/layer/mul.rs
+++ b/src/layer/mul.rs
@@ -20,18 +20,18 @@ impl Layer for MulLayer {
       N: 1,
     }));
     let change_SF = graph.addBB(Box::new(ChangeSFBasicBlock {
-      input_SF: onnx::SF_LOG * 2,
-      output_SF: onnx::SF_LOG,
+      input_SF: *onnx::SF_LOG * 2,
+      output_SF: *onnx::SF_LOG,
     }));
     let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
         setup: Some((
           Box::new(ChangeSFBasicBlock {
-            input_SF: onnx::SF_LOG * 2,
-            output_SF: onnx::SF_LOG,
+            input_SF: *onnx::SF_LOG * 2,
+            output_SF: *onnx::SF_LOG,
           }),
-          onnx::CQ_RANGE_LOWER,
-          onnx::CQ_RANGE,
+          *onnx::CQ_RANGE_LOWER,
+          *onnx::CQ_RANGE,
         )),
       }),
       N: 1,

--- a/src/layer/nonlinear.rs
+++ b/src/layer/nonlinear.rs
@@ -18,18 +18,18 @@ macro_rules! define_nonlinear_layer {
       ) -> (Graph, Vec<Vec<usize>>) {
         let mut graph = Graph::new();
         let layer = graph.addBB(Box::new($basic_block {
-          input_SF: onnx::SF_LOG,
-          output_SF: onnx::SF_LOG,
+          input_SF: *onnx::SF_LOG,
+          output_SF: *onnx::SF_LOG,
         }));
         let layer_check = graph.addBB(Box::new(RepeaterBasicBlock {
           basic_block: Box::new(CQ2BasicBlock {
             setup: Some((
               Box::new($basic_block {
-                input_SF: onnx::SF_LOG,
-                output_SF: onnx::SF_LOG,
+                input_SF: *onnx::SF_LOG,
+                output_SF: *onnx::SF_LOG,
               }),
-              onnx::CQ_RANGE_LOWER,
-              onnx::CQ_RANGE,
+              *onnx::CQ_RANGE_LOWER,
+              *onnx::CQ_RANGE,
             )),
           }),
           N: 1,

--- a/src/layer/norm.rs
+++ b/src/layer/norm.rs
@@ -50,7 +50,7 @@ impl Layer for BatchNormLayer {
       // epsilon is not provided, use the default value
       1e-5
     };
-    epsilon *= onnx::SF_FLOAT;
+    epsilon *= *onnx::SF_FLOAT;
 
     let epsilon = graph.addBB(Box::new(Const2BasicBlock {
       c: arr1(&vec![Fr::from(epsilon.round() as i32)]).into_dyn(),
@@ -77,52 +77,52 @@ impl Layer for BatchNormLayer {
       N: 1,
     }));
     let sqrt = graph.addBB(Box::new(SqrtBasicBlock {
-      input_SF: onnx::SF_LOG * 2,
-      output_SF: onnx::SF_LOG,
+      input_SF: *onnx::SF_LOG * 2,
+      output_SF: *onnx::SF_LOG,
     }));
     let sqrt_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
         setup: Some((
           Box::new(SqrtBasicBlock {
-            input_SF: onnx::SF_LOG * 2,
-            output_SF: onnx::SF_LOG,
+            input_SF: *onnx::SF_LOG * 2,
+            output_SF: *onnx::SF_LOG,
           }),
-          onnx::CQ_RANGE_LOWER,
-          onnx::CQ_RANGE,
+          *onnx::CQ_RANGE_LOWER,
+          *onnx::CQ_RANGE,
         )),
       }),
       N: 1,
     }));
     let change_SF = graph.addBB(Box::new(ChangeSFBasicBlock {
-      input_SF: onnx::SF_LOG * 2,
-      output_SF: onnx::SF_LOG,
+      input_SF: *onnx::SF_LOG * 2,
+      output_SF: *onnx::SF_LOG,
     }));
     let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
         setup: Some((
           Box::new(ChangeSFBasicBlock {
-            input_SF: onnx::SF_LOG * 2,
-            output_SF: onnx::SF_LOG,
+            input_SF: *onnx::SF_LOG * 2,
+            output_SF: *onnx::SF_LOG,
           }),
-          onnx::CQ_RANGE_LOWER,
-          onnx::CQ_RANGE,
+          *onnx::CQ_RANGE_LOWER,
+          *onnx::CQ_RANGE,
         )),
       }),
       N: 1,
     }));
 
     let div = graph.addBB(Box::new(RepeaterBasicBlock {
-      basic_block: Box::new(DivScalarBasicBlock { output_SF: onnx::SF }),
+      basic_block: Box::new(DivScalarBasicBlock { output_SF: *onnx::SF }),
       N: 1,
     }));
     let range_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQBasicBlock {
-        setup: Array1::from_iter(0..onnx::CQ_RANGE).map(|x| Fr::from(*x as i32)),
+        setup: Array1::from_iter(0..*onnx::CQ_RANGE).map(|x| Fr::from(*x as i32)),
       }),
       N: 1,
     }));
     let mul_SF2 = graph.addBB(Box::new(RepeaterBasicBlock {
-      basic_block: Box::new(MulConstBasicBlock { c: onnx::SF * 2 }),
+      basic_block: Box::new(MulConstBasicBlock { c: *onnx::SF * 2 }),
       N: 1,
     }));
     let mul_2 = graph.addBB(Box::new(RepeaterBasicBlock {
@@ -243,7 +243,7 @@ impl Layer for InstanceNormLayer {
       // epsilon is not provided, use the default value
       1e-5
     };
-    epsilon *= onnx::SF_FLOAT;
+    epsilon *= *onnx::SF_FLOAT;
 
     // X_shape_for_mean: [N, C, D1 * D2 * ... * DN]
     let x_shape_for_mean = vec![
@@ -273,8 +273,8 @@ impl Layer for InstanceNormLayer {
           Box::new(DivConstBasicBlock {
             c: X_shape.into_iter().skip(2).cloned().collect::<Vec<_>>().iter().fold(1, |x, &y| x * y) as f32,
           }),
-          onnx::CQ_RANGE_LOWER,
-          onnx::CQ_RANGE,
+          *onnx::CQ_RANGE_LOWER,
+          *onnx::CQ_RANGE,
         )),
       }),
       N: 1,
@@ -315,52 +315,52 @@ impl Layer for InstanceNormLayer {
       N: 1,
     }));
     let sqrt = graph.addBB(Box::new(SqrtBasicBlock {
-      input_SF: onnx::SF_LOG * 2,
-      output_SF: onnx::SF_LOG,
+      input_SF: *onnx::SF_LOG * 2,
+      output_SF: *onnx::SF_LOG,
     }));
     let sqrt_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
         setup: Some((
           Box::new(SqrtBasicBlock {
-            input_SF: onnx::SF_LOG * 2,
-            output_SF: onnx::SF_LOG,
+            input_SF: *onnx::SF_LOG * 2,
+            output_SF: *onnx::SF_LOG,
           }),
-          onnx::CQ_RANGE_LOWER,
-          onnx::CQ_RANGE,
+          *onnx::CQ_RANGE_LOWER,
+          *onnx::CQ_RANGE,
         )),
       }),
       N: 1,
     }));
     let change_SF = graph.addBB(Box::new(ChangeSFBasicBlock {
-      input_SF: onnx::SF_LOG * 2,
-      output_SF: onnx::SF_LOG,
+      input_SF: *onnx::SF_LOG * 2,
+      output_SF: *onnx::SF_LOG,
     }));
     let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
         setup: Some((
           Box::new(ChangeSFBasicBlock {
-            input_SF: onnx::SF_LOG * 2,
-            output_SF: onnx::SF_LOG,
+            input_SF: *onnx::SF_LOG * 2,
+            output_SF: *onnx::SF_LOG,
           }),
-          onnx::CQ_RANGE_LOWER,
-          onnx::CQ_RANGE,
+          *onnx::CQ_RANGE_LOWER,
+          *onnx::CQ_RANGE,
         )),
       }),
       N: 1,
     }));
 
     let div = graph.addBB(Box::new(RepeaterBasicBlock {
-      basic_block: Box::new(DivScalarBasicBlock { output_SF: onnx::SF }),
+      basic_block: Box::new(DivScalarBasicBlock { output_SF: *onnx::SF }),
       N: 1,
     }));
     let range_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQBasicBlock {
-        setup: Array1::from_iter(0..onnx::CQ_RANGE).map(|x| Fr::from(*x as i32)),
+        setup: Array1::from_iter(0..*onnx::CQ_RANGE).map(|x| Fr::from(*x as i32)),
       }),
       N: 1,
     }));
     let mul_SF2 = graph.addBB(Box::new(RepeaterBasicBlock {
-      basic_block: Box::new(MulConstBasicBlock { c: onnx::SF * 2 }),
+      basic_block: Box::new(MulConstBasicBlock { c: *onnx::SF * 2 }),
       N: 1,
     }));
     let mul_2 = graph.addBB(Box::new(RepeaterBasicBlock {

--- a/src/layer/pool.rs
+++ b/src/layer/pool.rs
@@ -67,7 +67,7 @@ impl Layer for MaxPoolLayer {
     let permutation = splat_input(&input_shapes[0], &strides, &pads, ch, &kernel_shape);
     let permutation_padded = splat_pad(&permutation);
     let input_shape_padded: Vec<_> = input_shapes[0].iter().map(|i| i.next_power_of_two()).collect();
-    let padding_partitions = util::max_padding_partitions(&permutation_padded, Fr::from(onnx::CQ_RANGE_LOWER));
+    let padding_partitions = util::max_padding_partitions(&permutation_padded, Fr::from(*onnx::CQ_RANGE_LOWER));
     let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
       permutation: permutation_padded,
       input_dim: IxDyn(&input_shape_padded),
@@ -76,7 +76,9 @@ impl Layer for MaxPoolLayer {
 
     // Prove max over each row
     let max = graph.addBB(Box::new(RepeaterBasicBlock {
-      basic_block: Box::new(MaxProofBasicBlock {}),
+      basic_block: Box::new(MaxProofBasicBlock {
+        cq_range_lower: *onnx::CQ_RANGE_LOWER,
+      }),
       N: 1,
     }));
 
@@ -97,7 +99,7 @@ impl Layer for MaxPoolLayer {
       padding_partitions,
     }));
 
-    let r: Vec<_> = (0..-onnx::CQ_RANGE_LOWER).map(Fr::from).collect();
+    let r: Vec<_> = (0..-*onnx::CQ_RANGE_LOWER).map(Fr::from).collect();
     let range_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQBasicBlock { setup: arr1(&r) }),
       N: 1,

--- a/src/layer/pow.rs
+++ b/src/layer/pow.rs
@@ -10,24 +10,24 @@ pub struct PowLayer;
 impl Layer for PowLayer {
   fn graph(input_shapes: &Vec<&Vec<usize>>, constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
-    assert!(constants[1].unwrap().first().unwrap() == &Fr::from(2 * crate::onnx::SF as u32));
+    assert!(constants[1].unwrap().first().unwrap() == &Fr::from(2 * *onnx::SF as u32));
     let mul = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(MulBasicBlock {}),
       N: 1,
     }));
     let change_SF = graph.addBB(Box::new(ChangeSFBasicBlock {
-      input_SF: crate::onnx::SF_LOG * 2,
-      output_SF: crate::onnx::SF_LOG,
+      input_SF: *onnx::SF_LOG * 2,
+      output_SF: *onnx::SF_LOG,
     }));
     let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
         setup: Some((
           Box::new(ChangeSFBasicBlock {
-            input_SF: crate::onnx::SF_LOG * 2,
-            output_SF: crate::onnx::SF_LOG,
+            input_SF: *onnx::SF_LOG * 2,
+            output_SF: *onnx::SF_LOG,
           }),
-          onnx::CQ_RANGE_LOWER,
-          onnx::CQ_RANGE,
+          *onnx::CQ_RANGE_LOWER,
+          *onnx::CQ_RANGE,
         )),
       }),
       N: 1,

--- a/src/layer/reducemean.rs
+++ b/src/layer/reducemean.rs
@@ -59,8 +59,8 @@ impl Layer for ReduceMeanLayer {
           Box::new(DivConstBasicBlock {
             c: input_shapes[0][input_shapes[0].len() - 1] as f32,
           }),
-          onnx::CQ_RANGE_LOWER,
-          onnx::CQ_RANGE,
+          *onnx::CQ_RANGE_LOWER,
+          *onnx::CQ_RANGE,
         )),
       }),
       N: 1,

--- a/src/layer/resize.rs
+++ b/src/layer/resize.rs
@@ -67,7 +67,7 @@ impl Layer for ResizeLayer {
       panic!("Resize has invalid nearest_mode string");
     };
     // scales is a float, so it will have been scaled by onnx::SF by the onnx compiler. This assumes that dividing by onnx::SF will recover the original value
-    let scales: Vec<_> = constants[2].unwrap().iter().map(|x| util::fr_to_int(*x) as f32 / onnx::SF as f32).collect();
+    let scales: Vec<_> = constants[2].unwrap().iter().map(|x| util::fr_to_int(*x) as f32 / *onnx::SF as f32).collect();
     assert!(scales.len() == input_shapes[0].len());
 
     let (output_shape, permutation) = resize_permutation(input_shapes[0], &scales);

--- a/src/layer/softmax.rs
+++ b/src/layer/softmax.rs
@@ -16,18 +16,18 @@ impl Layer for SoftmaxLayer {
       N: 1,
     }));
     let exp = graph.addBB(Box::new(ExpBasicBlock {
-      input_SF: onnx::SF_LOG,
-      output_SF: onnx::SF_LOG,
+      input_SF: *onnx::SF_LOG,
+      output_SF: *onnx::SF_LOG,
     }));
     let exp_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
         setup: Some((
           Box::new(ExpBasicBlock {
-            input_SF: onnx::SF_LOG,
-            output_SF: onnx::SF_LOG,
+            input_SF: *onnx::SF_LOG,
+            output_SF: *onnx::SF_LOG,
           }),
-          -(onnx::CQ_RANGE as i32),
-          onnx::CQ_RANGE,
+          -(*onnx::CQ_RANGE as i32),
+          *onnx::CQ_RANGE,
         )),
       }),
       N: 1,
@@ -37,18 +37,18 @@ impl Layer for SoftmaxLayer {
       N: 1,
     }));
     let log = graph.addBB(Box::new(LogBasicBlock {
-      input_SF: onnx::SF_LOG,
-      output_SF: onnx::SF_LOG,
+      input_SF: *onnx::SF_LOG,
+      output_SF: *onnx::SF_LOG,
     }));
     let log_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
         setup: Some((
           Box::new(LogBasicBlock {
-            input_SF: onnx::SF_LOG,
-            output_SF: onnx::SF_LOG,
+            input_SF: *onnx::SF_LOG,
+            output_SF: *onnx::SF_LOG,
           }),
           0,
-          onnx::CQ_RANGE,
+          *onnx::CQ_RANGE,
         )),
       }),
       N: 1,

--- a/src/layer/topk.rs
+++ b/src/layer/topk.rs
@@ -59,9 +59,9 @@ impl Layer for TopKLayer {
       N: 1,
     }));
     let r: Vec<_> = if descending {
-      (0..-onnx::CQ_RANGE_LOWER).map(Fr::from).collect()
+      (0..-*onnx::CQ_RANGE_LOWER).map(Fr::from).collect()
     } else {
-      (onnx::CQ_RANGE_LOWER + 1..1).map(Fr::from).collect()
+      (*onnx::CQ_RANGE_LOWER + 1..1).map(Fr::from).collect()
     };
     let range_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQBasicBlock { setup: arr1(&r) }),
@@ -149,7 +149,7 @@ impl Layer for ArgMaxLayer {
       basic_block: Box::new(OrderedBasicBlock {}),
       N: 1,
     }));
-    let r: Vec<_> = (0..-onnx::CQ_RANGE_LOWER).map(Fr::from).collect();
+    let r: Vec<_> = (0..-*onnx::CQ_RANGE_LOWER).map(Fr::from).collect();
     let range_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQBasicBlock { setup: arr1(&r) }),
       N: 1,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
 use crate::graph::Graph;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_poly::univariate::DensePolynomial;
@@ -24,7 +25,30 @@ mod util;
 
 fn setup(srs: &SRS, graph: &Graph, models: &Vec<&ArrayD<Fr>>, timing: &mut TimingTree) {
   // Setup:
-  let models: Vec<ArrayD<Data>> = models.par_iter().map(|model| convert_to_data(srs, model)).collect();
+  let models: Vec<ArrayD<Data>> = util::vec_iter(&models)
+    .enumerate()
+    .map(|(i, model)| {
+      let bb = &graph.basic_blocks[i];
+      let bb_name = format!("{bb:?}");
+      let file_name = format!("{}.model", util::hash_str(&format!("{bb_name:?}")));
+      let file_path = format!("layer_setup/{}", file_name);
+      if util::file_exists(&file_path) {
+        println!("CQs: Loading layer model from file: {}", file_path);
+        let mut modelBytes = Vec::new();
+        File::open(file_path).unwrap().read_to_end(&mut modelBytes).unwrap();
+        let model: ArrayD<Data> = bincode::deserialize(&modelBytes).unwrap();
+        model
+      } else {
+        let model = convert_to_data(srs, model);
+        if bb_name.contains("CQ2BasicBlock") || bb_name.contains("CQBasicBlock") {
+          let modelBytes = bincode::serialize(&model).unwrap();
+          fs::write(file_path, &modelBytes).unwrap();
+        }
+        model
+      }
+    })
+    .collect();
+
   let models_ref: Vec<&ArrayD<Data>> = models.iter().map(|model| model).collect();
   let setups = timed!(timing, "setup and encode models", graph.setup(srs, &models_ref));
   // Save files:

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,8 @@ mod util;
 
 fn setup(srs: &SRS, graph: &Graph, models: &Vec<&ArrayD<Fr>>, timing: &mut TimingTree) {
   // Setup:
-  let models: Vec<ArrayD<Data>> = util::vec_iter(&models)
+  let models: Vec<ArrayD<Data>> = models
+    .par_iter()
     .enumerate()
     .map(|(i, model)| {
       let bb = &graph.basic_blocks[i];

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,14 @@ use ark_poly::univariate::DensePolynomial;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use basic_block::*;
 use ndarray::ArrayD;
+use once_cell::sync::Lazy;
 use rand::{rngs::StdRng, SeedableRng};
 use rayon::prelude::*;
 use sha3::{Digest, Keccak256};
+use std::env;
 use std::fs::{self, File};
 use std::io::Read;
+use std::path::Path;
 use util::{convert_to_data, measure_file_size};
 mod basic_block;
 mod graph;
@@ -23,6 +26,28 @@ mod ptau;
 mod tests;
 mod util;
 
+// Define a static CONFIG that holds the loaded configuration
+static CONFIG: Lazy<util::Config> = Lazy::new(|| {
+  let args: Vec<String> = env::args().collect();
+  if args.len() != 2 {
+    panic!("Usage: cargo run -- <config file>");
+  }
+  let mut file = File::open(&args[1]).expect("Could not open config");
+  let mut contents = String::new();
+  file.read_to_string(&mut contents).expect("Could not read config");
+
+  serde_yaml::from_str(&contents).expect("Could not parse config")
+});
+
+static LAYER_SETUP_DIR: Lazy<String> = Lazy::new(|| {
+  let dir = format!(
+    "layer_setup/{}_{}_{}",
+    CONFIG.sf.scale_factor_log, CONFIG.sf.cq_range_log, CONFIG.sf.cq_range_lower_log
+  );
+  assert!(Path::new(&dir).exists() || fs::create_dir_all(&dir).is_ok());
+  dir
+});
+
 fn setup(srs: &SRS, graph: &Graph, models: &Vec<&ArrayD<Fr>>, timing: &mut TimingTree) {
   // Setup:
   let models: Vec<ArrayD<Data>> = models
@@ -32,7 +57,7 @@ fn setup(srs: &SRS, graph: &Graph, models: &Vec<&ArrayD<Fr>>, timing: &mut Timin
       let bb = &graph.basic_blocks[i];
       let bb_name = format!("{bb:?}");
       let file_name = format!("{}.model", util::hash_str(&format!("{bb_name:?}")));
-      let file_path = format!("layer_setup/{}", file_name);
+      let file_path = format!("{}/{}", *LAYER_SETUP_DIR, file_name);
       if util::file_exists(&file_path) {
         println!("CQs: Loading layer model from file: {}", file_path);
         let mut modelBytes = Vec::new();
@@ -53,9 +78,9 @@ fn setup(srs: &SRS, graph: &Graph, models: &Vec<&ArrayD<Fr>>, timing: &mut Timin
   let models_ref: Vec<&ArrayD<Data>> = models.iter().map(|model| model).collect();
   let setups = timed!(timing, "setup and encode models", graph.setup(srs, &models_ref));
   // Save files:
-  setups.serialize_uncompressed(File::create("setups").unwrap()).unwrap();
+  setups.serialize_uncompressed(File::create(&CONFIG.prover.setup_path).unwrap()).unwrap();
   let modelsBytes = bincode::serialize(&models).unwrap();
-  fs::write("models", &modelsBytes).unwrap();
+  fs::write(&CONFIG.prover.model_path, &modelsBytes).unwrap();
 }
 
 fn run(inputs: &Vec<&ArrayD<Fr>>, graph: &Graph, models: &Vec<&ArrayD<Fr>>, timing: &mut TimingTree) -> Vec<Vec<ArrayD<Fr>>> {
@@ -66,7 +91,8 @@ fn run(inputs: &Vec<&ArrayD<Fr>>, graph: &Graph, models: &Vec<&ArrayD<Fr>>, timi
 fn prove(srs: &SRS, inputs: &Vec<&ArrayD<Fr>>, outputs: Vec<Vec<ArrayD<Fr>>>, graph: &mut Graph, timing: &mut TimingTree) {
   // Load model and setup:
   let setups =
-    Vec::<(Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>)>::deserialize_uncompressed(File::open("setups").unwrap()).unwrap();
+    Vec::<(Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>)>::deserialize_uncompressed(File::open(&CONFIG.prover.setup_path).unwrap())
+      .unwrap();
   let setups: Vec<(Vec<G1Affine>, Vec<G2Affine>, Vec<DensePolynomial<Fr>>)> = util::vec_iter(&setups)
     .map(|x| {
       (
@@ -79,7 +105,7 @@ fn prove(srs: &SRS, inputs: &Vec<&ArrayD<Fr>>, outputs: Vec<Vec<ArrayD<Fr>>>, gr
   let setups = setups.iter().map(|x| (&x.0, &x.1, &x.2)).collect();
 
   let mut modelsBytes = Vec::new();
-  File::open("models").unwrap().read_to_end(&mut modelsBytes).unwrap();
+  File::open(&CONFIG.prover.model_path).unwrap().read_to_end(&mut modelsBytes).unwrap();
   let models: Vec<ArrayD<Data>> = bincode::deserialize(&modelsBytes).unwrap();
   let models: Vec<&ArrayD<Data>> = models.iter().map(|model| model).collect();
 
@@ -104,9 +130,9 @@ fn prove(srs: &SRS, inputs: &Vec<&ArrayD<Fr>>, outputs: Vec<Vec<ArrayD<Fr>>>, gr
   let modelsEncBytes = bincode::serialize(&modelsEnc).unwrap();
   let inputsEncBytes = bincode::serialize(&inputsEnc).unwrap();
   let outputsEncBytes = bincode::serialize(&outputsEnc).unwrap();
-  fs::write("modelsEnc", &modelsEncBytes).unwrap();
-  fs::write("inputsEnc", &inputsEncBytes).unwrap();
-  fs::write("outputsEnc", &outputsEncBytes).unwrap();
+  fs::write(&CONFIG.prover.enc_model_path, &modelsEncBytes).unwrap();
+  fs::write(&CONFIG.prover.enc_input_path, &inputsEncBytes).unwrap();
+  fs::write(&CONFIG.prover.enc_output_path, &outputsEncBytes).unwrap();
 
   // Fiat-Shamir:
   let mut hasher = Keccak256::new();
@@ -119,23 +145,24 @@ fn prove(srs: &SRS, inputs: &Vec<&ArrayD<Fr>>, outputs: Vec<Vec<ArrayD<Fr>>>, gr
 
   // Prove:
   let proofs = timed!(timing, "prove", graph.prove(srs, &setups, &models, &inputs, &outputs, &mut rng, timing));
-  proofs.serialize_uncompressed(File::create("proofs").unwrap()).unwrap();
+  proofs.serialize_uncompressed(File::create(&CONFIG.prover.proof_path).unwrap()).unwrap();
 }
 
 fn verify(srs: &SRS, graph: &Graph, timing: &mut TimingTree) {
   // Read Files:
-  let proofs = Vec::<(Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>)>::deserialize_uncompressed_unchecked(File::open("proofs").unwrap()).unwrap();
+  let proofs =
+    Vec::<(Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>)>::deserialize_uncompressed_unchecked(File::open(&CONFIG.verifier.proof_path).unwrap()).unwrap();
   let proofs = proofs.iter().map(|x| (&x.0, &x.1, &x.2)).collect();
   let mut modelsEncBytes = Vec::new();
-  File::open("modelsEnc").unwrap().read_to_end(&mut modelsEncBytes).unwrap();
+  File::open(&CONFIG.verifier.enc_model_path).unwrap().read_to_end(&mut modelsEncBytes).unwrap();
   let modelsEnc: Vec<ArrayD<DataEnc>> = bincode::deserialize(&modelsEncBytes).unwrap();
   let modelsEnc: Vec<&ArrayD<DataEnc>> = modelsEnc.iter().map(|model| model).collect();
   let mut inputsEncBytes = Vec::new();
-  File::open("inputsEnc").unwrap().read_to_end(&mut inputsEncBytes).unwrap();
+  File::open(&CONFIG.verifier.enc_input_path).unwrap().read_to_end(&mut inputsEncBytes).unwrap();
   let inputsEnc: Vec<ArrayD<DataEnc>> = bincode::deserialize(&inputsEncBytes).unwrap();
   let inputsEnc: Vec<&ArrayD<DataEnc>> = inputsEnc.iter().map(|input| input).collect();
   let mut outputsEncBytes = Vec::new();
-  File::open("outputsEnc").unwrap().read_to_end(&mut outputsEncBytes).unwrap();
+  File::open(&CONFIG.verifier.enc_output_path).unwrap().read_to_end(&mut outputsEncBytes).unwrap();
   let outputsEnc: Vec<Vec<ArrayD<DataEnc>>> = bincode::deserialize(&outputsEncBytes).unwrap();
   let outputsEnc: Vec<Vec<&ArrayD<DataEnc>>> = outputsEnc.iter().map(|output| output.iter().map(|x| x).collect()).collect();
   let outputsEnc: Vec<&Vec<&ArrayD<DataEnc>>> = outputsEnc.iter().map(|x| x).collect();
@@ -170,8 +197,8 @@ fn main() {
   // please export RUST_LOG=debug; the debug logs for timing will be printed
   env_logger::init();
 
-  let srs = &ptau::load_file("challenge", 7, 7);
-  let onnx_file_name = "sample.onnx";
+  let srs = &ptau::load_file(&CONFIG.ptau.ptau_path, CONFIG.ptau.pow_len_log, CONFIG.ptau.loaded_pow_len_log);
+  let onnx_file_name = &CONFIG.onnx.model_path;
   let (mut graph, models) = onnx::load_file(onnx_file_name);
   let fake_inputs = util::generate_fake_inputs_for_onnx(onnx_file_name);
   let inputs = fake_inputs.iter().map(|x| x).collect();
@@ -180,11 +207,12 @@ fn main() {
   let outputs = run(&inputs, &graph, &models, &mut timing);
   prove(&srs, &inputs, outputs, &mut graph, &mut timing);
   verify(&srs, &graph, &mut timing);
+
   // measure proof size
-  measure_file_size("modelsEnc");
-  measure_file_size("inputsEnc");
-  measure_file_size("outputsEnc");
-  measure_file_size("proofs");
+  measure_file_size(&CONFIG.prover.enc_model_path);
+  measure_file_size(&CONFIG.prover.enc_input_path);
+  measure_file_size(&CONFIG.prover.enc_output_path);
+  measure_file_size(&CONFIG.prover.proof_path);
   timing.print();
   println!("Cargo run was successful.");
 }

--- a/src/onnx.rs
+++ b/src/onnx.rs
@@ -2,9 +2,11 @@ use crate::basic_block::*;
 use crate::graph::*;
 use crate::layer::*;
 use crate::util;
+use crate::CONFIG;
 use ark_bn254::Fr;
 use ark_std::Zero;
 use ndarray::{arr1, ArrayD};
+use once_cell::sync::Lazy;
 use pool::MaxPoolLayer;
 use std::collections::HashMap;
 use tract_onnx::pb;
@@ -12,11 +14,11 @@ use tract_onnx::pb::AttributeProto;
 use tract_onnx::prelude::{DatumType, Framework};
 use tract_onnx::tensor::load_tensor;
 
-pub const SF_LOG: usize = 3; //9
-pub const SF: usize = 1 << SF_LOG;
-pub const SF_FLOAT: f32 = (1 << SF_LOG) as f32;
-pub const CQ_RANGE: usize = 1 << 6; //12
-pub const CQ_RANGE_LOWER: i32 = -(1 << 5);
+pub static SF_LOG: Lazy<usize> = Lazy::new(|| CONFIG.sf.scale_factor_log);
+pub static SF: Lazy<usize> = Lazy::new(|| 1 << *SF_LOG);
+pub static SF_FLOAT: Lazy<f32> = Lazy::new(|| (1 << *SF_LOG) as f32);
+pub static CQ_RANGE: Lazy<usize> = Lazy::new(|| 1 << CONFIG.sf.cq_range_log);
+pub static CQ_RANGE_LOWER: Lazy<i32> = Lazy::new(|| -(1 << CONFIG.sf.cq_range_lower_log));
 
 // This function is used for parsing the inputs of onnx models
 fn parse_onnx_inputs(onnx_graph: &pb::GraphProto) -> (HashMap<String, usize>, HashMap<String, Vec<usize>>) {
@@ -75,7 +77,7 @@ fn parse_onnx_constants<'a>(
       DatumType::F32 => {
         let tensor = tensor.into_array::<f32>().unwrap();
         Ok(tensor.map(|x| {
-          let mut y = (*x * SF_FLOAT).round();
+          let mut y = (*x * *SF_FLOAT).round();
           y = y.clamp(-(1 << 15) as f32, (1 << 15) as f32);
           Fr::from(y as i32)
         }))
@@ -276,16 +278,12 @@ fn process_node(
     let node_inputs: Vec<_> = node_constants.iter().map(|&x| x.unwrap().clone()).collect();
     let node_inputs = node_inputs.iter().map(|x| x).collect();
     let outputs = local_graph.run(&node_inputs, &vec![&arr1(&[]).into_dyn(); local_graph.basic_blocks.len()]);
-    node
-      .output
-      .iter()
-      .zip(local_graph.outputs.iter())
-      .for_each(|(output_str, &(nodeX, nodeY))| {
-        passed_constants.insert(
-          output_str.to_string(),
-          util::pad_to_pow_of_two(&outputs[nodeX as usize][nodeY].clone(), &Fr::zero()),
-        );
-      });
+    node.output.iter().zip(local_graph.outputs.iter()).for_each(|(output_str, &(nodeX, nodeY))| {
+      passed_constants.insert(
+        output_str.to_string(),
+        util::pad_to_pow_of_two(&outputs[nodeX as usize][nodeY].clone(), &Fr::zero()),
+      );
+    });
   }
 
   // update graph with local graph
@@ -294,10 +292,7 @@ fn process_node(
   // handle a special case (op == "Shape")
   if op == "Shape" {
     let shape = arr1(&input_shapes[0].iter().map(|&x| Fr::from(x as i32)).collect::<Vec<_>>()).into_dyn();
-    passed_constants.insert(
-      (&node.output[0]).to_string(),
-      util::pad_to_pow_of_two(&shape, &Fr::zero()),
-    );
+    passed_constants.insert((&node.output[0]).to_string(), util::pad_to_pow_of_two(&shape, &Fr::zero()));
   }
 
   // update shapes

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -136,14 +136,36 @@ fn testBasicBlocks() {
 
 #[test]
 fn test_max() {
+  let CQ_RANGE_LOWER: i32 = -(1 << 5);
   let srs = &ptau::load_file("challenge", 7, 7);
   let empty = ArrayD::zeros(IxDyn(&[0]));
   let a = ArrayD::from_shape_vec(IxDyn(&[2]), vec![1, 0].into_iter().map(|x| Fr::from(x)).collect()).unwrap();
-  testBasicBlock(MaxProofBasicBlock {}, srs, &empty, &vec![&a]);
+  testBasicBlock(
+    MaxProofBasicBlock {
+      cq_range_lower: CQ_RANGE_LOWER,
+    },
+    srs,
+    &empty,
+    &vec![&a],
+  );
   let b = ArrayD::from_shape_vec(IxDyn(&[4]), vec![-2, 2, -1, 4].into_iter().map(|x| Fr::from(x)).collect()).unwrap();
-  testBasicBlock(MaxProofBasicBlock {}, srs, &empty, &vec![&b]);
+  testBasicBlock(
+    MaxProofBasicBlock {
+      cq_range_lower: CQ_RANGE_LOWER,
+    },
+    srs,
+    &empty,
+    &vec![&b],
+  );
   let c = ArrayD::from_shape_vec(IxDyn(&[4]), vec![-4, -3, -1, -2].into_iter().map(|x| Fr::from(x)).collect()).unwrap();
-  testBasicBlock(MaxProofBasicBlock {}, srs, &empty, &vec![&c]);
+  testBasicBlock(
+    MaxProofBasicBlock {
+      cq_range_lower: CQ_RANGE_LOWER,
+    },
+    srs,
+    &empty,
+    &vec![&c],
+  );
 }
 
 #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
 pub use arithmetic::*;
+pub use config::*;
 pub use copy_constraint::*;
 pub use fft::*;
 pub use iter::*;
@@ -11,6 +12,7 @@ pub use shape::*;
 pub use verifier::*;
 
 pub mod arithmetic;
+pub mod config;
 pub mod copy_constraint;
 pub mod fft;
 pub mod iter;

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -1,0 +1,50 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+  pub task: String,
+  pub onnx: OnnxConfig,
+  pub ptau: PtauConfig,
+  pub sf: ScaleFactorConfig,
+  pub prover: ProverConfig,
+  pub verifier: VerifierConfig,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PtauConfig {
+  pub ptau_path: String,
+  pub pow_len_log: usize,
+  pub loaded_pow_len_log: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OnnxConfig {
+  pub model_path: String,
+  pub input_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ScaleFactorConfig {
+  pub scale_factor_log: usize,
+  pub cq_range_log: usize,
+  pub cq_range_lower_log: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ProverConfig {
+  pub model_path: String,
+  pub setup_path: String,
+  pub enc_model_path: String,
+  pub enc_input_path: String,
+  pub enc_output_path: String,
+  pub proof_path: String,
+  pub enable_layer_setup: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct VerifierConfig {
+  pub enc_model_path: String,
+  pub enc_input_path: String,
+  pub enc_output_path: String,
+  pub proof_path: String,
+}

--- a/src/util/serialization.rs
+++ b/src/util/serialization.rs
@@ -3,7 +3,9 @@
  * And other file I/O utilities.
  */
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use std::fs::File;
+use std::collections::hash_map::DefaultHasher;
+use std::fs::{self, File};
+use std::hash::{Hash, Hasher};
 
 // For serialization, ArrayD uses serde while G1Affine uses ark_serialize.
 // In order to bridge between the two, the following code snippet is used:
@@ -48,4 +50,15 @@ pub fn format_file_size(bytes: u64) -> String {
   } else {
     format!("{} bytes", bytes)
   }
+}
+
+pub fn hash_str(s: &str) -> String {
+  let mut hasher = DefaultHasher::new();
+  s.hash(&mut hasher);
+  let hash_value = hasher.finish();
+  hash_value.to_string()
+}
+
+pub fn file_exists(path: &str) -> bool {
+  fs::metadata(path).is_ok()
 }

--- a/test_gpu_scripts/test_gpu.sbatch
+++ b/test_gpu_scripts/test_gpu.sbatch
@@ -18,7 +18,7 @@ srun python test_gpu_scripts/notify_enqueue.py "$1" "$2" "$3"
 srun rustup override set nightly
 
 export LIBCLANG_PATH=/projects/illinois/eng/cs/ddkang/bjchen4/gpu/llvm-project/build/lib
-srun --export=ALL cargo run --features gpu
+srun --export=ALL cargo run --features gpu -- config.yaml
 srun python test_gpu_scripts/notify_result.py "$1" "$2" "$3"
 
 srun --export=ALL cargo test --features gpu


### PR DESCRIPTION
This PR added a feature that saves CQ/CQ2 setups, which prevents us from wasting time for setting up the same nonlinear layers across different models.