### PR TITLE
Add DatumType to Layer constants

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -39,7 +39,7 @@ pub use split::SplitLayer;
 pub use squeeze::{SqueezeLayer, UnsqueezeLayer};
 pub use tile::TileLayer;
 pub use topk::{ArgMaxLayer, TopKLayer};
-use tract_onnx::pb::AttributeProto;
+use tract_onnx::{pb::AttributeProto, prelude::DatumType};
 pub use transpose::TransposeLayer;
 pub use xor::XorLayer;
 
@@ -86,5 +86,9 @@ pub mod r#where;
 pub mod xor;
 
 pub trait Layer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>);
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>);
 }

--- a/src/layer/and.rs
+++ b/src/layer/and.rs
@@ -5,10 +5,15 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 pub struct AndLayer;
 impl Layer for AndLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     let bool_check = graph.addBB(Box::new(BooleanCheckBasicBlock {}));
     let mul = graph.addBB(Box::new(RepeaterBasicBlock {

--- a/src/layer/arithmetic.rs
+++ b/src/layer/arithmetic.rs
@@ -5,6 +5,7 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 macro_rules! define_arithmetic_layer {
   ($struct_name:ident, $basic_block:ident) => {
@@ -13,7 +14,7 @@ macro_rules! define_arithmetic_layer {
     impl Layer for $struct_name {
       fn graph(
         input_shapes: &Vec<&Vec<usize>>,
-        _constants: &Vec<Option<&ArrayD<Fr>>>,
+        _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
         _attributes: &Vec<&AttributeProto>,
       ) -> (Graph, Vec<Vec<usize>>) {
         let mut graph = Graph::new();

--- a/src/layer/cast.rs
+++ b/src/layer/cast.rs
@@ -4,10 +4,15 @@ use crate::layer::Layer;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 pub struct CastLayer;
 impl Layer for CastLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     let id = graph.addBB(Box::new(IdBasicBlock {}));
     let id_output = graph.addNode(id, vec![(-1, 0)]);

--- a/src/layer/clip.rs
+++ b/src/layer/clip.rs
@@ -6,13 +6,18 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 pub struct ClipLayer;
 impl Layer for ClipLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
-    let min = util::fr_to_int(constants[1].unwrap().as_slice().unwrap()[0]) as f32;
-    let max = util::fr_to_int(constants[2].unwrap().as_slice().unwrap()[0]) as f32;
+    let min = util::fr_to_int(constants[1].unwrap().0.as_slice().unwrap()[0]) as f32;
+    let max = util::fr_to_int(constants[2].unwrap().0.as_slice().unwrap()[0]) as f32;
 
     let clip = graph.addBB(Box::new(ClipBasicBlock { min: min, max: max }));
     let clip_output = graph.addNode(clip, vec![(-1, 0)]);

--- a/src/layer/concat.rs
+++ b/src/layer/concat.rs
@@ -6,6 +6,7 @@ use ark_bn254::Fr;
 use ark_std::Zero;
 use ndarray::{ArrayD, IxDyn};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 // This function returns N outputs where N is the number of inputs.
 // Each output is an array with the same shape as the final concatenation array.
@@ -37,7 +38,11 @@ fn get_concat_indices(input_shapes: &Vec<&Vec<usize>>, output_shape: &Vec<usize>
 // Otherwise, we directly concatenate the input arrays.
 pub struct ConcatLayer;
 impl Layer for ConcatLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
 
     // Extract the 'axis' attribute and adjust for negative values
@@ -90,7 +95,7 @@ impl Layer for ConcatLayer {
 
       let n_input = input_shapes.len();
       let n_input_padded = util::next_pow(n_input as u32) as usize;
-      
+
       let concat = graph.addBB(Box::new(ConcatBasicBlock { axis: axis as usize }));
       let mut concat_input: Vec<_> = (0..n_input).map(|i| (-(i as i32 + 1), 0)).collect();
       for _ in 0..n_input_padded - n_input {

--- a/src/layer/constantofshape.rs
+++ b/src/layer/constantofshape.rs
@@ -5,16 +5,21 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 // Generate a tensor with a given value (the value is in the ONNX attribute) and shape (the shape is in the input tensor)
 // reference: https://onnx.ai/onnx/operators/onnx__ConstantOfShape.html
 pub struct ConstOfShapeLayer;
 impl Layer for ConstOfShapeLayer {
-  fn graph(_input_shapes: &Vec<&Vec<usize>>, constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    _input_shapes: &Vec<&Vec<usize>>,
+    constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
 
     let value = Fr::from(attributes.iter().filter(|x| x.name == "value").next().unwrap().i);
-    let endShape: Vec<usize> = constants[0].unwrap().as_slice().unwrap().iter().map(|x| util::fr_to_int(*x) as usize).filter(|x| *x != 0).collect();
+    let endShape: Vec<usize> = constants[0].unwrap().0.as_slice().unwrap().iter().map(|x| util::fr_to_int(*x) as usize).filter(|x| *x != 0).collect();
     let endShape_padded: Vec<usize> = endShape.iter().map(|&x| util::next_pow(x as u32) as usize).collect();
 
     let constantOfShape = graph.addBB(Box::new(ConstOfShapeBasicBlock {

--- a/src/layer/conv.rs
+++ b/src/layer/conv.rs
@@ -10,6 +10,7 @@ use ndarray::Dimension;
 use ndarray::IxDyn;
 use ndarray::{Array1, ArrayD};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 // Returns output dimensions given the actual padding amount
 pub fn out_hw(dims: &Vec<usize>, strides: &Vec<usize>, ch_dims: &Vec<usize>, padding: &Vec<[usize; 2]>, is_transpose: bool) -> Vec<usize> {
@@ -141,7 +142,7 @@ macro_rules! create_conv_layer {
     impl Layer for $layer_name {
       fn graph(
         input_shapes: &Vec<&Vec<usize>>,
-        _constants: &Vec<Option<&ArrayD<Fr>>>,
+        _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
         attributes: &Vec<&AttributeProto>,
       ) -> (Graph, Vec<Vec<usize>>) {
         let mut graph = Graph::new();

--- a/src/layer/div.rs
+++ b/src/layer/div.rs
@@ -30,7 +30,16 @@ macro_rules! create_division_layer {
 
           // Convert the constant to a floating-point number
           let c_value = util::fr_to_int(*c.0.first().unwrap()) as f32;
-          let c_value = if $output_idx == 0 { c_value / *onnx::SF_FLOAT as f32 } else { c_value };
+          let c_value = match c.1 {
+            DatumType::I64 => c_value,
+            _ => {
+              if $output_idx == 0 {
+                c_value / *onnx::SF_FLOAT as f32
+              } else {
+                c_value
+              }
+            }
+          };
 
           // Add a basic block for division/modulo by a constant
           let const_block = graph.addBB(Box::new($const_block { c: c_value as _ }));

--- a/src/layer/div.rs
+++ b/src/layer/div.rs
@@ -6,6 +6,7 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::{Array1, ArrayD};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 // Define a macro to unify common behavior for DivLayer and ModLayer
 // when output_idx equals to 0, the layer returns the quotient. (Div)
@@ -16,19 +17,19 @@ macro_rules! create_division_layer {
 
     impl Layer for $layer_name {
       fn graph(
-        input_shapes: &Vec<&Vec<usize>>,      // Input shapes for the layer
-        constants: &Vec<Option<&ArrayD<Fr>>>, // Constants used in the layer
-        _attributes: &Vec<&AttributeProto>,   // Attributes for the layer (not used in this implementation)
+        input_shapes: &Vec<&Vec<usize>>,                   // Input shapes for the layer
+        constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>, // Constants used in the layer
+        _attributes: &Vec<&AttributeProto>,                // Attributes for the layer (not used in this implementation)
       ) -> (Graph, Vec<Vec<usize>>) {
         let mut graph = Graph::new(); // Create a new computational graph
 
         // Check if the second input is a constant
         if let Some(c) = constants[1] {
           // Assert the length of the constant is 1
-          assert!(c.len() == 1);
+          assert!(c.0.len() == 1);
 
           // Convert the constant to a floating-point number
-          let c_value = util::fr_to_int(*c.first().unwrap()) as f32;
+          let c_value = util::fr_to_int(*c.0.first().unwrap()) as f32;
           let c_value = if $output_idx == 0 { c_value / *onnx::SF_FLOAT as f32 } else { c_value };
 
           // Add a basic block for division/modulo by a constant

--- a/src/layer/einsum.rs
+++ b/src/layer/einsum.rs
@@ -7,6 +7,7 @@ use ark_bn254::Fr;
 use ndarray::ArrayD;
 use std::collections::HashMap;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 fn parse_einsum(equation: &str) -> (Vec<String>, Vec<String>) {
   // Helper function to map letters to a standard set while preserving "..."
@@ -149,7 +150,11 @@ fn vector_inner_product(graph: &mut Graph, _input_shapes: &Vec<&Vec<usize>>) -> 
 // Other equations are not supported yet.
 pub struct EinsumLayer;
 impl Layer for EinsumLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     let equation = &attributes.iter().filter(|x| x.name == "equation").next().unwrap().s;
     let equation = std::str::from_utf8(&equation).unwrap();

--- a/src/layer/equal.rs
+++ b/src/layer/equal.rs
@@ -6,10 +6,15 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::{arr1, ArrayD};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 pub struct EqualLayer;
 impl Layer for EqualLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     let one = graph.addBB(Box::new(Const2BasicBlock {
       c: arr1(&vec![Fr::from(1); util::next_pow(*input_shapes[0].last().unwrap() as u32) as usize]).into_dyn(),

--- a/src/layer/expand.rs
+++ b/src/layer/expand.rs
@@ -6,6 +6,7 @@ use ark_bn254::Fr;
 use ark_std::One;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 #[derive(Debug)]
 pub struct ExpandBasicBlock;
@@ -19,8 +20,12 @@ impl BasicBlock for ExpandBasicBlock {
 
 pub struct ExpandLayer;
 impl Layer for ExpandLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
-    let newShape: Vec<_> = constants[1].unwrap().as_slice().unwrap().iter().map(|&x| util::fr_to_int(x) as usize).filter(|x| *x != 0).collect();
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
+    let newShape: Vec<_> = constants[1].unwrap().0.as_slice().unwrap().iter().map(|&x| util::fr_to_int(x) as usize).filter(|x| *x != 0).collect();
     let mut graph = Graph::new();
     if *input_shapes[0].last().unwrap() == *newShape.clone().last().unwrap() {
       let expand = graph.addBB(Box::new(ExpandBasicBlock {}));
@@ -43,7 +48,7 @@ impl Layer for ExpandLayer {
       };
       graph.outputs.push((expand_output, 0));
     }
-    
+
     (graph, vec![newShape])
   }
 }

--- a/src/layer/flatten.rs
+++ b/src/layer/flatten.rs
@@ -5,6 +5,7 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::{ArrayD, IxDyn};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 fn get_permutation(input_shape: &[usize], axis: usize) -> (ArrayD<Option<IxDyn>>, Vec<usize>) {
   assert!(axis < input_shape.len());
@@ -26,7 +27,11 @@ fn get_permutation(input_shape: &[usize], axis: usize) -> (ArrayD<Option<IxDyn>>
 // If input tensor has shape (d_0, d_1, ..., d_n) then the output will have shape (d_0 × d_1 × ... × d_{axis-1}, d_{axis} × d_{axis+1} × ... × dn).
 pub struct FlattenLayer;
 impl Layer for FlattenLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
 
     let axis: isize = attributes.iter().filter(|x| x.name == "axis").next().unwrap().i as isize;

--- a/src/layer/gather.rs
+++ b/src/layer/gather.rs
@@ -5,6 +5,7 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::{ArrayD, Axis};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 #[derive(Debug)]
 pub struct GatherBasicBlock;
@@ -24,7 +25,11 @@ impl BasicBlock for GatherBasicBlock {
 
 pub struct GatherLayer;
 impl Layer for GatherLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     let gather = graph.addBB(Box::new(GatherBasicBlock {}));
     let output = graph.addNode(gather, vec![(-1, 0), (-2, 0)]);

--- a/src/layer/gathernd.rs
+++ b/src/layer/gathernd.rs
@@ -7,6 +7,7 @@ use ark_std::iterable::Iterable;
 use ndarray::Dimension;
 use ndarray::{ArrayD, Axis, IxDyn};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 // array: the N-dimensional array
 // n_minus_1_index: the index of the N-1 dimension
@@ -59,14 +60,18 @@ fn get_gathernd_masks(input_shape: &[usize], indices: &ArrayD<usize>, batch_dims
 // reference (v13): https://onnx.ai/onnx/operators/onnx__GatherND.html
 pub struct GatherNDLayer;
 impl Layer for GatherNDLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
 
     let indices = if constants[1].is_none() {
       // we cannot handle non-constant indices because we need to know the shape of the indices to compile graph in zk-torch
       panic!("GatherNDLayer: indices must be a constant");
     } else {
-      constants[1].unwrap().map(|x| util::fr_to_int(*x) as usize)
+      constants[1].unwrap().0.map(|x| util::fr_to_int(*x) as usize)
     };
 
     // attributes may contain batch_dims, but we only support batch_dims = 0 for now

--- a/src/layer/gemm.rs
+++ b/src/layer/gemm.rs
@@ -6,6 +6,7 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::{arr1, ArrayD};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 // Gemm computes Y = alpha * A' * B' + beta * C, where
 // the first input tensor A has shape (M, K) or (K, M),
@@ -15,7 +16,11 @@ use tract_onnx::pb::AttributeProto;
 // A will be transposed to A' before doing the computation if attribute transA is non-zero, same for B and transB.
 pub struct GemmLayer;
 impl Layer for GemmLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
 
     let alpha = if attributes.iter().any(|x| x.name == "alpha") {

--- a/src/layer/less.rs
+++ b/src/layer/less.rs
@@ -6,11 +6,16 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::{arr1, ArrayD};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 // Less layer performs `less`, an element-wise logical comparison of two tensors.
 pub struct LessLayer;
 impl Layer for LessLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     // Inputs: A, B
     // Outputs: L = (A < B); then 1 - L = (A >= B). We can view them as selection of indices.
     // Check 1: (A - B) * L + (-1) * (1 - L) < 0 because A - B will always < 0 at indices of A < B and we set values at other indices as -1

--- a/src/layer/lstm.rs
+++ b/src/layer/lstm.rs
@@ -7,11 +7,16 @@ use ark_bn254::Fr;
 use ark_std::Zero;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 // reference: https://github.com/onnx/onnx/blob/main/onnx/backend/test/case/node/lstm.py
 pub struct LSTMLayer;
 impl Layer for LSTMLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     // currently, we do not support P (peepholes)
     assert!(input_shapes.len() == 6); // X, W, R, B, initial_h, initial_c
 

--- a/src/layer/matmul.rs
+++ b/src/layer/matmul.rs
@@ -6,10 +6,15 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 pub struct MatMulLayer;
 impl Layer for MatMulLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     let n = input_shapes[1].len();
     let (mut a, mut b) = (input_shapes[1][n - 2], input_shapes[1][n - 1]);

--- a/src/layer/max.rs
+++ b/src/layer/max.rs
@@ -6,6 +6,7 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::{concatenate, indices, ArrayD, Axis, Dim, Dimension, IxDyn};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 // Returns the splat needed to pass into MaxProofBasicBlock. This produces a (product of input dims X 2) permutation where the first column corresponds to the input elements and the second column contains cmp_val
 fn splat_input(input_shape: &Vec<usize>, cmp_val: Option<IxDyn>) -> ArrayD<Option<IxDyn>> {
@@ -19,11 +20,15 @@ fn splat_input(input_shape: &Vec<usize>, cmp_val: Option<IxDyn>) -> ArrayD<Optio
 
 pub struct MaxLayer;
 impl Layer for MaxLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     // For now we only support the case when there are two inputs and the second input is a constant of a single element. The single element is compared element-wise with the first input
     if input_shapes.len() == 2 && input_shapes[1].len() == 1 && constants[1].is_some() {
-      let constant = constants[1].unwrap().first().unwrap();
+      let constant = constants[1].unwrap().0.first().unwrap();
       let permutation = splat_input(&input_shapes[0], None);
       let input_shape_padded: Vec<_> = input_shapes[0].iter().map(|i| i.next_power_of_two()).collect();
       let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
@@ -59,7 +64,11 @@ impl Layer for MaxLayer {
 
 pub struct MinLayer;
 impl Layer for MinLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     // For now we only support the case when there are two inputs where the first input has ndim > 1 and the second input is a single element. The single element is compared element-wise with the first input. This is its only use case in RetinaNet where the first input has the same dimensions as the Max output and second input comes from Shape -> Gather layers.
     if input_shapes.len() == 2 && input_shapes[1].len() == 1 && input_shapes[0].len() > 1 {

--- a/src/layer/mul.rs
+++ b/src/layer/mul.rs
@@ -6,10 +6,15 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 pub struct MulLayer;
 impl Layer for MulLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     let mul = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(MulBasicBlock {}),

--- a/src/layer/neg.rs
+++ b/src/layer/neg.rs
@@ -6,11 +6,16 @@ use ark_bn254::Fr;
 use ark_std::Zero;
 use ndarray::{arr1, ArrayD};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 pub struct NegLayer;
 
 impl Layer for NegLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     let zero = graph.addBB(Box::new(Const2BasicBlock {
       c: arr1(&vec![Fr::zero(); *input_shapes[0].last().unwrap()]).into_dyn(),

--- a/src/layer/nonlinear.rs
+++ b/src/layer/nonlinear.rs
@@ -5,6 +5,7 @@ use crate::onnx;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 macro_rules! define_nonlinear_layer {
   ($struct_name:ident, $basic_block:ident) => {
@@ -13,7 +14,7 @@ macro_rules! define_nonlinear_layer {
     impl Layer for $struct_name {
       fn graph(
         input_shapes: &Vec<&Vec<usize>>,
-        _constants: &Vec<Option<&ArrayD<Fr>>>,
+        _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
         _attributes: &Vec<&AttributeProto>,
       ) -> (Graph, Vec<Vec<usize>>) {
         let mut graph = Graph::new();

--- a/src/layer/norm.rs
+++ b/src/layer/norm.rs
@@ -6,13 +6,18 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::{arr1, Array1, ArrayD, IxDyn};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 use util::copy_constraint::get_reshape_indices;
 
 // BatchNormLayer is a struct that represents a batch normalization layer, which computes
 // Y = (X - input_mean) * scale / sqrt(input_var + epsilon) + bias
 pub struct BatchNormLayer;
 impl Layer for BatchNormLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
 
     let X_shape = input_shapes[0];
@@ -220,7 +225,11 @@ impl Layer for BatchNormLayer {
 // where mean and var are computed per instance per channel
 pub struct InstanceNormLayer;
 impl Layer for InstanceNormLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
 
     let X_shape = input_shapes[0];

--- a/src/layer/not.rs
+++ b/src/layer/not.rs
@@ -6,11 +6,16 @@ use ark_bn254::Fr;
 use ark_std::One;
 use ndarray::{arr1, ArrayD};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 pub struct NotLayer;
 
 impl Layer for NotLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     let bool_check = graph.addBB(Box::new(BooleanCheckBasicBlock {}));
     let one = graph.addBB(Box::new(Const2BasicBlock {

--- a/src/layer/pool.rs
+++ b/src/layer/pool.rs
@@ -7,6 +7,7 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::{arr1, indices, ArrayD, Dim, Dimension, IxDyn};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 // This constructs the permutation for CopyConstraintBasicBlock to be inputted into MaxProofBasicBlock. The output is a (product of output dims of the pool operation * input channels X product of kernel_dims) permutation where the rows correspond to one max operation, and each row contains the set of arguments to max.
 // ci is the number of input channels
@@ -46,7 +47,11 @@ fn splat_input(input_shape: &Vec<usize>, strides: &Vec<usize>, pads: &Vec<usize>
 
 pub struct MaxPoolLayer;
 impl Layer for MaxPoolLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     let dims = input_shapes[0][2..].to_vec();
 

--- a/src/layer/pow.rs
+++ b/src/layer/pow.rs
@@ -5,12 +5,17 @@ use crate::onnx;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 pub struct PowLayer;
 impl Layer for PowLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
-    assert!(constants[1].unwrap().first().unwrap() == &Fr::from(2 * *onnx::SF as u32));
+    assert!(constants[1].unwrap().0.first().unwrap() == &Fr::from(2 * *onnx::SF as u32));
     let mul = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(MulBasicBlock {}),
       N: 1,

--- a/src/layer/range.rs
+++ b/src/layer/range.rs
@@ -5,10 +5,15 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 pub struct RangeLayer;
 impl Layer for RangeLayer {
-  fn graph(_input_shapes: &Vec<&Vec<usize>>, constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    _input_shapes: &Vec<&Vec<usize>>,
+    constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     let mut all_are_constant = true;
 
@@ -22,9 +27,9 @@ impl Layer for RangeLayer {
 
     let mut length = 0;
     if all_are_constant {
-      let start = util::fr_to_int(constants[0].unwrap().as_slice().unwrap()[0]);
-      let limit = util::fr_to_int(constants[1].unwrap().as_slice().unwrap()[0]);
-      let delta = util::fr_to_int(constants[2].unwrap().as_slice().unwrap()[0]);
+      let start = util::fr_to_int(constants[0].unwrap().0.as_slice().unwrap()[0]);
+      let limit = util::fr_to_int(constants[1].unwrap().0.as_slice().unwrap()[0]);
+      let delta = util::fr_to_int(constants[2].unwrap().0.as_slice().unwrap()[0]);
 
       // all fields are constant
       let range = graph.addBB(Box::new(RangeConstBasicBlock {

--- a/src/layer/reducemean.rs
+++ b/src/layer/reducemean.rs
@@ -6,12 +6,17 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 // ReduceMeanLayer is a layer that returns the mean of the input tensor along one or two given axis/axes
 // More than two axes is not supported for now
 pub struct ReduceMeanLayer;
 impl Layer for ReduceMeanLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
 
     let axes: Vec<_> = match attributes.iter().filter(|x| x.name == "axes").next() {

--- a/src/layer/reshape.rs
+++ b/src/layer/reshape.rs
@@ -5,14 +5,19 @@ use crate::util::{self, get_reshape_indices};
 use ark_bn254::Fr;
 use ndarray::{ArrayD, IxDyn};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 pub struct ReshapeLayer;
 impl Layer for ReshapeLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
 
     let startShape = input_shapes[0];
-    let mut endShape: Vec<_> = constants[1].unwrap().as_slice().unwrap().iter().map(|x| util::fr_to_int(*x)).filter(|x| *x != 0).collect();
+    let mut endShape: Vec<_> = constants[1].unwrap().0.as_slice().unwrap().iter().map(|x| util::fr_to_int(*x)).filter(|x| *x != 0).collect();
     if let Some(i) = endShape.iter().position(|&x| x == -1) {
       let a = input_shapes[0].iter().fold(1, |x, &y| x * y) as i32;
       let b = endShape.iter().fold(-1, |x, &y| x * y);

--- a/src/layer/resize.rs
+++ b/src/layer/resize.rs
@@ -7,6 +7,7 @@ use ark_bn254::Fr;
 use ndarray::Dimension;
 use ndarray::{ArrayD, IxDyn};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 // Assumes nearest_mode = floor
 fn resize_permutation(input_shape: &Vec<usize>, scales: &Vec<f32>) -> (Vec<usize>, ArrayD<Option<IxDyn>>) {
@@ -23,7 +24,11 @@ fn resize_permutation(input_shape: &Vec<usize>, scales: &Vec<f32>) -> (Vec<usize
 pub struct ResizeLayer;
 // Only supports coordinate_transformation_mode = asymmetric, mode = nearest, and nearest_mode = floor
 impl Layer for ResizeLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
 
     let ctm = match attributes.iter().filter(|x| x.name == "coordinate_transformation_mode").next() {
@@ -66,7 +71,7 @@ impl Layer for ResizeLayer {
       panic!("Resize has invalid nearest_mode string");
     };
     // scales is a float, so it will have been scaled by onnx::SF by the onnx compiler. This assumes that dividing by onnx::SF will recover the original value
-    let scales: Vec<_> = constants[2].unwrap().iter().map(|x| util::fr_to_int(*x) as f32 / *onnx::SF as f32).collect();
+    let scales: Vec<_> = constants[2].unwrap().0.iter().map(|x| util::fr_to_int(*x) as f32 / *onnx::SF as f32).collect();
     assert!(scales.len() == input_shapes[0].len());
 
     let (output_shape, permutation) = resize_permutation(input_shapes[0], &scales);

--- a/src/layer/scatternd.rs
+++ b/src/layer/scatternd.rs
@@ -5,6 +5,7 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::{ArrayD, Axis, Dim, IxDyn};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 fn get_masks(input_shape: &[usize], indices: &ArrayD<Fr>) -> (ArrayD<Option<IxDyn>>, ArrayD<Option<IxDyn>>) {
   let preserve = ArrayD::from_shape_fn(input_shape, |index| Some(index));
@@ -72,10 +73,14 @@ fn ndindex(shape: &[usize], current_index: &mut Vec<usize>, all_indices: &mut Ve
 // https://onnx.ai/onnx/operators/onnx__ScatterND.html
 pub struct ScatterNDLayer;
 impl Layer for ScatterNDLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     // TODO: handle cases when attribute is not none
-    let indices = constants[1].unwrap();
+    let indices = constants[1].unwrap().0;
 
     let (permutation_preserve, permutation_update) = get_masks(&input_shapes[0], &indices);
     let input_shape_0_padded: Vec<_> = input_shapes[0].iter().map(|x| util::next_pow(*x as u32) as usize).collect();

--- a/src/layer/shape.rs
+++ b/src/layer/shape.rs
@@ -6,6 +6,7 @@ use ark_bn254::Fr;
 use ark_std::Zero;
 use ndarray::{arr1, ArrayD};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 #[derive(Debug)]
 pub struct ShapeBasicBlock;
@@ -20,7 +21,11 @@ impl BasicBlock for ShapeBasicBlock {
 
 pub struct ShapeLayer;
 impl Layer for ShapeLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     let shape = graph.addBB(Box::new(ShapeBasicBlock {}));
     let shape_output = graph.addNode(shape, vec![(-1, 0)]);

--- a/src/layer/slice.rs
+++ b/src/layer/slice.rs
@@ -5,6 +5,7 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::{ArrayD, IxDyn};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 fn combinations<T: Clone>(vecs: &Vec<Vec<T>>) -> Vec<Vec<T>> {
   // Recursive function to generate combinations
@@ -76,17 +77,21 @@ fn get_slice(
 // https://onnx.ai/onnx/operators/onnx__Slice.html
 pub struct SliceLayer;
 impl Layer for SliceLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
-    let starts: Vec<_> = constants[1].unwrap().as_slice().unwrap().iter().map(|x| util::fr_to_int(*x)).collect();
-    let ends: Vec<_> = constants[2].unwrap().as_slice().unwrap().iter().map(|x| util::fr_to_int(*x)).collect();
+    let starts: Vec<_> = constants[1].unwrap().0.as_slice().unwrap().iter().map(|x| util::fr_to_int(*x)).collect();
+    let ends: Vec<_> = constants[2].unwrap().0.as_slice().unwrap().iter().map(|x| util::fr_to_int(*x)).collect();
     // steps and axes might be optional
     let axes: Vec<_> = match constants.get(3) {
-      Some(x) => x.unwrap().as_slice().unwrap().iter().map(|x| util::fr_to_int(*x)).collect(),
+      Some(x) => x.unwrap().0.as_slice().unwrap().iter().map(|x| util::fr_to_int(*x)).collect(),
       None => (0..input_shapes[0].len()).map(|x| x as i32).collect(),
     };
     let mut steps: Vec<_> = match constants.get(4) {
-      Some(x) => x.unwrap().as_slice().unwrap().iter().map(|x| util::fr_to_int(*x) as usize).collect(),
+      Some(x) => x.unwrap().0.as_slice().unwrap().iter().map(|x| util::fr_to_int(*x) as usize).collect(),
       None => vec![1; starts.len()],
     };
     let mut axes: Vec<_> = axes

--- a/src/layer/softmax.rs
+++ b/src/layer/softmax.rs
@@ -5,10 +5,15 @@ use crate::onnx;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 pub struct SoftmaxLayer;
 impl Layer for SoftmaxLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     let max = graph.addBB(Box::new(MaxBasicBlock {}));
     let sub = graph.addBB(Box::new(RepeaterBasicBlock {

--- a/src/layer/split.rs
+++ b/src/layer/split.rs
@@ -5,10 +5,15 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 pub struct SplitLayer;
 impl Layer for SplitLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
 
     // This code is for Opset 11; in the latest version of ONNX, "split" is in inputs instead of the attributes

--- a/src/layer/squeeze.rs
+++ b/src/layer/squeeze.rs
@@ -5,6 +5,7 @@ use crate::util::{self, get_reshape_indices};
 use ark_bn254::Fr;
 use ndarray::{ArrayD, Axis, IxDyn};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 // Squeeze the input tensor by removing all dimensions of size 1.
 // If axes is provided, remove the dimensions specified by axes.
@@ -12,7 +13,11 @@ use tract_onnx::pb::AttributeProto;
 // If the last dimension is squeezed, we need to permute the tensor before reshaping because the last dimension affects the commitment.
 pub struct SqueezeLayer;
 impl Layer for SqueezeLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
 
     let axes_result = attributes.iter().filter(|x| x.name == "axes").next();
@@ -68,7 +73,11 @@ impl BasicBlock for UnsqueezeBasicBlock {
 // Otherwise, when the last dimension is not unsqueezed or an arr0 is unsqueezed (special case), we can directly reshape it.
 pub struct UnsqueezeLayer;
 impl Layer for UnsqueezeLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
 
     let axis: isize = attributes.iter().filter(|x| x.name == "axes").next().unwrap().ints[0] as isize;

--- a/src/layer/tile.rs
+++ b/src/layer/tile.rs
@@ -5,6 +5,7 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::{concatenate, ArrayD, Axis, IxDyn};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 // Helper function to get the indices of the tiled tensor
 fn get_tile_indices(input_shape: Vec<usize>, repeats: Vec<usize>) -> ArrayD<Option<IxDyn>> {
@@ -30,9 +31,13 @@ fn get_tile_indices(input_shape: Vec<usize>, repeats: Vec<usize>) -> ArrayD<Opti
 // reference: https://numpy.org/doc/stable/reference/generated/numpy.tile.html
 pub struct TileLayer;
 impl Layer for TileLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
-    let repeats: Vec<_> = constants[1].unwrap().as_slice().unwrap().iter().map(|x| util::fr_to_int(*x)).collect();
+    let repeats: Vec<_> = constants[1].unwrap().0.as_slice().unwrap().iter().map(|x| util::fr_to_int(*x)).collect();
     let mut repeats: Vec<_> = repeats.iter().map(|x| *x as usize).collect();
 
     let mut input_shape = input_shapes[0].clone();

--- a/src/layer/topk.rs
+++ b/src/layer/topk.rs
@@ -6,6 +6,7 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::{arr1, ArrayD, IxDyn};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 // Helper function to get the indices of the topk tensor
 fn get_topk_indices(sorted_data_shape: Vec<usize>, k: usize) -> ArrayD<Option<IxDyn>> {
@@ -25,10 +26,14 @@ fn get_topk_indices(sorted_data_shape: Vec<usize>, k: usize) -> ArrayD<Option<Ix
 // The order of the elements is determined by the 'largest' attribute, the default '1' means descending
 pub struct TopKLayer;
 impl Layer for TopKLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     let mut descending = true;
-    let k = constants[1].unwrap().as_slice().unwrap().iter().map(|x| util::fr_to_int(*x)).collect::<Vec<_>>()[0] as usize;
+    let k = constants[1].unwrap().0.as_slice().unwrap().iter().map(|x| util::fr_to_int(*x)).collect::<Vec<_>>()[0] as usize;
     let axis: isize = attributes.iter().filter(|x| x.name == "axis").next().unwrap().i as isize;
     let axis = (if axis < 0 { input_shapes[0].len() as isize + axis } else { axis }) as usize;
     let largest = attributes.iter().filter(|x| x.name == "largest").next().unwrap().i as usize;
@@ -119,7 +124,11 @@ impl Layer for TopKLayer {
 // ArgMaxLayer is a layer that returns the top 1 index of the input tensor along a given axis
 pub struct ArgMaxLayer;
 impl Layer for ArgMaxLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     let descending = true;
     let axis: isize = attributes.iter().filter(|x| x.name == "axis").next().unwrap().i as isize;

--- a/src/layer/transpose.rs
+++ b/src/layer/transpose.rs
@@ -5,10 +5,15 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 pub struct TransposeLayer;
 impl Layer for TransposeLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
 
     let axes: Vec<_> = attributes.iter().filter(|x| x.name == "perm").next().unwrap().ints.iter().map(|x| *x as usize).collect();

--- a/src/layer/where.rs
+++ b/src/layer/where.rs
@@ -5,10 +5,15 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::{arr1, ArrayD};
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 pub struct WhereLayer;
 impl Layer for WhereLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     //condition, X, Y
     //condition * X + (1-condition) * Y
     let mut graph = Graph::new();

--- a/src/layer/xor.rs
+++ b/src/layer/xor.rs
@@ -5,10 +5,15 @@ use crate::util;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::DatumType;
 
 pub struct XorLayer;
 impl Layer for XorLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, _attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(
+    input_shapes: &Vec<&Vec<usize>>,
+    _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
+    _attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
     let bool_check = graph.addBB(Box::new(BooleanCheckBasicBlock {}));
     let sub = graph.addBB(Box::new(RepeaterBasicBlock {

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,7 +202,7 @@ fn main() {
   let (mut graph, models) = onnx::load_file(onnx_file_name);
   let fake_inputs = util::generate_fake_inputs_for_onnx(onnx_file_name);
   let inputs = fake_inputs.iter().map(|x| x).collect();
-  let models = models.iter().map(|x| x).collect();
+  let models = models.iter().map(|x| &x.0).collect();
   setup(&srs, &graph, &models, &mut timing);
   let outputs = run(&inputs, &graph, &models, &mut timing);
   prove(&srs, &inputs, outputs, &mut graph, &mut timing);

--- a/src/onnx.rs
+++ b/src/onnx.rs
@@ -11,6 +11,7 @@ use pool::MaxPoolLayer;
 use std::collections::HashMap;
 use tract_onnx::pb;
 use tract_onnx::pb::AttributeProto;
+use tract_onnx::prelude::Datum;
 use tract_onnx::prelude::{DatumType, Framework};
 use tract_onnx::tensor::load_tensor;
 
@@ -56,7 +57,7 @@ fn parse_onnx_constants<'a>(
 ) -> (
   impl Iterator<Item = (String, &'a pb::TensorProto)> + 'a,
   HashMap<String, usize>,
-  Vec<ArrayD<Fr>>,
+  Vec<(ArrayD<Fr>, DatumType)>,
 ) {
   let onnx = tract_onnx::onnx();
   let constants = onnx_graph.initializer.iter().map(|tensor| (tensor.name.clone(), tensor)).chain(
@@ -73,27 +74,30 @@ fn parse_onnx_constants<'a>(
 
   for (name, tensor) in constants.clone() {
     let tensor = load_tensor(&*onnx.provider, tensor, None).unwrap();
-    let tensor = match tensor.datum_type() {
+    let (tensor, data_type) = match tensor.datum_type() {
       DatumType::F32 => {
         let tensor = tensor.into_array::<f32>().unwrap();
-        Ok(tensor.map(|x| {
-          // handle the case where the constant is very close to zero (i.e., epsilon to prevent division by zero)
-          if *x < 1e-10 && *x > 0.0 {
-            // the reason we use 1 here is because it is the smallest positive value that can be represented in the field
-            return Fr::from(1);
-          }
-          let mut y = (*x * *SF_FLOAT).round();
-          y = y.clamp(-(1 << 15) as f32, (1 << 15) as f32);
-          Fr::from(y as i32)
-        }))
+        Ok((
+          tensor.map(|x| {
+            // handle the case where the constant is very close to zero (i.e., epsilon to prevent division by zero)
+            if *x < 1e-10 && *x > 0.0 {
+              // the reason we use 1 here is because it is the smallest positive value that can be represented in the field
+              return Fr::from(1);
+            }
+            let mut y = (*x * *SF_FLOAT).round();
+            y = y.clamp(-(1 << 15) as f32, (1 << 15) as f32);
+            Fr::from(y as i32)
+          }),
+          DatumType::F32,
+        ))
       }
       DatumType::I64 => {
         let tensor = tensor.into_array::<i64>().unwrap();
-        Ok(tensor.map(|x| Fr::from(*x)))
+        Ok((tensor.map(|x| Fr::from(*x)), DatumType::I64))
       }
       DatumType::Bool => {
         let tensor = tensor.into_array::<bool>().unwrap();
-        Ok(tensor.map(|x| Fr::from(*x as i32)))
+        Ok((tensor.map(|x| Fr::from(*x as i32)), DatumType::Bool))
       }
       _ => Err(format!("Unsupported constant type: {:?}", tensor.datum_type())),
     }
@@ -102,7 +106,7 @@ fn parse_onnx_constants<'a>(
     shapes.insert(name.clone(), tensor.shape().to_vec());
     let tensor = util::pad_to_pow_of_two(&tensor, &Fr::zero());
     constants_hashmap.insert(name.clone(), idx);
-    models.push(tensor);
+    models.push((tensor, data_type));
     idx += 1;
   }
 
@@ -133,7 +137,7 @@ fn create_output_indices<'a>(
 fn get_local_graph(
   op: &str,
   input_shapes: &Vec<&Vec<usize>>,
-  node_constants: &Vec<Option<&ArrayD<Fr>>>,
+  node_constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
   node_attributes: Vec<&AttributeProto>,
 ) -> (Graph, Vec<Vec<usize>>) {
   match op {
@@ -208,7 +212,7 @@ fn update_graph_w_local_graph(
   input_idx: &HashMap<String, usize>,
   outputs_idx: &mut HashMap<String, Vec<(i32, usize)>>,
   basic_blocks_idx: &mut HashMap<String, usize>,
-  models: &mut Vec<ArrayD<Fr>>,
+  models: &mut Vec<(ArrayD<Fr>, DatumType)>,
 ) {
   // pushing basicblocks and models in a local graph to update graph.basic_blocks and models
   let mut local_block_idx = vec![];
@@ -218,7 +222,7 @@ fn update_graph_w_local_graph(
     let idx = *basic_blocks_idx.entry(name).or_insert_with(|| graph.basic_blocks.len());
     local_block_idx.push(idx);
     if idx == graph.basic_blocks.len() {
-      models.push(basic_block.genModel());
+      models.push((basic_block.genModel(), DatumType::I64));
       graph.basic_blocks.push(basic_block);
     }
   }
@@ -246,7 +250,11 @@ fn update_graph_w_local_graph(
         })
         .collect(),
     });
-    let name = if node.name.clone() == "" { node.op_type.to_string() } else { node.name.clone() };
+    let name = if node.name.clone() == "" {
+      node.op_type.to_string()
+    } else {
+      node.name.clone()
+    };
     graph.layer_names.push(format!("Op {}", name));
   }
   // tracking output_idx of local_graph
@@ -264,7 +272,7 @@ fn process_node(
   graph: &mut Graph,
   shapes: &mut HashMap<String, Vec<usize>>,
   constants_hashmap: &HashMap<String, usize>,
-  models: &mut Vec<ArrayD<Fr>>,
+  models: &mut Vec<(ArrayD<Fr>, DatumType)>,
   passed_constants: &mut HashMap<String, ArrayD<Fr>>,
   input_idx: &HashMap<String, usize>,
   outputs_idx: &mut HashMap<String, Vec<(i32, usize)>>,
@@ -275,20 +283,27 @@ fn process_node(
   println!("Compiling ONNX node: {}", node.name);
   let input_shapes: Vec<_> = node.input.iter().map(|x| shapes.get(x)).collect();
   let input_shapes = input_shapes.into_iter().filter_map(|x| x).collect::<Vec<_>>(); // hack: we ignore optional inputs
-  let node_constants = node.input.iter().map(|x| passed_constants.get(x).or(constants_hashmap.get(x).map(|&y| &models[y]))).collect();
+  let node_constants = node
+    .input
+    .iter()
+    .map(|x| {
+      if let Some(a) = passed_constants.get(x) {
+        Some((a, DatumType::I64))
+      } else {
+        constants_hashmap.get(x).map(|&y| (&models[y].0, models[y].1))
+      }
+    })
+    .collect();
   let node_attributes = node.attribute.iter().map(|x| x).collect();
   let (local_graph, output_shapes) = get_local_graph(op, &input_shapes, &node_constants, node_attributes);
 
   // compute precomputable constants (these are constants that can be computed without proving)
   if node_constants.iter().all(|&x| x.is_some()) {
     let node_inputs: Vec<_> = node_constants.iter().map(|&x| x.unwrap().clone()).collect();
-    let node_inputs = node_inputs.iter().map(|x| x).collect();
+    let node_inputs = node_inputs.iter().map(|x| x.0).collect();
     let outputs = local_graph.run(&node_inputs, &vec![&arr1(&[]).into_dyn(); local_graph.basic_blocks.len()]);
     node.output.iter().zip(local_graph.outputs.iter()).for_each(|(output_str, &(nodeX, nodeY))| {
-      passed_constants.insert(
-        output_str.to_string(),
-        outputs[nodeX as usize][nodeY].clone(),
-      );
+      passed_constants.insert(output_str.to_string(), outputs[nodeX as usize][nodeY].clone());
     });
   }
 
@@ -310,7 +325,7 @@ fn process_node(
 // This function is used for loading onnx models and returning the graph and models
 // - Graph: the graph of zk-torch BasicBlocks after parsing the onnx layers
 // - Models: input tensors required for generating a setup for each BasicBlock
-pub fn load_file(filename: &str) -> (Graph, Vec<ArrayD<Fr>>) {
+pub fn load_file(filename: &str) -> (Graph, Vec<(ArrayD<Fr>, DatumType)>) {
   let onnx = tract_onnx::onnx();
   let onnx_graph = onnx.proto_model_for_path(filename).unwrap().graph.unwrap();
 


### PR DESCRIPTION
When we process constants in the onnx compiler, we scale floats based on the scale factor but not ints when converting them to their field values. This causes issues for layers such as Div which involve potential scale factor changes and can accept either float or int arguments.

The solution here is to pass the onnx DatumType to `graph()` for the `constants` parameter for layer-specific logic.

Also added the Div int fix