### PR TITLE
Faster cq check

### DIFF
--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -16,12 +16,12 @@ use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct CQBasicBlock {
-  pub setup: Array1<Fr>,
+  pub setup: util::CQArrayType,
 }
 
 impl BasicBlock for CQBasicBlock {
   fn genModel(&self) -> ArrayD<Fr> {
-    self.setup.clone().into_dyn()
+    util::gen_cq_array(self.setup.clone())
   }
 
   fn run(&self, model: &ArrayD<Fr>, inputs: &Vec<&ArrayD<Fr>>) -> Result<Vec<ArrayD<Fr>>, util::CQOutOfRangeError> {
@@ -29,14 +29,9 @@ impl BasicBlock for CQBasicBlock {
       return Ok(vec![]);
     }
     assert!(inputs.len() == 1);
-    let mut table_dict = HashMap::new();
-    for (i, x) in model.view().as_slice().unwrap().iter().enumerate() {
-      table_dict.insert(*x, i);
-    }
     for x in inputs[0].view().as_slice().unwrap() {
-      if !table_dict.contains_key(x) {
-        let x_int = util::fr_to_int(*x);
-        println!("{:?},{:?},{:?}", x_int, x, -*x);
+      let x_int = util::fr_to_int(*x);
+      if !util::check_cq_array(self.setup.clone(), x_int) {
         return Err(util::CQOutOfRangeError { input: x_int });
       }
     }

--- a/src/layer/conv.rs
+++ b/src/layer/conv.rs
@@ -201,8 +201,15 @@ macro_rules! create_conv_layer {
           output_SF: sf_log,
         }));
         let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
-          basic_block: Box::new(CQBasicBlock {
-            setup: Array1::from_iter(*onnx::CQ_RANGE_LOWER..-*onnx::CQ_RANGE_LOWER).map(|x| Fr::from(*x)),
+          basic_block: Box::new(CQ2BasicBlock {
+            setup: Some((
+              Box::new(ChangeSFBasicBlock {
+                input_SF: sf_log * 2,
+                output_SF: sf_log,
+              }),
+              *onnx::CQ_RANGE_LOWER,
+              *onnx::CQ_RANGE,
+            )),
           }),
           N: 1,
         }));
@@ -238,7 +245,7 @@ macro_rules! create_conv_layer {
         let cc1_output = graph.addNode(cc1, vec![(-2, 0)]);
         let cqlin_output = graph.addNode(matmul, vec![(cc_output, 0), (cc1_output, 0)]);
         let change_SF_output = graph.addNode(change_SF, vec![(cqlin_output, 0)]);
-        let _ = graph.addNode(change_SF_check, vec![(change_SF_output, 0)]);
+        let _ = graph.addNode(change_SF_check, vec![(cqlin_output, 0), (change_SF_output, 0)]);
 
         // Add bias if it exists
         let add_output = {

--- a/src/layer/div.rs
+++ b/src/layer/div.rs
@@ -86,7 +86,7 @@ macro_rules! create_division_layer {
         // Add a range check basic block for ensuring the remainder is non-negative
         let range_check = graph.addBB(Box::new(RepeaterBasicBlock {
           basic_block: Box::new(CQBasicBlock {
-            setup: Array1::from_iter(0..-*onnx::CQ_RANGE_LOWER).map(|x| Fr::from(*x as i32)),
+            setup: util::CQArrayType::NonNegative,
           }),
           N: 1,
         }));

--- a/src/layer/equal.rs
+++ b/src/layer/equal.rs
@@ -41,9 +41,10 @@ impl Layer for EqualLayer {
       N: 1,
     }));
 
-    let r: Vec<_> = (*onnx::CQ_RANGE_LOWER..-*onnx::CQ_RANGE_LOWER + 1).filter(|&x| x != 0).map(Fr::from).collect();
     let nonzero_check = graph.addBB(Box::new(RepeaterBasicBlock {
-      basic_block: Box::new(CQBasicBlock { setup: arr1(&r) }),
+      basic_block: Box::new(CQBasicBlock {
+        setup: util::CQArrayType::NonZero,
+      }),
       N: 1,
     }));
 

--- a/src/layer/less.rs
+++ b/src/layer/less.rs
@@ -40,14 +40,16 @@ impl Layer for LessLayer {
       basic_block: Box::new(SubBasicBlock {}),
       N: 1,
     }));
