### PR TITLE
Karatsuba mul for high degree polynomials

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -291,21 +291,3 @@ fn test_copy_constraint() {
     &vec![&ArrayD::from_shape_vec(vec![2, 1, 4], (1..9).map(|x| Fr::from(x)).collect()).unwrap()],
   );
 }
-
-#[test]
-fn test_poly_mul() {
-  fn random_dense_polynomial(degree: usize) -> DensePolynomial<Fr> {
-    let mut rng = thread_rng();
-    DensePolynomial::rand(degree, &mut rng)
-  }
-
-  let degrees = 10..25;
-  for i in degrees {
-    let poly_1 = random_dense_polynomial(1 << i);
-    let poly_2 = random_dense_polynomial(1 << i);
-    let start = Instant::now();
-    util::mul_polys(&vec![poly_1, poly_2]);
-    let duration: std::time::Duration = start.elapsed();
-    println!("{} duration: {:?}", i, duration);
-  }
-}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,15 +1,19 @@
 use crate::basic_block::*;
+use crate::util::mul_two_polys;
 use crate::{ptau, util, util::convert_to_data};
 use ark_bn254::{Bn254, Fr, G1Affine, G2Affine};
 use ark_ec::pairing::{Pairing, PairingOutput};
 use ark_poly::univariate::DensePolynomial;
+use ark_poly::DenseUVPolynomial;
 use ark_std::UniformRand;
 use ark_std::{One, Zero};
 use core::panic;
 use ndarray::{arr0, concatenate, s, ArrayD, Axis, IxDyn};
+use rand::thread_rng;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 fn testBasicBlock<BB: BasicBlock>(basic_block: BB, srs: &SRS, model: &ArrayD<Fr>, inputs: &Vec<&ArrayD<Fr>>) {
   let mut rng = StdRng::from_entropy();
@@ -286,4 +290,22 @@ fn test_copy_constraint() {
     &empty,
     &vec![&ArrayD::from_shape_vec(vec![2, 1, 4], (1..9).map(|x| Fr::from(x)).collect()).unwrap()],
   );
+}
+
+#[test]
+fn test_poly_mul() {
+  fn random_dense_polynomial(degree: usize) -> DensePolynomial<Fr> {
+    let mut rng = thread_rng();
+    DensePolynomial::rand(degree, &mut rng)
+  }
+
+  let degrees = 10..25;
+  for i in degrees {
+    let poly_1 = random_dense_polynomial(1 << i);
+    let poly_2 = random_dense_polynomial(1 << i);
+    let start = Instant::now();
+    util::mul_polys(&vec![poly_1, poly_2]);
+    let duration: std::time::Duration = start.elapsed();
+    println!("{} duration: {:?}", i, duration);
+  }
 }

--- a/src/util/poly.rs
+++ b/src/util/poly.rs
@@ -20,11 +20,58 @@ pub fn mul_two_polys(polys: &Vec<DensePolynomial<Fr>>) -> DensePolynomial<Fr> {
     return DensePolynomial::zero();
   }
   let N: usize = polys.iter().map(|p| p.coeffs.len()).sum();
-  let domain = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
+  let domain = GeneralEvaluationDomain::<Fr>::new(N);
+  if domain.is_some() {
+    let domain = domain.unwrap();
+    let p_evals = polys.par_iter().map(|p| domain.fft(&p.coeffs)).collect::<Vec<_>>();
+    let p_evals = elementwise_product(&p_evals);
+    DensePolynomial::from_coefficients_vec(domain.ifft(&p_evals))
+  } else {
+    karatsuba_multiply(&polys[0], &polys[1])
+  }
+}
 
