### PR TITLE
Pass input types to layers and fix Mul layer scaling based on type

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -88,7 +88,8 @@ pub mod xor;
 pub trait Layer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>);
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>);
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -85,6 +85,7 @@ pub mod transpose;
 pub mod r#where;
 pub mod xor;
 
+// Most output types will only depend on an input type but for e.g., Range layer depends on the type of the constants
 pub trait Layer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,

--- a/src/layer/and.rs
+++ b/src/layer/and.rs
@@ -11,9 +11,10 @@ pub struct AndLayer;
 impl Layer for AndLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    _input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let bool_check = graph.addBB(Box::new(BooleanCheckBasicBlock {}));
     let mul = graph.addBB(Box::new(RepeaterBasicBlock {
@@ -42,6 +43,6 @@ impl Layer for AndLayer {
     };
 
     graph.outputs.push((and_output, 0));
-    (graph, vec![util::broadcastDims(input_shapes, 0)])
+    (graph, vec![util::broadcastDims(input_shapes, 0)], vec![DatumType::Bool])
   }
 }

--- a/src/layer/arithmetic.rs
+++ b/src/layer/arithmetic.rs
@@ -14,9 +14,10 @@ macro_rules! define_arithmetic_layer {
     impl Layer for $struct_name {
       fn graph(
         input_shapes: &Vec<&Vec<usize>>,
+        input_types: &Vec<DatumType>,
         _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
         _attributes: &Vec<&AttributeProto>,
-      ) -> (Graph, Vec<Vec<usize>>) {
+      ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
         let mut graph = Graph::new();
         let layer = graph.addBB(Box::new(RepeaterBasicBlock {
           basic_block: Box::new($basic_block {}),
@@ -24,7 +25,7 @@ macro_rules! define_arithmetic_layer {
         }));
         let layer_output = graph.addNode(layer, vec![(-1, 0), (-2, 0)]);
         graph.outputs.push((layer_output, 0));
-        (graph, vec![util::broadcastDims(input_shapes, 0)])
+        (graph, vec![util::broadcastDims(input_shapes, 0)], vec![input_types[0]])
       }
     }
   };

--- a/src/layer/cast.rs
+++ b/src/layer/cast.rs
@@ -1,6 +1,8 @@
 use crate::basic_block::*;
 use crate::graph::*;
 use crate::layer::Layer;
+use crate::util;
+use crate::util::datumtype_to_sf;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
@@ -10,13 +12,24 @@ pub struct CastLayer;
 impl Layer for CastLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
-    _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+    attributes: &Vec<&AttributeProto>,
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
-    let id = graph.addBB(Box::new(IdBasicBlock {}));
+    let to = match attributes.iter().filter(|x| x.name == "to").next() {
+      Some(v) => vec![util::datatype_to_datumtype(v.i as i32)],
+      None => vec![input_types[0]],
+    };
+    let input_SF = datumtype_to_sf(input_types[0]);
+    let output_SF = datumtype_to_sf(to[0]);
+    let id = if input_SF == output_SF {
+      graph.addBB(Box::new(IdBasicBlock {}))
+    } else {
+      graph.addBB(Box::new(ChangeSFBasicBlock { input_SF, output_SF }))
+    };
     let id_output = graph.addNode(id, vec![(-1, 0)]);
     graph.outputs.push((id_output, 0));
-    (graph, vec![input_shapes[0].clone()])
+    (graph, vec![input_shapes[0].clone()], to)
   }
 }

--- a/src/layer/clip.rs
+++ b/src/layer/clip.rs
@@ -12,9 +12,10 @@ pub struct ClipLayer;
 impl Layer for ClipLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let min = util::fr_to_int(constants[1].unwrap().0.as_slice().unwrap()[0]) as f32;
     let max = util::fr_to_int(constants[2].unwrap().0.as_slice().unwrap()[0]) as f32;
@@ -31,6 +32,6 @@ impl Layer for ClipLayer {
 
     graph.outputs.push((clip_output, 0));
 
-    (graph, vec![input_shapes[0].clone()])
+    (graph, vec![input_shapes[0].clone()], vec![input_types[0]])
   }
 }

--- a/src/layer/concat.rs
+++ b/src/layer/concat.rs
@@ -40,9 +40,10 @@ pub struct ConcatLayer;
 impl Layer for ConcatLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
 
     // Extract the 'axis' attribute and adjust for negative values
@@ -105,6 +106,6 @@ impl Layer for ConcatLayer {
       graph.outputs.push((concat_output, 0));
     }
 
-    (graph, vec![outputShape])
+    (graph, vec![outputShape], vec![input_types[0]])
   }
 }

--- a/src/layer/constantofshape.rs
+++ b/src/layer/constantofshape.rs
@@ -13,9 +13,10 @@ pub struct ConstOfShapeLayer;
 impl Layer for ConstOfShapeLayer {
   fn graph(
     _input_shapes: &Vec<&Vec<usize>>,
+    _input_types: &Vec<DatumType>,
     constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
 
     let value = Fr::from(attributes.iter().filter(|x| x.name == "value").next().unwrap().i);
@@ -28,6 +29,6 @@ impl Layer for ConstOfShapeLayer {
     }));
     let output = graph.addNode(constantOfShape, vec![]);
     graph.outputs.push((output, 0));
-    (graph, vec![endShape])
+    (graph, vec![endShape], vec![DatumType::I64])
   }
 }

--- a/src/layer/conv.rs
+++ b/src/layer/conv.rs
@@ -142,9 +142,10 @@ macro_rules! create_conv_layer {
     impl Layer for $layer_name {
       fn graph(
         input_shapes: &Vec<&Vec<usize>>,
+        input_types: &Vec<DatumType>,
         _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
         attributes: &Vec<&AttributeProto>,
-      ) -> (Graph, Vec<Vec<usize>>) {
+      ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
         let mut graph = Graph::new();
         let weight_shape = input_shapes[1];
         let dims = input_shapes[0][2..].to_vec();
@@ -248,7 +249,7 @@ macro_rules! create_conv_layer {
         };
         let cc2_output = graph.addNode(cc2, vec![(add_output, 0)]);
         graph.outputs.push((cc2_output, 0));
-        (graph, vec![output_shape])
+        (graph, vec![output_shape], vec![input_types[0]])
       }
     }
   };

