### PR TITLE
Show verify breakdown

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -261,7 +261,8 @@ impl Graph {
           );
           return vec![];
         }
-        println!("{} | verifying {i} {:?}", self.layer_names[i], self.basic_blocks[n.basic_block]);
+        let verify_id = format!("{} | verifying {i} {:?}", self.layer_names[i], self.basic_blocks[n.basic_block]);
+        println!("{}", verify_id);
         let myInputs = n
           .inputs
           .iter()
@@ -275,7 +276,7 @@ impl Graph {
           .collect();
         let pairings = timed!(
           timing,
-          "verify",
+          &verify_id,
           self.basic_blocks[n.basic_block].verify(srs, models[n.basic_block], &myInputs, outputs[i], proofs[i], rng, cache.clone())
         );
         let mut bytes = Vec::new();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -241,6 +241,7 @@ impl Graph {
     outputs: &Vec<&Vec<&ArrayD<DataEnc>>>,
     proofs: &Vec<(&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>)>,
     rng: &mut StdRng,
+    timing: &mut TimingTree,
   ) {
     assert!(self.nodes.len() == self.precomputable.prove_and_verify.len());
     let cache = Arc::new(Mutex::new(HashMap::new()));
@@ -272,7 +273,11 @@ impl Graph {
             }
           })
           .collect();
-        let pairings = self.basic_blocks[n.basic_block].verify(srs, models[n.basic_block], &myInputs, outputs[i], proofs[i], rng, cache.clone());
+        let pairings = timed!(
+          timing,
+          "verify",
+          self.basic_blocks[n.basic_block].verify(srs, models[n.basic_block], &myInputs, outputs[i], proofs[i], rng, cache.clone())
+        );
         let mut bytes = Vec::new();
         let temp: (Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>) = (proofs[i].0.clone(), proofs[i].1.clone(), proofs[i].2.clone());
         temp.serialize_uncompressed(&mut bytes).unwrap();
@@ -280,8 +285,13 @@ impl Graph {
         pairings
       })
       .collect();
-    let pairings = util::combine_pairing_checks(&pairings.iter().flatten().collect());
-    assert_eq!(Bn254::multi_pairing(pairings.0.iter(), pairings.1.iter()), PairingOutput::zero());
+    let pairings = timed!(
+      timing,
+      "combine pairings",
+      util::combine_pairing_checks(&pairings.iter().flatten().collect())
+    );
+    let pairing_check = timed!(timing, "pairings", Bn254::multi_pairing(pairings.0.iter(), pairings.1.iter()));
+    assert_eq!(pairing_check, PairingOutput::zero());
   }
 
   // This function should be only used for debugging purposes (it is very slow).

--- a/src/util/verifier.rs
+++ b/src/util/verifier.rs
@@ -134,6 +134,6 @@ pub fn verify(srs: &SRS, graph: &Graph, timing: &mut TimingTree) {
   timed!(
     timing,
     "verify",
-    graph.verify(srs, &modelsEnc, &inputsEnc, &outputsEnc, &proofs, &mut rng)
+    graph.verify(srs, &modelsEnc, &inputsEnc, &outputsEnc, &proofs, &mut rng, timing)
   );
 }


