### PR TITLE
Fixes for Stable Diffusion text-encoder

### DIFF
--- a/src/layer/expand.rs
+++ b/src/layer/expand.rs
@@ -46,17 +46,23 @@ impl Layer for ExpandLayer {
     } else {
       let constantOfShape = graph.addBB(Box::new(ConstOfShapeBasicBlock {
         c: Fr::one(),
-        shape: newShape_padded,
+        shape: newShape_padded.clone(),
       }));
       let mul_scalar = graph.addBB(Box::new(RepeaterBasicBlock {
         basic_block: Box::new(MulScalarBasicBlock {}),
         N: 1,
       }));
+      let mul = graph.addBB(Box::new(RepeaterBasicBlock {
+        basic_block: Box::new(MulBasicBlock {}),
+        N: 1,
+      }));
       let constantOfShape_output = graph.addNode(constantOfShape, vec![]);
       let expand_output = if *input_shapes[0].last().unwrap() == 1 {
         graph.addNode(mul_scalar, vec![(constantOfShape_output, 0), (-1, 0)])
-      } else {
+      } else if *newShape_padded.last().unwrap() == 1 {
         graph.addNode(mul_scalar, vec![(-1, 0), (constantOfShape_output, 0)])
+      } else {
+        graph.addNode(mul, vec![(-1, 0), (constantOfShape_output, 0)])
       };
       graph.outputs.push((expand_output, 0));
     }

--- a/src/util/onnx.rs
+++ b/src/util/onnx.rs
@@ -60,6 +60,7 @@ pub fn generate_fake_inputs_for_onnx(filename: &str) -> Vec<ArrayD<Fr>> {
 pub fn datatype_to_datumtype(t: i32) -> DatumType {
   match t {
     1 => DatumType::F32,
+    6 => DatumType::I32,
     7 => DatumType::I64,
     9 => DatumType::Bool,
     _ => panic!("DatumType {:?} not supported", t),
@@ -68,6 +69,7 @@ pub fn datatype_to_datumtype(t: i32) -> DatumType {
 
 pub fn datumtype_to_sf(t: DatumType) -> usize {
   match t {
+    DatumType::I32 => 1,
     DatumType::I64 => 1,
     DatumType::Bool => 1,
     DatumType::F32 => *onnx::SF,


### PR DESCRIPTION
add case for expand when neither input's last dim is 1