--- a/src/layer/div.rs
+++ b/src/layer/div.rs
@@ -17,10 +17,11 @@ macro_rules! create_division_layer {
 
     impl Layer for $layer_name {
       fn graph(
-        input_shapes: &Vec<&Vec<usize>>,                   // Input shapes for the layer
+        input_shapes: &Vec<&Vec<usize>>, // Input shapes for the layer
+        input_types: &Vec<DatumType>,
         constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>, // Constants used in the layer
         _attributes: &Vec<&AttributeProto>,                // Attributes for the layer (not used in this implementation)
-      ) -> (Graph, Vec<Vec<usize>>) {
+      ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
         let mut graph = Graph::new(); // Create a new computational graph
 
         // Check if the second input is a constant
@@ -62,7 +63,7 @@ macro_rules! create_division_layer {
           graph.outputs.push((const_output, 0));
 
           // Return the graph and updated input shapes
-          return (graph, vec![input_shapes[0].clone()]);
+          return (graph, vec![input_shapes[0].clone()], vec![input_types[0]]);
         }
 
         // Assert that the second input has only one element
@@ -150,7 +151,7 @@ macro_rules! create_division_layer {
         graph.outputs.push((div_output, $output_idx));
 
         // Return the constructed graph and the updated input shapes
-        (graph, vec![input_shapes[0].clone()])
+        (graph, vec![input_shapes[0].clone()], vec![input_types[0]])
       }
     }
   };

--- a/src/layer/einsum.rs
+++ b/src/layer/einsum.rs
@@ -152,9 +152,10 @@ pub struct EinsumLayer;
 impl Layer for EinsumLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let equation = &attributes.iter().filter(|x| x.name == "equation").next().unwrap().s;
     let equation = std::str::from_utf8(&equation).unwrap();
@@ -164,12 +165,12 @@ impl Layer for EinsumLayer {
     if input_eqs == vec!["a", "b"] && output_eq == vec!["ab"] {
       assert!(input_shapes[0].len() == 1 && input_shapes[1].len() == 1);
       let output_shape = vector_outer_product(&mut graph, input_shapes);
-      (graph, vec![output_shape])
+      (graph, vec![output_shape], vec![input_types[0]])
     // vector inner product
     } else if input_eqs == vec!["a", "a"] && output_eq.len() == 0 {
       assert!(input_shapes[0].len() == 1 && input_shapes[1].len() == 1);
       let output_shape = vector_inner_product(&mut graph, input_shapes);
-      (graph, vec![output_shape])
+      (graph, vec![output_shape], vec![input_types[0]])
     } else {
       panic!("EinsumLayer not implemented for equation {:?}", equation);
     }

--- a/src/layer/equal.rs
+++ b/src/layer/equal.rs
@@ -12,9 +12,10 @@ pub struct EqualLayer;
 impl Layer for EqualLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    _input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let one = graph.addBB(Box::new(Const2BasicBlock {
       c: arr1(&vec![Fr::from(1); util::next_pow(*input_shapes[0].last().unwrap() as u32) as usize]).into_dyn(),
@@ -60,6 +61,6 @@ impl Layer for EqualLayer {
     let _nonzero_check = graph.addNode(nonzero_check, vec![(add_output, 0)]);
 
     graph.outputs.push((equal_output, 0));
-    (graph, vec![util::broadcastDims(input_shapes, 0)])
+    (graph, vec![util::broadcastDims(input_shapes, 0)], vec![DatumType::Bool])
   }
 }

--- a/src/layer/expand.rs
+++ b/src/layer/expand.rs
@@ -22,9 +22,10 @@ pub struct ExpandLayer;
 impl Layer for ExpandLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let newShape: Vec<_> = constants[1].unwrap().0.as_slice().unwrap().iter().map(|&x| util::fr_to_int(x) as usize).filter(|x| *x != 0).collect();
     let mut graph = Graph::new();
     if *input_shapes[0].last().unwrap() == *newShape.clone().last().unwrap() {
@@ -49,6 +50,6 @@ impl Layer for ExpandLayer {
       graph.outputs.push((expand_output, 0));
     }
 
-    (graph, vec![newShape])
+    (graph, vec![newShape], vec![input_types[0]])
   }
 }

--- a/src/layer/flatten.rs
+++ b/src/layer/flatten.rs
@@ -29,9 +29,10 @@ pub struct FlattenLayer;
 impl Layer for FlattenLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
 
     let axis: isize = attributes.iter().filter(|x| x.name == "axis").next().unwrap().i as isize;
@@ -50,6 +51,6 @@ impl Layer for FlattenLayer {
     let output = graph.addNode(cc, vec![(-1, 0)]);
     graph.outputs.push((output, 0));
 
-    (graph, vec![output_shape])
+    (graph, vec![output_shape], vec![input_types[0]])
   }
 }

--- a/src/layer/gather.rs
+++ b/src/layer/gather.rs
@@ -27,15 +27,16 @@ pub struct GatherLayer;
 impl Layer for GatherLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let gather = graph.addBB(Box::new(GatherBasicBlock {}));
     let output = graph.addNode(gather, vec![(-1, 0), (-2, 0)]);
     graph.outputs.push((output, 0));
     let mut output_shape = input_shapes[1].clone();
     output_shape.extend_from_slice(&input_shapes[0][1..]);
-    (graph, vec![output_shape])
+    (graph, vec![output_shape], vec![input_types[0]])
   }
 }

--- a/src/layer/gathernd.rs
+++ b/src/layer/gathernd.rs
@@ -62,9 +62,10 @@ pub struct GatherNDLayer;
 impl Layer for GatherNDLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
 
     let indices = if constants[1].is_none() {
@@ -100,6 +101,6 @@ impl Layer for GatherNDLayer {
     let output = graph.addNode(cc, vec![(-1, 0)]);
     graph.outputs.push((output, 0));
 
-    (graph, vec![output_shape])
+    (graph, vec![output_shape], vec![input_types[0]])
   }
 }

