### PR TITLE
Accelerate poly multiplication

### DIFF
--- a/src/util/poly.rs
+++ b/src/util/poly.rs
@@ -1,5 +1,5 @@
 use ark_bn254::Fr;
-use ark_ff::{Field, Zero};
+use ark_ff::Zero;
 use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain, Polynomial};
 use ark_std::One;
 use rayon::prelude::*;

--- a/src/util/poly.rs
+++ b/src/util/poly.rs
@@ -1,5 +1,5 @@
 use ark_bn254::Fr;
-use ark_ff::Zero;
+use ark_ff::{Field, Zero};
 use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain, Polynomial};
 use ark_std::One;
 use rayon::prelude::*;
@@ -11,22 +11,42 @@ where
   // Assuming vecs is non-empty and all vectors have the same length
   let m = vecs[0].len();
 
-  (0..m).into_par_iter().map(|i| vecs.iter().map(|v| v[i]).product()).collect()
+  (0..m).into_par_iter().map(|i| vecs[0][i] * vecs[1][i]).collect()
+}
+
+pub fn mul_two_polys(polys: &Vec<DensePolynomial<Fr>>) -> DensePolynomial<Fr> {
+  assert!(polys.len() == 2);
+  if polys[0].is_zero() || polys[1].is_zero() {
+    return DensePolynomial::zero();
+  }
+  let N: usize = polys.iter().map(|p| p.coeffs.len()).sum();
+  let domain = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
+
+  let p_evals = polys.par_iter().map(|p| domain.fft(&p.coeffs)).collect::<Vec<_>>();
+  let p_evals = elementwise_product(&p_evals);
+  DensePolynomial::from_coefficients_vec(domain.ifft(&p_evals))
 }
 
 pub fn mul_polys(polys: &Vec<DensePolynomial<Fr>>) -> DensePolynomial<Fr> {
-  let N: usize = polys.iter().map(|p| p.coeffs.len()).sum();
-  let domain = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
-  if polys[0].is_zero() {
-    return DensePolynomial::zero();
+  // Base case: if the list has only one polynomial, return it directly
+  if polys.len() == 1 {
+    return polys[0].clone();
   }
-  let mut p_evals = domain.fft(&polys[0].coeffs);
-  for p in polys[1..].iter() {
-    if p.is_zero() {
-      return DensePolynomial::zero();
-    } else {
-      p_evals = elementwise_product(&vec![p_evals, domain.fft(&p.coeffs)]);
-    }
-  }
-  DensePolynomial::from_coefficients_vec(domain.ifft(&p_evals))
+
+  // Parallel recursive case: pairwise multiply the polynomials
+  let next_level: Vec<DensePolynomial<Fr>> = polys
+    .par_chunks(2) // Parallelize processing in chunks of 2
+    .map(|chunk| {
+      if chunk.len() == 2 {
+        // If there are two polynomials in the chunk, multiply them
+        mul_two_polys(&vec![chunk[0].clone(), chunk[1].clone()])
+      } else {
+        // If there's only one polynomial in the chunk, return it
+        chunk[0].clone()
+      }
+    })
+    .collect();
+
+  // Recursively call mul_polys on the next level until we get the root
+  mul_polys(&next_level)
 }

--- a/src/util/poly.rs
+++ b/src/util/poly.rs
@@ -27,6 +27,8 @@ pub fn mul_two_polys(polys: &Vec<DensePolynomial<Fr>>) -> DensePolynomial<Fr> {
   DensePolynomial::from_coefficients_vec(domain.ifft(&p_evals))
 }
 
+// Multiply a list of polynomials in parallel
+// TODO: explore if there exists a more efficient parallel algorithm
 pub fn mul_polys(polys: &Vec<DensePolynomial<Fr>>) -> DensePolynomial<Fr> {
   // Base case: if the list has only one polynomial, return it directly
   if polys.len() == 1 {


### PR DESCRIPTION
When creating the t polynomial in copy constraint BB, we need to compute two products of N degree-D polynomials. The part was the main bottleneck when the given permutation is big. This PR further accelerated the polynomial multiplication by improving the time complexity from O(NDlogD) to O(DlogDlogN). (btw, this PR also used rayon to parallelize the updated algorithm)

The before-and-after stats for this part (the first CCBB of resnet18 on my mac): 
10207.93s -> 61.97s (-99.39%)