### PR DESCRIPTION
Looks like 
```
[2024-11-05T18:07:01Z DEBUG plonky2::util::timing] | 0.0170s to verify
[2024-11-05T18:07:01Z DEBUG plonky2::util::timing] | | 0.0005s to Op /lin1/MatMul | verifying 4 CQLinBasicBlock { setup: [[BigInt([0, 0, 0, 0]), BigInt([0, 0, 0, 0]), BigInt([4, 0, 0, 0]), BigInt([4891460686036598783, 2896914383306846353, 13281191951274694749, 3486998266802970665])],
     [BigInt([2, 0, 0, 0]), BigInt([1, 0, 0, 0]), BigInt([2, 0, 0, 0]), BigInt([4891460686036598781, 2896914383306846353, 13281191951274694749, 3486998266802970665])],
     [BigInt([4, 0, 0, 0]), BigInt([4891460686036598784, 2896914383306846353, 13281191951274694749, 3486998266802970665]), BigInt([1, 0, 0, 0]), BigInt([1, 0, 0, 0])],
     [BigInt([4, 0, 0, 0]), BigInt([4891460686036598782, 2896914383306846353, 13281191951274694749, 3486998266802970665]), BigInt([1, 0, 0, 0]), BigInt([2, 0, 0, 0])]], shape=[4, 4], strides=[4, 1], layout=Cc (0x5), dynamic ndim=2 }
[2024-11-05T18:07:01Z DEBUG plonky2::util::timing] | | 0.0000s to Op /lin1/MatMul | verifying 5 ChangeSFBasicBlock { input_SF: 6, output_SF: 3 }
[2024-11-05T18:07:01Z DEBUG plonky2::util::timing] | | 0.0004s to Op /lin1/MatMul | verifying 6 RepeaterBasicBlock { basic_block: CQ2BasicBlock { setup: Some((ChangeSFBasicBlock { input_SF: 6, output_SF: 3 }, -32, 64)) }, N: 1 }
[2024-11-05T18:07:01Z DEBUG plonky2::util::timing] | | 0.0000s to Op /lin1/Add | verifying 7 RepeaterBasicBlock { basic_block: AddBasicBlock, N: 1 }
[2024-11-05T18:07:01Z DEBUG plonky2::util::timing] | | 0.0000s to Op /relu/Relu | verifying 8 ReLUBasicBlock { input_SF: 3, output_SF: 3 }
[2024-11-05T18:07:01Z DEBUG plonky2::util::timing] | | 0.0004s to Op /relu/Relu | verifying 9 RepeaterBasicBlock { basic_block: CQ2BasicBlock { setup: Some((ReLUBasicBlock { input_SF: 3, output_SF: 3 }, -32, 64)) }, N: 1 }
[2024-11-05T18:07:01Z DEBUG plonky2::util::timing] | | 0.0005s to Op /lin2/MatMul | verifying 10 CQLinBasicBlock { setup: [[BigInt([4891460686036598782, 2896914383306846353, 13281191951274694749, 3486998266802970665]), BigInt([4891460686036598782, 2896914383306846353, 13281191951274694749, 3486998266802970665]), BigInt([4891460686036598783, 2896914383306846353, 13281191951274694749, 3486998266802970665]), BigInt([4891460686036598783, 2896914383306846353, 13281191951274694749, 3486998266802970665])],
     [BigInt([3, 0, 0, 0]), BigInt([4891460686036598782, 2896914383306846353, 13281191951274694749, 3486998266802970665]), BigInt([0, 0, 0, 0]), BigInt([0, 0, 0, 0])],
     [BigInt([4, 0, 0, 0]), BigInt([1, 0, 0, 0]), BigInt([1, 0, 0, 0]), BigInt([4891460686036598782, 2896914383306846353, 13281191951274694749, 3486998266802970665])],
     [BigInt([1, 0, 0, 0]), BigInt([4891460686036598782, 2896914383306846353, 13281191951274694749, 3486998266802970665]), BigInt([4891460686036598782, 2896914383306846353, 13281191951274694749, 3486998266802970665]), BigInt([2, 0, 0, 0])]], shape=[4, 4], strides=[4, 1], layout=Cc (0x5), dynamic ndim=2 }
[2024-11-05T18:07:01Z DEBUG plonky2::util::timing] | | 0.0000s to Op /lin2/MatMul | verifying 11 ChangeSFBasicBlock { input_SF: 6, output_SF: 3 }
[2024-11-05T18:07:01Z DEBUG plonky2::util::timing] | | 0.0004s to Op /lin2/MatMul | verifying 12 RepeaterBasicBlock { basic_block: CQ2BasicBlock { setup: Some((ChangeSFBasicBlock { input_SF: 6, output_SF: 3 }, -32, 64)) }, N: 1 }
[2024-11-05T18:07:01Z DEBUG plonky2::util::timing] | | 0.0000s to Op /lin2/Add | verifying 13 RepeaterBasicBlock { basic_block: AddBasicBlock, N: 1 }
[2024-11-05T18:07:01Z DEBUG plonky2::util::timing] | | 0.0000s to Op /relu_1/Relu | verifying 14 ReLUBasicBlock { input_SF: 3, output_SF: 3 }
[2024-11-05T18:07:01Z DEBUG plonky2::util::timing] | | 0.0004s to Op /relu_1/Relu | verifying 15 RepeaterBasicBlock { basic_block: CQ2BasicBlock { setup: Some((ReLUBasicBlock { input_SF: 3, output_SF: 3 }, -32, 64)) }, N: 1 }
[2024-11-05T18:07:01Z DEBUG plonky2::util::timing] | | 0.0060s to combine pairings
[2024-11-05T18:07:01Z DEBUG plonky2::util::timing] | | 0.0083s to pairings
```
I don't think we can exclude the combine pairings from being included using TimingTree so we may need to subtract it out 