--- a/src/layer/gemm.rs
+++ b/src/layer/gemm.rs
@@ -18,9 +18,10 @@ pub struct GemmLayer;
 impl Layer for GemmLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
 
     let alpha = if attributes.iter().any(|x| x.name == "alpha") {
@@ -133,6 +134,6 @@ impl Layer for GemmLayer {
     graph.outputs.push((output, 0));
 
     let output_shape = vec![M, N];
-    (graph, vec![output_shape])
+    (graph, vec![output_shape], vec![input_types[0]])
   }
 }

--- a/src/layer/less.rs
+++ b/src/layer/less.rs
@@ -13,9 +13,10 @@ pub struct LessLayer;
 impl Layer for LessLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    _input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     // Inputs: A, B
     // Outputs: L = (A < B); then 1 - L = (A >= B). We can view them as selection of indices.
     // Check 1: (A - B) * L + (-1) * (1 - L) < 0 because A - B will always < 0 at indices of A < B and we set values at other indices as -1
@@ -60,6 +61,6 @@ impl Layer for LessLayer {
     let _ = graph.addNode(negative_check, vec![(check1_output, 0)]);
     let _ = graph.addNode(non_negative_check, vec![(check2_output, 0)]);
     graph.outputs.push((less_output, 0));
-    (graph, vec![util::broadcastDims(input_shapes, 0)])
+    (graph, vec![util::broadcastDims(input_shapes, 0)], vec![DatumType::Bool])
   }
 }

--- a/src/layer/lstm.rs
+++ b/src/layer/lstm.rs
@@ -14,9 +14,10 @@ pub struct LSTMLayer;
 impl Layer for LSTMLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     // currently, we do not support P (peepholes)
     assert!(input_shapes.len() == 6); // X, W, R, B, initial_h, initial_c
 
@@ -307,6 +308,7 @@ impl Layer for LSTMLayer {
         vec![num_directions, batch_size, hidden_size],
         vec![num_directions, batch_size, hidden_size],
       ],
+      vec![input_types[0]; 3],
     )
   }
 }

--- a/src/layer/matmul.rs
+++ b/src/layer/matmul.rs
@@ -12,9 +12,10 @@ pub struct MatMulLayer;
 impl Layer for MatMulLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let n = input_shapes[1].len();
     let (mut a, mut b) = (input_shapes[1][n - 2], input_shapes[1][n - 1]);
@@ -60,6 +61,6 @@ impl Layer for MatMulLayer {
     } else {
       output_shape.push(input_shapes[1][input_shapes[1].len() - 1]);
     }
-    (graph, vec![output_shape])
+    (graph, vec![output_shape], vec![input_types[0]])
   }
 }

--- a/src/layer/max.rs
+++ b/src/layer/max.rs
@@ -22,9 +22,10 @@ pub struct MaxLayer;
 impl Layer for MaxLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     // For now we only support the case when there are two inputs and the second input is a constant of a single element. The single element is compared element-wise with the first input
     if input_shapes.len() == 2 && input_shapes[1].len() == 1 && constants[1].is_some() {
@@ -58,7 +59,7 @@ impl Layer for MaxLayer {
     } else {
       panic!("MaxLayer only supports having two inputs where the second input is a constant")
     }
-    (graph, vec![input_shapes[0].clone()])
+    (graph, vec![input_shapes[0].clone()], vec![input_types[0]])
   }
 }
 
@@ -66,9 +67,10 @@ pub struct MinLayer;
 impl Layer for MinLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     // For now we only support the case when there are two inputs where the first input has ndim > 1 and the second input is a single element. The single element is compared element-wise with the first input. This is its only use case in RetinaNet where the first input has the same dimensions as the Max output and second input comes from Shape -> Gather layers.
     if input_shapes.len() == 2 && input_shapes[1].len() == 1 && input_shapes[0].len() > 1 {
@@ -139,6 +141,6 @@ impl Layer for MinLayer {
     } else {
       panic!("MinLayer only supports having two inputs where the first input has ndim > 1 and the second input is a single element")
     }
-    (graph, vec![input_shapes[0].clone()])
+    (graph, vec![input_shapes[0].clone()], vec![input_types[0]])
   }
 }

--- a/src/layer/mul.rs
+++ b/src/layer/mul.rs
@@ -12,9 +12,10 @@ pub struct MulLayer;
 impl Layer for MulLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let mul = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(MulBasicBlock {}),
@@ -58,6 +59,6 @@ impl Layer for MulLayer {
     let change_SF_output = graph.addNode(change_SF, vec![(mul_output, 0)]);
     let _ = graph.addNode(change_SF_check, vec![(mul_output, 0), (change_SF_output, 0)]);
     graph.outputs.push((change_SF_output, 0));
-    (graph, vec![util::broadcastDims(input_shapes, 0)])
+    (graph, vec![util::broadcastDims(input_shapes, 0)], vec![input_types[0]])
   }
 }

--- a/src/layer/mul.rs
+++ b/src/layer/mul.rs
@@ -56,9 +56,15 @@ impl Layer for MulLayer {
       graph.addNode(mul_basicblock, vec![(-1, 0), (-2, 0)])
     };
 
-    let change_SF_output = graph.addNode(change_SF, vec![(mul_output, 0)]);
-    let _ = graph.addNode(change_SF_check, vec![(mul_output, 0), (change_SF_output, 0)]);
-    graph.outputs.push((change_SF_output, 0));
+    if input_types[0].is_float() {
+      let change_SF_output = graph.addNode(change_SF, vec![(mul_output, 0)]);
+      let _ = graph.addNode(change_SF_check, vec![(mul_output, 0), (change_SF_output, 0)]);
+      graph.outputs.push((change_SF_output, 0));
+    } else if input_types[0].is_integer() {
+      graph.outputs.push((mul_output, 0));
+    } else {
+      panic!("Mul input type {:?} is not supported", input_types[0]);
+    }
     (graph, vec![util::broadcastDims(input_shapes, 0)], vec![input_types[0]])
   }
 }