-  let p_evals = polys.par_iter().map(|p| domain.fft(&p.coeffs)).collect::<Vec<_>>();
-  let p_evals = elementwise_product(&p_evals);
-  DensePolynomial::from_coefficients_vec(domain.ifft(&p_evals))
+fn mul_by_xn(poly: &DensePolynomial<Fr>, n: usize) -> DensePolynomial<Fr> {
+  let mut new_coeffs = vec![Fr::zero(); n];
+  new_coeffs.extend(poly.coeffs().iter().cloned());
+  DensePolynomial::from_coefficients_vec(new_coeffs)
+}
+
+fn karatsuba_multiply(a: &DensePolynomial<Fr>, b: &DensePolynomial<Fr>) -> DensePolynomial<Fr> {
+  let n = std::cmp::max(a.degree(), b.degree()) + 1;
+
+  // Base case: use standard multiplication for small polynomials
+  if n <= 32 {
+    return a * b;
+  }
+
+  let m = n / 2;
+
+  // Split polynomials
+  let (a0, a1) = split_polynomial(a, m);
+  let (b0, b1) = split_polynomial(b, m);
+
+  // Recursive steps
+  let z0 = karatsuba_multiply(&a0, &b0);
+  let z2 = karatsuba_multiply(&a1, &b1);
+
+  let a0_plus_a1 = &a0 + &a1;
+  let b0_plus_b1 = &b0 + &b1;
+  let z1 = karatsuba_multiply(&a0_plus_a1, &b0_plus_b1);
+
+  // Combine results
+  let mut result = mul_by_xn(&z2, 2 * m);
+  result += &z0;
+  result = &result + &mul_by_xn(&(&(&z1 - &z2) - &z0), m);
+
+  result
+}
+
+fn split_polynomial(p: &DensePolynomial<Fr>, m: usize) -> (DensePolynomial<Fr>, DensePolynomial<Fr>) {
+  let coeffs = p.coeffs();
+  let low = DensePolynomial::from_coefficients_vec(coeffs[..m.min(coeffs.len())].to_vec());
+  let high = DensePolynomial::from_coefficients_vec(coeffs[m.min(coeffs.len())..].to_vec());
+  (low, high)
 }
 
 // Multiply a list of polynomials in parallel

--- a/src/util/poly.rs
+++ b/src/util/poly.rs
@@ -41,7 +41,7 @@ fn karatsuba_multiply(a: &DensePolynomial<Fr>, b: &DensePolynomial<Fr>) -> Dense
   let n = std::cmp::max(a.degree(), b.degree()) + 1;
 
   // Base case: use standard multiplication for small polynomials
-  if n <= 32 {
+  if n <= 134217728 {
     return a * b;
   }
 

--- a/src/util/poly.rs
+++ b/src/util/poly.rs
@@ -41,7 +41,7 @@ fn karatsuba_multiply(a: &DensePolynomial<Fr>, b: &DensePolynomial<Fr>) -> Dense
   let n = std::cmp::max(a.degree(), b.degree()) + 1;
 
   // Base case: use standard multiplication for small polynomials
-  if n <= 134217728 {
+  if n <= 1 << 27 {
     return a * b;
   }
 

--- a/src/util/poly.rs
+++ b/src/util/poly.rs
@@ -40,18 +40,15 @@ fn mul_by_xn(poly: &DensePolynomial<Fr>, n: usize) -> DensePolynomial<Fr> {
 fn karatsuba_multiply(a: &DensePolynomial<Fr>, b: &DensePolynomial<Fr>) -> DensePolynomial<Fr> {
   let n = std::cmp::max(a.degree(), b.degree()) + 1;
 
-  // Base case: use standard multiplication for small polynomials
   if n <= 1 << 27 {
     return a * b;
   }
 
   let m = n / 2;
 
-  // Split polynomials
   let (a0, a1) = split_polynomial(a, m);
   let (b0, b1) = split_polynomial(b, m);
 
-  // Recursive steps
   let z0 = karatsuba_multiply(&a0, &b0);
   let z2 = karatsuba_multiply(&a1, &b1);
 
@@ -59,7 +56,6 @@ fn karatsuba_multiply(a: &DensePolynomial<Fr>, b: &DensePolynomial<Fr>) -> Dense
   let b0_plus_b1 = &b0 + &b1;
   let z1 = karatsuba_multiply(&a0_plus_a1, &b0_plus_b1);
 
-  // Combine results
   let mut result = mul_by_xn(&z2, 2 * m);
   result += &z0;
   result = &result + &mul_by_xn(&(&(&z1 - &z2) - &z0), m);


### PR DESCRIPTION
Implements Karatsuba multiplication when the degree of the product exceeds the allowed degree from the evaluation domain (1<<28)

Timings with product of two polynomials of degree 2^x:
no karatsuba
x
20 duration: 695.99797ms
21 duration: 1.291637419s
22 duration: 2.808398087s
23 duration: 5.306105351s
24 duration: 9.263419673s
25 duration: 18.645103696s
26 duration: 37.43332432s
karatsuba
27 duration: 136.338719556s
28 duration: 356.805152415s
29 duration: 936.75454377s