### PR TITLE
Fixes for matmul and neg

### DIFF
--- a/src/layer/matmul.rs
+++ b/src/layer/matmul.rs
@@ -42,7 +42,7 @@ impl Layer for MatMulLayer {
       }),
       N: 1,
     }));
-    let small_matmul = (a * b) <= 1 << CONFIG.ptau.loaded_pow_len_log;
+    let small_matmul = (a * b) < 1 << CONFIG.ptau.loaded_pow_len_log;
     let use_cqlin = constants.len() > 1 && constants[1].is_some() && small_matmul;
     let matmul_output = if use_cqlin {
       let b = constants[1].unwrap().0;

--- a/src/layer/matmul.rs
+++ b/src/layer/matmul.rs
@@ -3,6 +3,7 @@ use crate::graph::*;
 use crate::layer::Layer;
 use crate::onnx;
 use crate::util;
+use crate::CONFIG;
 use ark_bn254::Fr;
 use ndarray::ArrayD;
 use tract_onnx::pb::AttributeProto;
@@ -41,7 +42,9 @@ impl Layer for MatMulLayer {
       }),
       N: 1,
     }));
-    let matmul_output = if constants.len() > 1 && constants[1].is_some() {
+    let small_matmul = (a * b) <= 1 << CONFIG.ptau.loaded_pow_len_log;
+    let use_cqlin = constants.len() > 1 && constants[1].is_some() && small_matmul;
+    let matmul_output = if use_cqlin {
       let b = constants[1].unwrap().0;
       let cqlin = if input_shapes[0].len() > 1 {
         graph.addBB(Box::new(RepeaterBasicBlock {

--- a/src/layer/neg.rs
+++ b/src/layer/neg.rs
@@ -19,7 +19,7 @@ impl Layer for NegLayer {
   ) -> (Graph, Vec<Vec<usize>>, Vec<DatumType>) {
     let mut graph = Graph::new();
     let zero = graph.addBB(Box::new(Const2BasicBlock {
-      c: arr1(&vec![Fr::zero(); *input_shapes[0].last().unwrap()]).into_dyn(),
+      c: arr1(&vec![Fr::zero(); util::next_pow(*input_shapes[0].last().unwrap() as u32) as usize]).into_dyn(),
     }));
     let layer = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(SubBasicBlock {}),


### PR DESCRIPTION
This PR included the following fixes for matmul and neg layers:
- Use proper BB. When the matrix sizes involved in a MatMul layer are too large, we should switch to use MatMul basicblock insteaf of CQLin.
- Fixed a shape bug in Neg.