-    let r1: Vec<_> = (*onnx::CQ_RANGE_LOWER..0).map(Fr::from).collect();
     let negative_check = graph.addBB(Box::new(RepeaterBasicBlock {
-      basic_block: Box::new(CQBasicBlock { setup: arr1(&r1) }),
+      basic_block: Box::new(CQBasicBlock {
+        setup: util::CQArrayType::Negative,
+      }),
       N: 1,
     }));
-    let r2: Vec<_> = (0..-*onnx::CQ_RANGE_LOWER).map(Fr::from).collect();
     let non_negative_check = graph.addBB(Box::new(RepeaterBasicBlock {
-      basic_block: Box::new(CQBasicBlock { setup: arr1(&r2) }),
+      basic_block: Box::new(CQBasicBlock {
+        setup: util::CQArrayType::NonNegative,
+      }),
       N: 1,
     }));
 

--- a/src/layer/norm.rs
+++ b/src/layer/norm.rs
@@ -125,7 +125,7 @@ impl Layer for BatchNormLayer {
     }));
     let range_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQBasicBlock {
-        setup: Array1::from_iter(0..*onnx::CQ_RANGE).map(|x| Fr::from(*x as i32)),
+        setup: util::CQArrayType::NonNegative,
       }),
       N: 1,
     }));
@@ -371,7 +371,7 @@ impl Layer for InstanceNormLayer {
     }));
     let range_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQBasicBlock {
-        setup: Array1::from_iter(0..*onnx::CQ_RANGE).map(|x| Fr::from(*x as i32)),
+        setup: util::CQArrayType::NonNegative,
       }),
       N: 1,
     }));

--- a/src/layer/pool.rs
+++ b/src/layer/pool.rs
@@ -103,9 +103,10 @@ impl Layer for MaxPoolLayer {
       padding_partition: copy_constraint::PaddingEnum::Zero,
     }));
 
-    let r: Vec<_> = (0..-*onnx::CQ_RANGE_LOWER).map(Fr::from).collect();
     let range_check = graph.addBB(Box::new(RepeaterBasicBlock {
-      basic_block: Box::new(CQBasicBlock { setup: arr1(&r) }),
+      basic_block: Box::new(CQBasicBlock {
+        setup: util::CQArrayType::NonNegative,
+      }),
       N: 1,
     }));
 

--- a/src/layer/topk.rs
+++ b/src/layer/topk.rs
@@ -63,13 +63,13 @@ impl Layer for TopKLayer {
       basic_block: Box::new(OrderedBasicBlock {}),
       N: 1,
     }));
-    let r: Vec<_> = if descending {
-      (0..-*onnx::CQ_RANGE_LOWER).map(Fr::from).collect()
+    let cq_type = if descending {
+      util::CQArrayType::NonNegative
     } else {
-      (*onnx::CQ_RANGE_LOWER + 1..1).map(Fr::from).collect()
+      util::CQArrayType::NonPositive
     };
     let range_check = graph.addBB(Box::new(RepeaterBasicBlock {
-      basic_block: Box::new(CQBasicBlock { setup: arr1(&r) }),
+      basic_block: Box::new(CQBasicBlock { setup: cq_type }),
       N: 1,
     }));
 
@@ -154,9 +154,10 @@ impl Layer for ArgMaxLayer {
       basic_block: Box::new(OrderedBasicBlock {}),
       N: 1,
     }));