--- a/src/layer/neg.rs
+++ b/src/layer/neg.rs
@@ -13,9 +13,10 @@ pub struct NegLayer;
 impl Layer for NegLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let zero = graph.addBB(Box::new(Const2BasicBlock {
       c: arr1(&vec![Fr::zero(); *input_shapes[0].last().unwrap()]).into_dyn(),
@@ -27,6 +28,6 @@ impl Layer for NegLayer {
     let zero_output = graph.addNode(zero, vec![]);
     let layer_output = graph.addNode(layer, vec![(zero_output, 0), (-1, 0)]);
     graph.outputs.push((layer_output, 0));
-    (graph, vec![util::broadcastDims(input_shapes, 0)])
+    (graph, vec![util::broadcastDims(input_shapes, 0)], vec![input_types[0]])
   }
 }

--- a/src/layer/nonlinear.rs
+++ b/src/layer/nonlinear.rs
@@ -14,9 +14,10 @@ macro_rules! define_nonlinear_layer {
     impl Layer for $struct_name {
       fn graph(
         input_shapes: &Vec<&Vec<usize>>,
+        input_types: &Vec<DatumType>,
         _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
         _attributes: &Vec<&AttributeProto>,
-      ) -> (Graph, Vec<Vec<usize>>) {
+      ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
         let mut graph = Graph::new();
         let layer = graph.addBB(Box::new($basic_block {
           input_SF: *onnx::SF_LOG,
@@ -38,7 +39,7 @@ macro_rules! define_nonlinear_layer {
         let layer_output = graph.addNode(layer, vec![(-1, 0)]);
         let _ = graph.addNode(layer_check, vec![(-1, 0), (layer_output, 0)]);
         graph.outputs.push((layer_output, 0));
-        (graph, vec![input_shapes[0].clone()])
+        (graph, vec![input_shapes[0].clone()], vec![input_types[0]])
       }
     }
   };

--- a/src/layer/norm.rs
+++ b/src/layer/norm.rs
@@ -15,9 +15,10 @@ pub struct BatchNormLayer;
 impl Layer for BatchNormLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
 
     let X_shape = input_shapes[0];
@@ -216,7 +217,7 @@ impl Layer for BatchNormLayer {
     let output = graph.addNode(add, vec![(concat_output, 0), (bias_output, 0)]);
 
     graph.outputs.push((output, 0));
-    (graph, vec![input_shapes[0].clone()])
+    (graph, vec![input_shapes[0].clone()], vec![input_types[0]])
   }
 }
 
@@ -227,9 +228,10 @@ pub struct InstanceNormLayer;
 impl Layer for InstanceNormLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
 
     let X_shape = input_shapes[0];
@@ -487,6 +489,6 @@ impl Layer for InstanceNormLayer {
     let output = graph.addNode(add, vec![(concat_output, 0), (bias_output, 0)]);
 
     graph.outputs.push((output, 0));
-    (graph, vec![input_shapes[0].clone()])
+    (graph, vec![input_shapes[0].clone()], vec![input_types[0]])
   }
 }

--- a/src/layer/not.rs
+++ b/src/layer/not.rs
@@ -13,9 +13,10 @@ pub struct NotLayer;
 impl Layer for NotLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    _input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let bool_check = graph.addBB(Box::new(BooleanCheckBasicBlock {}));
     let one = graph.addBB(Box::new(Const2BasicBlock {
@@ -29,6 +30,6 @@ impl Layer for NotLayer {
     let one_output = graph.addNode(one, vec![]);
     let layer_output = graph.addNode(layer, vec![(one_output, 0), (-1, 0)]);
     graph.outputs.push((layer_output, 0));
-    (graph, vec![util::broadcastDims(input_shapes, 0)])
+    (graph, vec![util::broadcastDims(input_shapes, 0)], vec![DatumType::Bool])
   }
 }

--- a/src/layer/pool.rs
+++ b/src/layer/pool.rs
@@ -49,9 +49,10 @@ pub struct MaxPoolLayer;
 impl Layer for MaxPoolLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let dims = input_shapes[0][2..].to_vec();
 
@@ -113,6 +114,6 @@ impl Layer for MaxPoolLayer {
     let cc1_output = graph.addNode(cc1, vec![(max_output, 0)]);
     let _ = graph.addNode(range_check, vec![(max_output, 1)]);
     graph.outputs.push((cc1_output, 0));
-    (graph, vec![output_shape])
+    (graph, vec![output_shape], vec![input_types[0]])
   }
 }

--- a/src/layer/pow.rs
+++ b/src/layer/pow.rs
@@ -11,9 +11,10 @@ pub struct PowLayer;
 impl Layer for PowLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     assert!(constants[1].unwrap().0.first().unwrap() == &Fr::from(2 * *onnx::SF as u32));
     let mul = graph.addBB(Box::new(RepeaterBasicBlock {
@@ -41,6 +42,6 @@ impl Layer for PowLayer {
     let change_SF_output = graph.addNode(change_SF, vec![(mul_output, 0)]);
     let _ = graph.addNode(change_SF_check, vec![(mul_output, 0), (change_SF_output, 0)]);
     graph.outputs.push((change_SF_output, 0));
-    (graph, vec![input_shapes[0].clone()])
+    (graph, vec![input_shapes[0].clone()], vec![input_types[0]])
   }
 }

--- a/src/layer/range.rs
+++ b/src/layer/range.rs
@@ -11,9 +11,10 @@ pub struct RangeLayer;
 impl Layer for RangeLayer {
   fn graph(
     _input_shapes: &Vec<&Vec<usize>>,
+    _input_types: &Vec<DatumType>,
     constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let mut all_are_constant = true;
 
@@ -49,6 +50,6 @@ impl Layer for RangeLayer {
       panic!("Don't support non-constant range yet");
     }
 
-    (graph, vec![vec![length]])
+    (graph, vec![vec![length]], vec![constants[0].unwrap().1])
   }
 }

--- a/src/layer/reducemean.rs
+++ b/src/layer/reducemean.rs
@@ -14,9 +14,10 @@ pub struct ReduceMeanLayer;
 impl Layer for ReduceMeanLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
 
     let axes: Vec<_> = match attributes.iter().filter(|x| x.name == "axes").next() {
@@ -83,12 +84,12 @@ impl Layer for ReduceMeanLayer {
       let mut outputShape = input_shapes[0].clone();
       outputShape[input_shapes[0].len() - 1] = 1;
       outputShape[input_shapes[0].len() - 2] = 1;
-      (graph, vec![outputShape])
+      (graph, vec![outputShape], vec![input_types[0]])
     } else if axes.len() == 1 {
       graph.outputs.push((div_output, 0));
       let mut outputShape = input_shapes[0].clone();
       outputShape[input_shapes[0].len() - 1] = 1;
-      (graph, vec![outputShape])
+      (graph, vec![outputShape], vec![input_types[0]])
     } else {
       panic!("Only support reducing along one or two axis");
     }

--- a/src/layer/reshape.rs
+++ b/src/layer/reshape.rs
@@ -11,9 +11,10 @@ pub struct ReshapeLayer;
 impl Layer for ReshapeLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
 
     let startShape = input_shapes[0];
@@ -30,7 +31,9 @@ impl Layer for ReshapeLayer {
     let equal = startShape_padded.iter().fold(1, |x, &y| x * y) == endShape_padded.iter().fold(1, |x, &y| x * y);
 
     if equal && (startShape.last() == endShape.last()) {
-      let reshape = graph.addBB(Box::new(ReshapeBasicBlock { shape: endShape_padded.clone() }));
+      let reshape = graph.addBB(Box::new(ReshapeBasicBlock {
+        shape: endShape_padded.clone(),
+      }));
       let output = graph.addNode(reshape, vec![(-1, 0)]);
       graph.outputs.push((output, 0));
     } else if startShape.len() == 0 {
@@ -52,6 +55,6 @@ impl Layer for ReshapeLayer {
       graph.outputs.push((output, 0));
     }
 
-    (graph, vec![endShape])
+    (graph, vec![endShape], vec![input_types[0]])
   }
 }

--- a/src/layer/resize.rs
+++ b/src/layer/resize.rs
@@ -26,9 +26,10 @@ pub struct ResizeLayer;
 impl Layer for ResizeLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
 
     let ctm = match attributes.iter().filter(|x| x.name == "coordinate_transformation_mode").next() {
@@ -86,6 +87,6 @@ impl Layer for ResizeLayer {
     let cc_output = graph.addNode(cc, vec![(-1, 0)]);
     graph.outputs.push((cc_output, 0));
 
-    (graph, vec![output_shape])
+    (graph, vec![output_shape], vec![input_types[0]])
   }
 }

--- a/src/layer/scatternd.rs
+++ b/src/layer/scatternd.rs
@@ -75,9 +75,10 @@ pub struct ScatterNDLayer;
 impl Layer for ScatterNDLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     // TODO: handle cases when attribute is not none
     let indices = constants[1].unwrap().0;
@@ -105,6 +106,6 @@ impl Layer for ScatterNDLayer {
     let add_output = graph.addNode(add, vec![(data_to_preserve, 0), (data_to_update, 0)]);
     graph.outputs.push((add_output, 0));
 
-    (graph, vec![input_shapes[0].clone()])
+    (graph, vec![input_shapes[0].clone()], vec![input_types[0]])
   }
 }

--- a/src/layer/shape.rs
+++ b/src/layer/shape.rs
@@ -23,13 +23,14 @@ pub struct ShapeLayer;
 impl Layer for ShapeLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    _input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let shape = graph.addBB(Box::new(ShapeBasicBlock {}));
     let shape_output = graph.addNode(shape, vec![(-1, 0)]);
     graph.outputs.push((shape_output, 0));
-    (graph, vec![vec![input_shapes[0].len()]])
+    (graph, vec![vec![input_shapes[0].len()]], vec![DatumType::I64])
   }
 }

--- a/src/layer/slice.rs
+++ b/src/layer/slice.rs
@@ -79,9 +79,10 @@ pub struct SliceLayer;
 impl Layer for SliceLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let starts: Vec<_> = constants[1].unwrap().0.as_slice().unwrap().iter().map(|x| util::fr_to_int(*x)).collect();
     let ends: Vec<_> = constants[2].unwrap().0.as_slice().unwrap().iter().map(|x| util::fr_to_int(*x)).collect();
@@ -136,6 +137,6 @@ impl Layer for SliceLayer {
     let slice_output = graph.addNode(cc, vec![(-1, 0)]);
     graph.outputs.push((slice_output, 0));
 
-    (graph, vec![output_shape])
+    (graph, vec![output_shape], vec![input_types[0]])
   }
 }

--- a/src/layer/softmax.rs
+++ b/src/layer/softmax.rs
@@ -11,9 +11,10 @@ pub struct SoftmaxLayer;
 impl Layer for SoftmaxLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let max = graph.addBB(Box::new(MaxBasicBlock {}));
     let sub = graph.addBB(Box::new(RepeaterBasicBlock {
@@ -76,6 +77,6 @@ impl Layer for SoftmaxLayer {
     let _ = graph.addNode(exp_check, vec![(sub_output_2, 0), (exp_output_2, 0)]);
     graph.outputs.push((exp_output_2, 0));
 
-    (graph, vec![input_shapes[0].clone()])
+    (graph, vec![input_shapes[0].clone()], vec![input_types[0]])
   }
 }

--- a/src/layer/split.rs
+++ b/src/layer/split.rs
@@ -11,9 +11,10 @@ pub struct SplitLayer;
 impl Layer for SplitLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
 
     // This code is for Opset 11; in the latest version of ONNX, "split" is in inputs instead of the attributes
@@ -74,6 +75,7 @@ impl Layer for SplitLayer {
       }
     }
 
-    (graph, outputShapes)
+    let num_outputs = outputShapes.len();
+    (graph, outputShapes, vec![input_types[0]; num_outputs])
   }
 }

--- a/src/layer/squeeze.rs
+++ b/src/layer/squeeze.rs
@@ -15,9 +15,10 @@ pub struct SqueezeLayer;
 impl Layer for SqueezeLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
 
     let axes_result = attributes.iter().filter(|x| x.name == "axes").next();
@@ -57,7 +58,7 @@ impl Layer for SqueezeLayer {
       let output = graph.addNode(cc, vec![(-1, 0)]);
       graph.outputs.push((output, 0));
     }
-    (graph, vec![endShape])
+    (graph, vec![endShape], vec![input_types[0]])
   }
 }
 
@@ -79,9 +80,10 @@ pub struct UnsqueezeLayer;
 impl Layer for UnsqueezeLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
 
     let axis: isize = attributes.iter().filter(|x| x.name == "axes").next().unwrap().ints[0] as isize;
@@ -133,6 +135,6 @@ impl Layer for UnsqueezeLayer {
       graph.outputs.push((unsqueeze_output, 0));
     }
 
-    (graph, vec![endShape])
+    (graph, vec![endShape], vec![input_types[0]])
   }
 }

