### PR TITLE
Transpose+permute optimization for 1x1 kernel

### DIFF
--- a/src/layer/conv.rs
+++ b/src/layer/conv.rs
@@ -98,7 +98,7 @@ fn splat_input(
   inp_cells
 }
 
-// Splats weights into shape (out_channels x inp_channels * kernel_dims product) such that each row corresponds to flattened kernels for each input channel
+// Splats weights into shape (inp_channels * kernel_dims product x out_channels) such that each row corresponds to flattened kernels for each input channel
 fn splat_weights(weights: &ArrayD<Fr>, is_transpose: bool) -> Vec<Vec<Fr>> {
   let mut weights_cells = vec![];
   let mut weight_row_idx = 0;
@@ -132,10 +132,11 @@ pub fn splat_pad<G: Clone>(input: &Vec<Vec<G>>, pad_val: &G) -> ArrayD<G> {
 
 // The overview of the proving:
 // 1. Splat inputs into (out_dims product x inp_channels * kernel_dims product)
-// 2. Splat weights into (out_channels x inp_channels * kernel_dims product)
-// 3. Perform matmul between inputs and weights with the resulting shape (out_dims product x out_channels). Each element corresponds to an element of the final output
-// 4. Scale down and add bias if it exists
-// 5. Reshape into the final output shape
+// 1a. If 1x1 kernel, instead we transpose and permute the input so that inp_channels is the last dimension
+// 2. Perform matmul between inputs and weights with the resulting shape (out_dims product x out_channels). Each element corresponds to an element of the final output
+// 2a. If 1x1 kernel, the last dimension is out_channels and the rest are unchanged
+// 3. Scale down and add bias if it exists
+// 4. Reshape into the final output shape
 macro_rules! create_conv_layer {
   ($layer_name:ident, $is_transpose:expr) => {
     pub struct $layer_name;
@@ -177,17 +178,37 @@ macro_rules! create_conv_layer {
         // Splat input
         let ci = if $is_transpose { weight_shape[0] } else { weight_shape[1] };
         let permutation = splat_input(&input_shapes[0], &strides, &pads, ci, &ch_dims, $is_transpose);
-        let permutation_padded = splat_pad(&permutation, &None);
-        let input_shape_padded: Vec<_> = input_shapes[0].iter().map(|i| i.next_power_of_two()).collect();
-        let cc = graph.addBB(Box::new(CopyConstraintBasicBlock {
-          permutation: permutation_padded,
-          input_dim: IxDyn(&input_shape_padded),
-          padding_partition: copy_constraint::PaddingEnum::Zero,
+        let n = input_shapes[0].len();
+        let cc = if ch_dims[0] == 1 {
+          let mut perm = vec![0];
+          perm.append(&mut (2..n - 1).collect());
+          perm.append(&mut vec![1, n - 1]);
+          graph.addBB(Box::new(TransposeBasicBlock { perm }))
+        } else {
+          let permutation_padded = splat_pad(&permutation, &None);
+          let input_shape_padded: Vec<_> = input_shapes[0].iter().map(|i| i.next_power_of_two()).collect();
+          graph.addBB(Box::new(CopyConstraintBasicBlock {
+            permutation: permutation_padded,
+            input_dim: IxDyn(&input_shape_padded),
+            padding_partition: copy_constraint::PaddingEnum::Zero,
+          }))
+        };
+
+        // Only used if 1x1 kernel
+        let a = input_shapes[0][1].next_power_of_two();
+        let b = input_shapes[0][n - 1].next_power_of_two();
+        let transpose1 = ((0..b).map(|x| x * a).collect(), (0..a).collect());
+        let permute1 = graph.addBB(Box::new(RepeaterBasicBlock {
+          basic_block: Box::new(PermuteBasicBlock { permutation: transpose1 }),
+          N: 2,
         }));
 
         let weights_splatted = splat_weights(constants[1].unwrap().0, $is_transpose);
         let weights_padded = splat_pad(&weights_splatted, &Fr::zero());
-        let cqlin = graph.addBB(Box::new(CQLinBasicBlock { setup: weights_padded }));
+        let cqlin = graph.addBB(Box::new(RepeaterBasicBlock {
+          basic_block: Box::new(CQLinBasicBlock { setup: weights_padded }),
+          N: 2,
+        }));
 
         let sf_log = onnx::SF_LOG.read().unwrap().to_owned();
         let change_SF = graph.addBB(Box::new(ChangeSFBasicBlock {
@@ -214,6 +235,13 @@ macro_rules! create_conv_layer {
           N: 1,
         }));
 
+        // Only used if 1x1 kernel
+        let transpose2 = ((0..a).map(|x| x * b).collect(), (0..b).collect());
+        let permute2 = graph.addBB(Box::new(RepeaterBasicBlock {
+          basic_block: Box::new(PermuteBasicBlock { permutation: transpose2 }),
+          N: 2,
+        }));
+
         // Reshape matmul into output shape
         let mut padding = vec![];
         let pads = if $is_transpose {
@@ -228,14 +256,28 @@ macro_rules! create_conv_layer {
         let cout = if $is_transpose { weight_shape[1] } else { weight_shape[0] };
         let mut output_shape = vec![1, cout];
         output_shape.append(&mut out_dims);
-        let reshape_permutation = util::get_reshape_indices(vec![permutation.len(), weights_splatted[0].len()], output_shape.clone());
-        let cc2 = graph.addBB(Box::new(CopyConstraintBasicBlock {
-          permutation: reshape_permutation,
-          input_dim: IxDyn(&[permutation.len().next_power_of_two(), weights_splatted[0].len().next_power_of_two()]),
-          padding_partition: copy_constraint::PaddingEnum::Zero,
-        }));
 
-        let cc_output = graph.addNode(cc, vec![(-1, 0)]);
+        let cc2 = if ch_dims[0] == 1 {
+          let mut perm = vec![0, n - 2];
+          let n = input_shapes[0].len();
+          perm.append(&mut (1..n - 2).collect());
+          perm.append(&mut vec![n - 1]);
+          graph.addBB(Box::new(TransposeBasicBlock { perm }))
+        } else {
+          let reshape_permutation = util::get_reshape_indices(vec![permutation.len(), weights_splatted[0].len()], output_shape.clone());
+          graph.addBB(Box::new(CopyConstraintBasicBlock {
+            permutation: reshape_permutation,
+            input_dim: IxDyn(&[permutation.len().next_power_of_two(), weights_splatted[0].len().next_power_of_two()]),
+            padding_partition: copy_constraint::PaddingEnum::Zero,
+          }))
+        };
+
+        let cc_output = if ch_dims[0] == 1 {
+          let trans_output = graph.addNode(cc, vec![(-1, 0)]);
+          graph.addNode(permute1, vec![(trans_output, 0)])
+        } else {
+          graph.addNode(cc, vec![(-1, 0)])
+        };
         let cqlin_output = graph.addNode(cqlin, vec![(cc_output, 0)]);
         let change_SF_output = graph.addNode(change_SF, vec![(cqlin_output, 0)]);
         let _ = graph.addNode(change_SF_check, vec![(cqlin_output, 0), (change_SF_output, 0)]);
@@ -248,7 +290,12 @@ macro_rules! create_conv_layer {
             change_SF_output
           }
         };
-        let cc2_output = graph.addNode(cc2, vec![(add_output, 0)]);
+        let cc2_output = if ch_dims[0] == 1 {
+          let trans_output = graph.addNode(permute2, vec![(add_output, 0)]);
+          graph.addNode(cc2, vec![(trans_output, 0)])
+        } else {
+          graph.addNode(cc2, vec![(add_output, 0)])
+        };
         graph.outputs.push((cc2_output, 0));
         (graph, vec![output_shape], vec![input_types[0]])
       }

--- a/src/layer/conv.rs
+++ b/src/layer/conv.rs
@@ -179,7 +179,8 @@ macro_rules! create_conv_layer {
         let ci = if $is_transpose { weight_shape[0] } else { weight_shape[1] };
         let permutation = splat_input(&input_shapes[0], &strides, &pads, ci, &ch_dims, $is_transpose);
         let n = input_shapes[0].len();
-        let cc = if ch_dims[0] == 1 {
+        let kernel_1x1_opt = pads.iter().all(|&x| x == 0) && strides.iter().all(|&x| x == 1) && ch_dims[0] == 1;
+        let cc = if kernel_1x1_opt {
           let mut perm = vec![0];
           perm.append(&mut (2..n - 1).collect());
           perm.append(&mut vec![1, n - 1]);
@@ -257,7 +258,7 @@ macro_rules! create_conv_layer {
         let mut output_shape = vec![1, cout];
         output_shape.append(&mut out_dims);
 
-        let cc2 = if ch_dims[0] == 1 {
+        let cc2 = if kernel_1x1_opt {
           let mut perm = vec![0, n - 2];
           let n = input_shapes[0].len();
           perm.append(&mut (1..n - 2).collect());

--- a/src/layer/conv.rs
+++ b/src/layer/conv.rs
@@ -175,7 +175,41 @@ macro_rules! create_conv_layer {
           None => vec![1; dims.len() - 2],
         };
 
-        // Splat input
+        // Add bias
+        let add = graph.addBB(Box::new(RepeaterBasicBlock {
+          basic_block: Box::new(AddBasicBlock {}),
+          N: 1,
+        }));
+
+        // Matmul
+        let weights_splatted = splat_weights(constants[1].unwrap().0, $is_transpose);
+        let weights_padded = splat_pad(&weights_splatted, &Fr::zero());
+        let cqlin = graph.addBB(Box::new(RepeaterBasicBlock {
+          basic_block: Box::new(CQLinBasicBlock { setup: weights_padded }),
+          N: 2,
+        }));
+
+        // Scale down
+        let sf_log = onnx::SF_LOG.read().unwrap().to_owned();
+        let change_SF = graph.addBB(Box::new(ChangeSFBasicBlock {
+          input_SF: sf_log * 2,
+          output_SF: sf_log,
+        }));
+        let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
+          basic_block: Box::new(CQ2BasicBlock {
+            setup: Some((
+              Box::new(ChangeSFBasicBlock {
+                input_SF: sf_log * 2,
+                output_SF: sf_log,
+              }),
+              *onnx::CQ_RANGE_LOWER,
+              *onnx::CQ_RANGE,
+            )),
+          }),
+          N: 1,
+        }));
+
+        // Splat input with transpose+permute with 1x1 optimization or with copy constraint otherwise
         let ci = if $is_transpose { weight_shape[0] } else { weight_shape[1] };
         let permutation = splat_input(&input_shapes[0], &strides, &pads, ci, &ch_dims, $is_transpose);
         let n = input_shapes[0].len();
@@ -203,47 +237,13 @@ macro_rules! create_conv_layer {
           basic_block: Box::new(PermuteBasicBlock { permutation: transpose1 }),
           N: 2,
         }));
-
-        let weights_splatted = splat_weights(constants[1].unwrap().0, $is_transpose);
-        let weights_padded = splat_pad(&weights_splatted, &Fr::zero());
-        let cqlin = graph.addBB(Box::new(RepeaterBasicBlock {
-          basic_block: Box::new(CQLinBasicBlock { setup: weights_padded }),
-          N: 2,
-        }));
-
-        let sf_log = onnx::SF_LOG.read().unwrap().to_owned();
-        let change_SF = graph.addBB(Box::new(ChangeSFBasicBlock {
-          input_SF: sf_log * 2,
-          output_SF: sf_log,
-        }));
-        let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
-          basic_block: Box::new(CQ2BasicBlock {
-            setup: Some((
-              Box::new(ChangeSFBasicBlock {
-                input_SF: sf_log * 2,
-                output_SF: sf_log,
-              }),
-              *onnx::CQ_RANGE_LOWER,
-              *onnx::CQ_RANGE,
-            )),
-          }),
-          N: 1,
-        }));
-
-        // Add bias
-        let add = graph.addBB(Box::new(RepeaterBasicBlock {
-          basic_block: Box::new(AddBasicBlock {}),
-          N: 1,
-        }));
-
-        // Only used if 1x1 kernel
         let transpose2 = ((0..a).map(|x| x * b).collect(), (0..b).collect());
         let permute2 = graph.addBB(Box::new(RepeaterBasicBlock {
           basic_block: Box::new(PermuteBasicBlock { permutation: transpose2 }),
           N: 2,
         }));
 
-        // Reshape matmul into output shape
+        // Reshape matmul into output shape with transpose+permute with 1x1 optimization or with copy constraint otherwise
         let mut padding = vec![];
         let pads = if $is_transpose {
           conv_transpose_pads(&pads, &ch_dims)
@@ -273,12 +273,15 @@ macro_rules! create_conv_layer {
           }))
         };
 
-        let cc_output = if ch_dims[0] == 1 {
+        // Splat input with transpose+permute with 1x1 optimization or with copy constraint otherwise
+        let cc_output = if kernel_1x1_opt {
           let trans_output = graph.addNode(cc, vec![(-1, 0)]);
           graph.addNode(permute1, vec![(trans_output, 0)])
         } else {
           graph.addNode(cc, vec![(-1, 0)])
         };
+
+        // Matmul
         let cqlin_output = graph.addNode(cqlin, vec![(cc_output, 0)]);
         let change_SF_output = graph.addNode(change_SF, vec![(cqlin_output, 0)]);
         let _ = graph.addNode(change_SF_check, vec![(cqlin_output, 0), (change_SF_output, 0)]);
@@ -291,7 +294,9 @@ macro_rules! create_conv_layer {
             change_SF_output
           }
         };
-        let cc2_output = if ch_dims[0] == 1 {
+
+        // Reshape matmul into output shape with transpose+permute with 1x1 optimization or with copy constraint otherwise
+        let cc2_output = if kernel_1x1_opt {
           let trans_output = graph.addNode(permute2, vec![(add_output, 0)]);
           graph.addNode(cc2, vec![(trans_output, 0)])
         } else {


### PR DESCRIPTION
Instead of using copy constraint for a 1x1 kernel, we can use transpose+permute for ch_in to be the last dimension for the matmul.

first 1x1 kernel layer in resnet50 old -> new: 932s -> 651s (-30%)