-    let r: Vec<_> = (0..-*onnx::CQ_RANGE_LOWER).map(Fr::from).collect();
     let range_check = graph.addBB(Box::new(RepeaterBasicBlock {
-      basic_block: Box::new(CQBasicBlock { setup: arr1(&r) }),
+      basic_block: Box::new(CQBasicBlock {
+        setup: util::CQArrayType::NonNegative,
+      }),
       N: 1,
     }));
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -79,7 +79,7 @@ fn testBasicBlocks() {
   testBasicBlock(SubBasicBlock {}, srs, &empty, &vec![&a_0, &a_0]);
   testBasicBlock(
     CQBasicBlock {
-      setup: a.clone().into_dimensionality::<ndarray::Ix1>().unwrap(),
+      setup: util::CQArrayType::Custom(a.iter().map(|x| *x).collect::<Vec<_>>()),
     },
     srs,
     &a,

--- a/src/util/prover.rs
+++ b/src/util/prover.rs
@@ -4,9 +4,51 @@
  * generating CQ tables and converting them to Data (generating commitment).
  */
 use crate::basic_block::{BasicBlock, Data, SRS};
+use crate::{onnx, util};
 use ark_bn254::{Fr, G1Projective};
 use ark_std::Zero;
-use ndarray::{arr0, concatenate, Array1, ArrayD, Axis, IxDyn};
+use ndarray::{arr0, arr1, concatenate, Array1, ArrayD, Axis, IxDyn};
+use rayon::range;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CQArrayType {
+  Negative,
+  NonNegative,
+  NonZero,
+  NonPositive,
+  Positive,
+  Custom(Vec<Fr>),
+}
+
+pub fn gen_cq_array(cq_type: CQArrayType) -> ArrayD<Fr> {
+  let r = match cq_type {
+    CQArrayType::Negative => (*onnx::CQ_RANGE_LOWER..0).map(Fr::from).collect::<Vec<_>>(),
+    CQArrayType::NonNegative => (0..*onnx::CQ_RANGE as i32).map(Fr::from).collect::<Vec<_>>(),
+    CQArrayType::NonZero => (*onnx::CQ_RANGE_LOWER..-*onnx::CQ_RANGE_LOWER + 1).filter(|&x| x != 0).map(Fr::from).collect::<Vec<_>>(),
+    CQArrayType::NonPositive => (*onnx::CQ_RANGE_LOWER + 1..1).map(Fr::from).collect::<Vec<_>>(),
+    CQArrayType::Positive => (1..-*onnx::CQ_RANGE_LOWER + 1).map(Fr::from).collect::<Vec<_>>(),
+    CQArrayType::Custom(range) => range,
+  };
+  arr1(&r).into_dyn()
+}
+
+pub fn check_cq_array(cq_type: CQArrayType, x_int: i32) -> bool {
+  let result = match cq_type {
+    CQArrayType::Negative => x_int < 0 && x_int >= *onnx::CQ_RANGE_LOWER,
+    CQArrayType::NonNegative => x_int >= 0 && x_int < (*onnx::CQ_RANGE as i32),
+    CQArrayType::NonZero => x_int != 0 && x_int >= *onnx::CQ_RANGE_LOWER && x_int <= -*onnx::CQ_RANGE_LOWER,
+    CQArrayType::NonPositive => x_int <= 0 && x_int > *onnx::CQ_RANGE_LOWER,
+    CQArrayType::Positive => x_int > 0 && x_int <= -*onnx::CQ_RANGE_LOWER,
+    CQArrayType::Custom(range) => {
+      let range = range.iter().map(|x| util::fr_to_int(*x)).collect::<Vec<_>>();
+      range.contains(&x_int)
+    }
+  };
+  if !result {
+    println!("{:?}", x_int);
+  }
+  result
+}
 
 pub fn gen_cq_table(basic_block: &Box<dyn BasicBlock>, offset: i32, size: usize) -> ArrayD<Fr> {
   let range = Array1::from_shape_fn(size, |i| Fr::from(i as u32) + Fr::from(offset)).into_dyn();


### PR DESCRIPTION
This PR introduced a faster cq check during running so that it is no longer dependent on cq array size (except for the custom array in `tests.rs`).
Besides, the editions in `conv.rs` replaced the cq check with cq2 check to prove the sf changes.