--- a/src/layer/tile.rs
+++ b/src/layer/tile.rs
@@ -33,9 +33,10 @@ pub struct TileLayer;
 impl Layer for TileLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let repeats: Vec<_> = constants[1].unwrap().0.as_slice().unwrap().iter().map(|x| util::fr_to_int(*x)).collect();
     let mut repeats: Vec<_> = repeats.iter().map(|x| *x as usize).collect();
@@ -72,6 +73,6 @@ impl Layer for TileLayer {
     let tiled_output = graph.addNode(cc, vec![(input_index, 0)]);
     graph.outputs.push((tiled_output, 0));
 
-    (graph, vec![padded_output_shape])
+    (graph, vec![padded_output_shape], vec![input_types[0]])
   }
 }

--- a/src/layer/topk.rs
+++ b/src/layer/topk.rs
@@ -28,9 +28,10 @@ pub struct TopKLayer;
 impl Layer for TopKLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let mut descending = true;
     let k = constants[1].unwrap().0.as_slice().unwrap().iter().map(|x| util::fr_to_int(*x)).collect::<Vec<_>>()[0] as usize;
@@ -117,7 +118,7 @@ impl Layer for TopKLayer {
     output_shape[output_ndim - 1] = k;
     graph.outputs.push((topk_data_output, 0));
     graph.outputs.push((topk_indices_output, 0));
-    (graph, vec![output_shape; 2])
+    (graph, vec![output_shape; 2], vec![input_types[0], DatumType::I64])
   }
 }
 
