### PR TITLE
Fixed more shape issues

### DIFF
--- a/src/layer/reshape.rs
+++ b/src/layer/reshape.rs
@@ -19,9 +19,13 @@ impl Layer for ReshapeLayer {
       endShape[i] = a / b;
     }
     let endShape: Vec<_> = endShape.iter().map(|&x| x as usize).filter(|x| *x != 0).collect();
+    let endShape_padded: Vec<_> = endShape.iter().map(|&x| util::next_pow(x as u32) as usize).collect();
+    let startShape_padded: Vec<_> = startShape.iter().map(|&x| util::next_pow(x as u32) as usize).collect();
+    // check if the product of startShape_padded is equal to the product of endShape_padded
+    let equal = startShape_padded.iter().fold(1, |x, &y| x * y) == endShape_padded.iter().fold(1, |x, &y| x * y);
 
-    if startShape.last() == endShape.last() {
-      let reshape = graph.addBB(Box::new(ReshapeBasicBlock { shape: endShape.clone() }));
+    if equal && (startShape.last() == endShape.last()) {
+      let reshape = graph.addBB(Box::new(ReshapeBasicBlock { shape: endShape_padded.clone() }));
       let output = graph.addNode(reshape, vec![(-1, 0)]);
       graph.outputs.push((output, 0));
     } else if startShape.len() == 0 {
@@ -34,7 +38,6 @@ impl Layer for ReshapeLayer {
       graph.outputs.push((unsq_output, 0));
     } else {
       let permutation = get_reshape_indices(startShape.clone(), endShape.clone());
-      let startShape_padded: Vec<_> = startShape.iter().map(|x| util::next_pow(*x as u32) as usize).collect();
       let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
         permutation: permutation.clone(),
         input_dim: IxDyn(&startShape_padded),

--- a/src/layer/squeeze.rs
+++ b/src/layer/squeeze.rs
@@ -12,7 +12,7 @@ use tract_onnx::pb::AttributeProto;
 // If the last dimension is squeezed, we need to permute the tensor before reshaping because the last dimension affects the commitment.
 pub struct SqueezeLayer;
 impl Layer for SqueezeLayer {
-  fn graph(input_shapes: &Vec<&Vec<usize>>, _constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
+  fn graph(input_shapes: &Vec<&Vec<usize>>, constants: &Vec<Option<&ArrayD<Fr>>>, attributes: &Vec<&AttributeProto>) -> (Graph, Vec<Vec<usize>>) {
     let mut graph = Graph::new();
 
     let axes_result = attributes.iter().filter(|x| x.name == "axes").next();
@@ -22,7 +22,10 @@ impl Layer for SqueezeLayer {
       axes = x.ints.iter().map(|x| *x as i64).collect();
     } else {
       // axes is not provided
-      axes = input_shapes[0].iter().enumerate().filter(|(_, x)| **x == 1).map(|(i, _)| i as i64).collect();
+      axes = match constants.get(1) {
+        Some(x) => x.unwrap().iter().map(|x| util::fr_to_int(*x) as i64).collect(),
+        _ => input_shapes[0].iter().enumerate().filter(|(_, x)| **x == 1).map(|(i, _)| i as i64).collect(),
+      };
     }
 
     // map negative axes to positive
@@ -39,10 +42,11 @@ impl Layer for SqueezeLayer {
       let output = graph.addNode(reshape, vec![(-1, 0)]);
       graph.outputs.push((output, 0));
     } else {
+      let startShape_padded: Vec<_> = startShape.iter().map(|&x| util::next_pow(x as u32) as usize).collect();
       let permutation = get_reshape_indices(startShape.clone(), endShape.clone());
       let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
         permutation: permutation.clone(),
-        input_dim: IxDyn(&startShape),
+        input_dim: IxDyn(&startShape_padded),
         padding_partition: copy_constraint::PaddingEnum::Zero,
       }));
       let output = graph.addNode(cc, vec![(-1, 0)]);


### PR DESCRIPTION
(Not related to the running models Bert and ResNet)
This PR addresses more shape issues:
- Support various versions of Squeeze
- Consider a new special case for ReshapeBasicBlock: if we want to use ReshapeBB, we need to ensure the product of padded startShape is equal to that of padded endShape. Take reshaping [3,3,3,3] to [27,3] as an example, the thing happened behind the scene was we reshaped a padded [4,4,4,4] tensor into [32,4], which caused err because 4 * 4 * 4 != 32. In this case, we should use copy constraint.