@@ -126,9 +127,10 @@ pub struct ArgMaxLayer;
 impl Layer for ArgMaxLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    _input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let descending = true;
     let axis: isize = attributes.iter().filter(|x| x.name == "axis").next().unwrap().i as isize;
@@ -195,6 +197,6 @@ impl Layer for ArgMaxLayer {
     let output_ndim = output_shape.len();
     output_shape[output_ndim - 1] = 1;
     graph.outputs.push((top1_indices_output, 0));
-    (graph, vec![output_shape])
+    (graph, vec![output_shape], vec![DatumType::I64])
   }
 }

--- a/src/layer/transpose.rs
+++ b/src/layer/transpose.rs
@@ -11,9 +11,10 @@ pub struct TransposeLayer;
 impl Layer for TransposeLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
 
     let axes: Vec<_> = attributes.iter().filter(|x| x.name == "perm").next().unwrap().ints.iter().map(|x| *x as usize).collect();
@@ -45,6 +46,6 @@ impl Layer for TransposeLayer {
       todo!()
     }
 
-    (graph, vec![endShape])
+    (graph, vec![endShape], vec![input_types[0]])
   }
 }

--- a/src/layer/where.rs
+++ b/src/layer/where.rs
@@ -11,9 +11,10 @@ pub struct WhereLayer;
 impl Layer for WhereLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     //condition, X, Y
     //condition * X + (1-condition) * Y
     let mut graph = Graph::new();
@@ -43,6 +44,6 @@ impl Layer for WhereLayer {
     let mul2_output = graph.addNode(if input_shapes[2].len() == 0 { mul_scalar } else { mul }, vec![(sub_output, 0), (-3, 0)]);
     let add_output = graph.addNode(add, vec![(mul1_output, 0), (mul2_output, 0)]);
     graph.outputs.push((add_output, 0));
-    (graph, vec![input_shapes[0].clone()])
+    (graph, vec![input_shapes[0].clone()], vec![input_types[0]])
   }
 }

--- a/src/layer/xor.rs
+++ b/src/layer/xor.rs
@@ -11,9 +11,10 @@ pub struct XorLayer;
 impl Layer for XorLayer {
   fn graph(
     input_shapes: &Vec<&Vec<usize>>,
+    _input_types: &Vec<DatumType>,
     _constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
     _attributes: &Vec<&AttributeProto>,
-  ) -> (Graph, Vec<Vec<usize>>) {
+  ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let bool_check = graph.addBB(Box::new(BooleanCheckBasicBlock {}));
     let sub = graph.addBB(Box::new(RepeaterBasicBlock {
@@ -29,6 +30,6 @@ impl Layer for XorLayer {
     let sub_output = graph.addNode(sub, vec![(-1, 0), (-2, 0)]);
     let xor_output = graph.addNode(mul, vec![(sub_output, 0), (sub_output, 0)]); // XOR(a, b) = PointwiseMul((a - b), (a - b))
     graph.outputs.push((xor_output, 0));
-    (graph, vec![util::broadcastDims(input_shapes, 0)])
+    (graph, vec![util::broadcastDims(input_shapes, 0)], vec![DatumType::Bool])
   }
 }

--- a/src/onnx.rs
+++ b/src/onnx.rs
@@ -289,7 +289,6 @@ fn process_node(
   let input_shapes = input_shapes.into_iter().filter_map(|x| x).collect::<Vec<_>>(); // hack: we ignore optional inputs
   let input_types: Vec<_> = node.input.iter().map(|x| types.get(x)).collect();
   let input_types = input_types.into_iter().filter_map(|opt| opt.map(|x| *x)).collect::<Vec<_>>();
-  println!("input_types {:?}", input_types);
   let node_constants = node
     .input
     .iter()
@@ -303,7 +302,6 @@ fn process_node(
     .collect();
   let node_attributes = node.attribute.iter().map(|x| x).collect();
   let (local_graph, output_shapes, output_types) = get_local_graph(op, &input_shapes, &input_types, &node_constants, node_attributes);
-  println!("output_types {:?}", output_types);
 
   // compute precomputable constants (these are constants that can be computed without proving)
   if node_constants.iter().all(|&x| x.is_some()) {

--- a/src/onnx.rs
+++ b/src/onnx.rs
@@ -22,9 +22,10 @@ pub static CQ_RANGE: Lazy<usize> = Lazy::new(|| 1 << CONFIG.sf.cq_range_log);
 pub static CQ_RANGE_LOWER: Lazy<i32> = Lazy::new(|| -(1 << CONFIG.sf.cq_range_lower_log));
 
 // This function is used for parsing the inputs of onnx models
-fn parse_onnx_inputs(onnx_graph: &pb::GraphProto) -> (HashMap<String, usize>, HashMap<String, Vec<usize>>) {
+fn parse_onnx_inputs(onnx_graph: &pb::GraphProto) -> (HashMap<String, usize>, HashMap<String, Vec<usize>>, HashMap<String, DatumType>) {
   let mut input_idx = HashMap::new();
   let mut shapes = HashMap::new();
+  let mut types = HashMap::new();
 
   for (idx, i) in onnx_graph.input.iter().enumerate() {
     input_idx.insert(i.name.clone(), idx);
@@ -45,9 +46,10 @@ fn parse_onnx_inputs(onnx_graph: &pb::GraphProto) -> (HashMap<String, usize>, Ha
         })
         .collect::<Vec<_>>(),
     );
+    types.insert(i.name.clone(), util::datatype_to_datumtype(t.elem_type));
   }
 
-  (input_idx, shapes)
+  (input_idx, shapes, types)
 }
 
 // This function is used for parsing the constants of onnx models
@@ -137,68 +139,69 @@ fn create_output_indices<'a>(
 fn get_local_graph(
   op: &str,
   input_shapes: &Vec<&Vec<usize>>,
+  input_types: &Vec<DatumType>,
   node_constants: &Vec<Option<(&ArrayD<Fr>, DatumType)>>,
   node_attributes: Vec<&AttributeProto>,
-) -> (Graph, Vec<Vec<usize>>) {
+) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
   match op {
-    "Add" => Ok(AddLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "And" => Ok(AndLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "ArgMax" => Ok(ArgMaxLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Mul" => Ok(MulLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Cast" => Ok(CastLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Identity" => Ok(CastLayer::graph(&input_shapes, &node_constants, &node_attributes)), // Identity is equivalent to Cast in zk-torch
-    "InstanceNormalization" => Ok(InstanceNormLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "BatchNormalization" => Ok(BatchNormLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Ceil" => Ok(CeilLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Clip" => Ok(ClipLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Concat" => Ok(ConcatLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "ConstantOfShape" => Ok(ConstOfShapeLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Cos" => Ok(CosLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Sin" => Ok(SinLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Sub" => Ok(SubLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Einsum" => Ok(EinsumLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Less" => Ok(LessLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "LSTM" => Ok(LSTMLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "MatMul" => Ok(MatMulLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Mod" => Ok(ModLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Neg" => Ok(NegLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Not" => Ok(NotLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Relu" => Ok(ReLULayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Flatten" => Ok(FlattenLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Gather" => Ok(GatherLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "GatherND" => Ok(GatherNDLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Gemm" => Ok(GemmLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Range" => Ok(RangeLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Reciprocal" => Ok(ReciprocalLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "ReduceMean" => Ok(ReduceMeanLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Pow" => Ok(PowLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Div" => Ok(DivLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "ScatterND" => Ok(ScatterNDLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Slice" => Ok(SliceLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Split" => Ok(SplitLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Sqrt" => Ok(SqrtLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Reshape" => Ok(ReshapeLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Resize" => Ok(ResizeLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Transpose" => Ok(TransposeLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Tan" => Ok(TanLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Tanh" => Ok(TanhLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "TopK" => Ok(TopKLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Tile" => Ok(TileLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Shape" => Ok(ShapeLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Sigmoid" => Ok(SigmoidLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Equal" => Ok(EqualLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Where" => Ok(WhereLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Expand" => Ok(ExpandLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Softmax" => Ok(SoftmaxLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Squeeze" => Ok(SqueezeLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Unsqueeze" => Ok(UnsqueezeLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Erf" => Ok(ErfLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Conv" => Ok(ConvLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "ConvTranspose" => Ok(ConvTransposeLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Max" => Ok(MaxLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Min" => Ok(MinLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "MaxPool" => Ok(MaxPoolLayer::graph(&input_shapes, &node_constants, &node_attributes)),
-    "Xor" => Ok(XorLayer::graph(&input_shapes, &node_constants, &node_attributes)),
+    "Add" => Ok(AddLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "And" => Ok(AndLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "ArgMax" => Ok(ArgMaxLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Mul" => Ok(MulLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Cast" => Ok(CastLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Identity" => Ok(CastLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)), // Identity is equivalent to Cast in zk-torch
+    "InstanceNormalization" => Ok(InstanceNormLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "BatchNormalization" => Ok(BatchNormLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Ceil" => Ok(CeilLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Clip" => Ok(ClipLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Concat" => Ok(ConcatLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "ConstantOfShape" => Ok(ConstOfShapeLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Cos" => Ok(CosLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Sin" => Ok(SinLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Sub" => Ok(SubLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Einsum" => Ok(EinsumLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Less" => Ok(LessLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "LSTM" => Ok(LSTMLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "MatMul" => Ok(MatMulLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Mod" => Ok(ModLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Neg" => Ok(NegLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Not" => Ok(NotLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Relu" => Ok(ReLULayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Flatten" => Ok(FlattenLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Gather" => Ok(GatherLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "GatherND" => Ok(GatherNDLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Gemm" => Ok(GemmLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Range" => Ok(RangeLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Reciprocal" => Ok(ReciprocalLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "ReduceMean" => Ok(ReduceMeanLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Pow" => Ok(PowLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Div" => Ok(DivLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "ScatterND" => Ok(ScatterNDLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Slice" => Ok(SliceLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Split" => Ok(SplitLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Sqrt" => Ok(SqrtLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Reshape" => Ok(ReshapeLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Resize" => Ok(ResizeLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Transpose" => Ok(TransposeLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Tan" => Ok(TanLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Tanh" => Ok(TanhLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "TopK" => Ok(TopKLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Tile" => Ok(TileLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Shape" => Ok(ShapeLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Sigmoid" => Ok(SigmoidLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Equal" => Ok(EqualLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Where" => Ok(WhereLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Expand" => Ok(ExpandLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Softmax" => Ok(SoftmaxLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Squeeze" => Ok(SqueezeLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Unsqueeze" => Ok(UnsqueezeLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Erf" => Ok(ErfLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Conv" => Ok(ConvLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "ConvTranspose" => Ok(ConvTransposeLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Max" => Ok(MaxLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Min" => Ok(MinLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "MaxPool" => Ok(MaxPoolLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
+    "Xor" => Ok(XorLayer::graph(&input_shapes, &input_types, &node_constants, &node_attributes)),
     _ => Err(format!("Unsupported onnx operation: {op}")),
   }
   .unwrap()
@@ -271,6 +274,7 @@ fn process_node(
   node: &pb::NodeProto,
   graph: &mut Graph,
   shapes: &mut HashMap<String, Vec<usize>>,
+  types: &mut HashMap<String, DatumType>,
   constants_hashmap: &HashMap<String, usize>,
   models: &mut Vec<(ArrayD<Fr>, DatumType)>,
   passed_constants: &mut HashMap<String, ArrayD<Fr>>,
@@ -283,6 +287,9 @@ fn process_node(
   println!("Compiling ONNX node: {}", node.name);
   let input_shapes: Vec<_> = node.input.iter().map(|x| shapes.get(x)).collect();
   let input_shapes = input_shapes.into_iter().filter_map(|x| x).collect::<Vec<_>>(); // hack: we ignore optional inputs
+  let input_types: Vec<_> = node.input.iter().map(|x| types.get(x)).collect();
+  let input_types = input_types.into_iter().filter_map(|opt| opt.map(|x| *x)).collect::<Vec<_>>();
+  println!("input_types {:?}", input_types);
   let node_constants = node
     .input
     .iter()
@@ -295,7 +302,8 @@ fn process_node(
     })
     .collect();
   let node_attributes = node.attribute.iter().map(|x| x).collect();
-  let (local_graph, output_shapes) = get_local_graph(op, &input_shapes, &node_constants, node_attributes);
+  let (local_graph, output_shapes, output_types) = get_local_graph(op, &input_shapes, &input_types, &node_constants, node_attributes);
+  println!("output_types {:?}", output_types);
 
   // compute precomputable constants (these are constants that can be computed without proving)
   if node_constants.iter().all(|&x| x.is_some()) {
@@ -317,8 +325,9 @@ fn process_node(
   }
 
   // update shapes
-  node.output.iter().zip(output_shapes).for_each(|(output, shape)| {
+  node.output.iter().zip(output_shapes).zip(output_types).for_each(|((output, shape), t)| {
     shapes.insert(output.clone(), shape);
+    types.insert(output.clone(), t);
   });
 }
 
@@ -329,7 +338,7 @@ pub fn load_file(filename: &str) -> (Graph, Vec<(ArrayD<Fr>, DatumType)>) {
   let onnx = tract_onnx::onnx();
   let onnx_graph = onnx.proto_model_for_path(filename).unwrap().graph.unwrap();
 
-  let (input_idx, mut shapes) = parse_onnx_inputs(&onnx_graph);
+  let (input_idx, mut shapes, mut types) = parse_onnx_inputs(&onnx_graph);
   let (constants, constants_hashmap, mut models) = parse_onnx_constants(&onnx_graph, &mut shapes);
 
   let mut graph = Graph {
@@ -348,6 +357,7 @@ pub fn load_file(filename: &str) -> (Graph, Vec<(ArrayD<Fr>, DatumType)>) {
       node,
       &mut graph,
       &mut shapes,
+      &mut types,
       &constants_hashmap,
       &mut models,
       &mut passed_constants,

--- a/src/util/onnx.rs
+++ b/src/util/onnx.rs
@@ -1,3 +1,4 @@
+use crate::onnx;
 /*
  * ONNX utilities:
  * The function(s) are used for ONNX-related operations.
@@ -9,7 +10,7 @@ use ark_std::Zero;
 use ndarray::ArrayD;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use tract_onnx::pb::tensor_proto::DataType;
-use tract_onnx::prelude::Framework;
+use tract_onnx::prelude::{DatumType, Framework};
 
 // This function is used for generating fake inputs for onnx models
 // Fake inputs are random field (i.e., Fr) elements whose shapes and types match those described in the input tensors of an ONNX model.
@@ -52,4 +53,24 @@ pub fn generate_fake_inputs_for_onnx(filename: &str) -> Vec<ArrayD<Fr>> {
     inputs.push(input);
   }
   inputs
+}
+
+// Converts ints for the DataType enum into DatumType
+// https://docs.rs/tract-onnx/latest/tract_onnx/pb/tensor_proto/enum.DataType.html
+pub fn datatype_to_datumtype(t: i32) -> DatumType {
+  match t {
+    1 => DatumType::F32,
+    7 => DatumType::I64,
+    9 => DatumType::Bool,
+    _ => panic!("DatumType {:?} not supported", t),
+  }
+}
+
+pub fn datumtype_to_sf(t: DatumType) -> usize {
+  match t {
+    DatumType::I64 => 1,
+    DatumType::Bool => 1,
+    DatumType::F32 => *onnx::SF,
+    _ => panic!("DatumType {:?} not supported", t),
+  }
 }


### PR DESCRIPTION
Arithmetic layers like Mul assume that inputs are floats scaled by the scale factor, so when ints are passed to these layers (e.g., output of Shape layer) they will be incorrectly scaled down.

This PR
- implements passing input types between layers
- only adds scaling down to the graph in Mul if its inputs are floats