### PR TITLE
Batch CQ

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,7 @@ prover:
   enc_input_path: inputsEnc
   enc_output_path: outputsEnc
   proof_path: proofs
+  batch_proof_path: batch_proofs
   enable_layer_setup: true
 verifier:
   enc_model_path: modelsEnc

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -96,7 +96,15 @@ pub enum BatchProveStateValues {
     usize,
     HashMap<usize, usize>,
     G2Projective,
-    Vec<G1Affine>,
+    Vec<DensePolynomial<Fr>>,
+    Vec<Fr>,
+    Vec<G1Projective>,
+    Vec<Fr>,
+  ),
+  CQ2(
+    usize,
+    HashMap<usize, usize>,
+    G2Projective,
     Vec<DensePolynomial<Fr>>,
     Vec<Fr>,
     Vec<G1Projective>,
@@ -105,7 +113,7 @@ pub enum BatchProveStateValues {
 }
 
 pub enum BatchVerifyStateValues {
-  CQ(usize, Vec<G1Affine>),
+  CQ(usize, usize, G1Affine, Vec<G1Affine>),
 }
 
 // The cache is wrapped in Arc<Mutex<>> to allow multiple threads within the same role (either prover or verifier) to access it.
@@ -275,18 +283,15 @@ pub trait BasicBlock: std::fmt::Debug + Send + Sync {
     _rng: &mut StdRng,
     _cache: ProveVerifyCache,
   ) {
+    let _ = _batch_verify_state;
   }
 
   fn batch_verify(
     &self,
     _srs: &SRS,
-    _model: &ArrayD<DataEnc>,
-    _inputs: &Vec<&ArrayD<DataEnc>>,
-    _outputs: &Vec<&ArrayD<DataEnc>>,
     _proof: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>),
     _batch_verify_values: &BatchVerifyStateValues,
     _rng: &mut StdRng,
-    _cache: ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     vec![]
   }

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -123,9 +123,9 @@ pub enum BatchVerifyStateValues {
 // Note: Each prover and verifier maintains its own separate cache. There is no cache sharing between the prover and verifier.
 pub type ProveVerifyCache = Arc<Mutex<HashMap<String, CacheValues>>>;
 
-pub type BatchProveState = Arc<Mutex<HashMap<String, (Box<dyn BasicBlock>, BatchProveStateValues)>>>;
+pub type BatchProveState = RefCell<HashMap<String, (Box<dyn BasicBlock>, BatchProveStateValues)>>;
 
-pub type BatchVerifyState = Arc<Mutex<HashMap<String, (Box<dyn BasicBlock>, BatchVerifyStateValues)>>>;
+pub type BatchVerifyState = RefCell<HashMap<String, (Box<dyn BasicBlock>, BatchVerifyStateValues)>>;
 
 pub type PairingCheck = Vec<(G1Affine, G2Affine)>;
 

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -34,6 +34,7 @@ pub use rope::RoPEBasicBlock;
 use serde::{Deserialize, Serialize};
 pub use sort::SortBasicBlock;
 pub use split::SplitBasicBlock;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 pub use sub::SubBasicBlock;
@@ -94,21 +95,21 @@ pub enum CacheValues {
 pub enum BatchProveStateValues {
   CQ(
     usize,
-    HashMap<usize, usize>,
+    RefCell<HashMap<usize, usize>>,
     G2Projective,
     Vec<DensePolynomial<Fr>>,
     Vec<Fr>,
     Vec<G1Projective>,
-    Vec<Fr>,
+    RefCell<Vec<Fr>>,
   ),
   CQ2(
     usize,
-    HashMap<usize, usize>,
+    RefCell<HashMap<usize, usize>>,
     G2Projective,
     Vec<DensePolynomial<Fr>>,
     Vec<Fr>,
     Vec<G1Projective>,
-    Vec<Fr>,
+    RefCell<Vec<Fr>>,
   ),
 }
 

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -96,7 +96,7 @@ pub enum BatchProveStateValues {
   CQ(
     usize,
     RefCell<HashMap<usize, usize>>,
-    G2Projective,
+    Vec<G2Projective>,
     Vec<DensePolynomial<Fr>>,
     Vec<Fr>,
     Vec<G1Projective>,

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -91,11 +91,32 @@ pub enum CacheValues {
   G2(G2Affine),
 }
 
+pub enum BatchProveStateValues {
+  CQ(
+    usize,
+    HashMap<usize, usize>,
+    G2Projective,
+    Vec<G1Affine>,
+    Vec<DensePolynomial<Fr>>,
+    Vec<Fr>,
+    Vec<G1Projective>,
+    Vec<Fr>,
+  ),
+}
+
+pub enum BatchVerifyStateValues {
+  CQ(usize, Vec<G1Affine>),
+}
+
 // The cache is wrapped in Arc<Mutex<>> to allow multiple threads within the same role (either prover or verifier) to access it.
 // Arc (Atomic Reference Counting) enables safe sharing of the cache between threads,
 // while Mutex ensures that only one thread can write to the cache at a time, preventing race conditions.
 // Note: Each prover and verifier maintains its own separate cache. There is no cache sharing between the prover and verifier.
 pub type ProveVerifyCache = Arc<Mutex<HashMap<String, CacheValues>>>;
+
+pub type BatchProveState = Arc<Mutex<HashMap<String, (Box<dyn BasicBlock>, BatchProveStateValues)>>>;
+
+pub type BatchVerifyState = Arc<Mutex<HashMap<String, (Box<dyn BasicBlock>, BatchVerifyStateValues)>>>;
 
 pub type PairingCheck = Vec<(G1Affine, G2Affine)>;
 
@@ -184,6 +205,54 @@ pub trait BasicBlock: std::fmt::Debug + Send + Sync {
     (Vec::new(), Vec::new(), Vec::new())
   }
 
+  fn batch_prove_first(
+    &self,
+    _srs: &SRS,
+    _setup: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<DensePolynomial<Fr>>),
+    _batch_prove_state: &mut BatchProveState,
+    _model: &ArrayD<Data>,
+    _inputs: &Vec<&ArrayD<Data>>,
+    _outputs: &Vec<&ArrayD<Data>>,
+    _rng: &mut StdRng,
+    _cache: ProveVerifyCache,
+  ) {
+  }
+
+  fn batch_prove_second(
+    &self,
+    _srs: &SRS,
+    _setup: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<DensePolynomial<Fr>>),
+    _batch_prove_state: &mut BatchProveState,
+    _model: &ArrayD<Data>,
+    _inputs: &Vec<&ArrayD<Data>>,
+    _outputs: &Vec<&ArrayD<Data>>,
+    _rng: &mut StdRng,
+    _cache: ProveVerifyCache,
+  ) {
+  }
+
+  fn batch_prove_third(
+    &self,
+    _srs: &SRS,
+    _setup: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<DensePolynomial<Fr>>),
+    _batch_prove_state: &mut BatchProveState,
+    _model: &ArrayD<Data>,
+    _inputs: &Vec<&ArrayD<Data>>,
+    _outputs: &Vec<&ArrayD<Data>>,
+    _rng: &mut StdRng,
+    _cache: ProveVerifyCache,
+  ) {
+  }
+
+  fn batch_prove(
+    &self,
+    _srs: &SRS,
+    _batch_prove_values: &BatchProveStateValues,
+    _rng: &mut StdRng,
+  ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
+    (Vec::new(), Vec::new(), Vec::new())
+  }
+
   fn verify(
     &self,
     _srs: &SRS,
@@ -191,6 +260,31 @@ pub trait BasicBlock: std::fmt::Debug + Send + Sync {
     _inputs: &Vec<&ArrayD<DataEnc>>,
     _outputs: &Vec<&ArrayD<DataEnc>>,
     _proof: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>),
+    _rng: &mut StdRng,
+    _cache: ProveVerifyCache,
+  ) -> Vec<PairingCheck> {
+    vec![]
+  }
+
+  fn batch_verify_first(
+    &self,
+    _batch_verify_state: &mut BatchVerifyState,
+    _model: &ArrayD<DataEnc>,
+    _inputs: &Vec<&ArrayD<DataEnc>>,
+    _outputs: &Vec<&ArrayD<DataEnc>>,
+    _rng: &mut StdRng,
+    _cache: ProveVerifyCache,
+  ) {
+  }
+
+  fn batch_verify(
+    &self,
+    _srs: &SRS,
+    _model: &ArrayD<DataEnc>,
+    _inputs: &Vec<&ArrayD<DataEnc>>,
+    _outputs: &Vec<&ArrayD<DataEnc>>,
+    _proof: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>),
+    _batch_verify_values: &BatchVerifyStateValues,
     _rng: &mut StdRng,
     _cache: ProveVerifyCache,
   ) -> Vec<PairingCheck> {

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -1,10 +1,15 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{
+  BasicBlock, BatchProveState, BatchProveStateValues, BatchVerifyState, BatchVerifyStateValues, CacheValues, Data, DataEnc, PairingCheck,
+  ProveVerifyCache, SRS,
+};
 use crate::util;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
-use ark_poly::{evaluations::univariate::Evaluations, univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain};
+use ark_poly::{
+  evaluations::univariate::Evaluations, univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain, Polynomial,
+};
 use ark_std::{
   ops::{Mul, Sub},
   One, UniformRand, Zero,
@@ -12,9 +17,9 @@ use ark_std::{
 use ndarray::{Array1, ArrayD};
 use rand::{rngs::StdRng, SeedableRng};
 use rayon::prelude::*;
-use std::collections::HashMap;
+use std::{cmp::max, collections::HashMap};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CQBasicBlock {
   pub setup: util::CQArrayType,
 }
@@ -184,6 +189,301 @@ impl BasicBlock for CQBasicBlock {
     return (proof, vec![setup.1[0].into(), f_x_2], Vec::new());
   }
 
+  fn batch_prove_first(
+    &self,
+    srs: &SRS,
+    setup: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<DensePolynomial<Fr>>),
+    batch_prove_state: &mut BatchProveState,
+    model: &ArrayD<Data>,
+    inputs: &Vec<&ArrayD<Data>>,
+    _outputs: &Vec<&ArrayD<Data>>,
+    _rng: &mut StdRng,
+    cache: ProveVerifyCache,
+  ) {
+    let model = model.first().unwrap();
+    let input = inputs[0].first().unwrap();
+    let n = input.raw.len();
+    let N = model.raw.len();
+    assert!(n <= N);
+
+    let key = format!("{:?}_{}", self, input.raw.len());
+    let mut cache = cache.lock().unwrap();
+    let CacheValues::CQTableDict(table_dict) =
+      cache.entry(format!("cq_table_dict_{:p}", self)).or_insert_with(|| CacheValues::CQTableDict(HashMap::new()))
+    else {
+      panic!("Cache type error")
+    };
+    if table_dict.len() == 0 {
+      for i in 0..N {
+        table_dict.insert(model.raw[i], i);
+      }
+    }
+    let mut guard = batch_prove_state.lock().unwrap();
+    match guard.get_mut(&key) {
+      Some(value) => {
+        let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, affines, polys, _, _, _)) = value;
+        let mut m_i = m_i.clone();
+        for x in input.raw.iter() {
+          if !table_dict.contains_key(x) {
+            println!("{:?},{:?}", x, -*x);
+          }
+          m_i.entry(table_dict.get(x).unwrap().clone()).and_modify(|y| *y += 1).or_insert(1);
+        }
+        affines.push((input.g1 + srs.Y1P * input.r).into());
+        *value = (
+          Box::new(self.clone()),
+          BatchProveStateValues::CQ(*n, m_i, *T_x_2, affines.clone(), polys.clone(), vec![], vec![], vec![]),
+        )
+      }
+      _ => {
+        let mut m_i = HashMap::new();
+        for x in input.raw.iter() {
+          if !table_dict.contains_key(x) {
+            println!("{:?},{:?}", x, -*x);
+          }
+          m_i.entry(table_dict.get(x).unwrap().clone()).and_modify(|y| *y += 1).or_insert(1);
+        }
+        guard.insert(
+          key,
+          (
+            Box::new(self.clone()),
+            BatchProveStateValues::CQ(
+              n,
+              m_i,
+              setup.1[0].into(),
+              vec![(input.g1 + srs.Y1P * input.r).into()],
+              vec![
+                DensePolynomial::from_coefficients_vec(vec![Fr::zero()]),
+                DensePolynomial::from_coefficients_vec(vec![Fr::one()]),
+                DensePolynomial::from_coefficients_vec(vec![Fr::zero()]),
+                DensePolynomial::from_coefficients_vec(vec![Fr::zero()]),
+              ],
+              vec![],
+              vec![],
+              vec![],
+            ),
+          ),
+        );
+      }
+    };
+  }
+
+  fn batch_prove_second(
+    &self,
+    _srs: &SRS,
+    _setup: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<DensePolynomial<Fr>>),
+    batch_prove_state: &mut BatchProveState,
+    model: &ArrayD<Data>,
+    inputs: &Vec<&ArrayD<Data>>,
+    _outputs: &Vec<&ArrayD<Data>>,
+    rng: &mut StdRng,
+    _cache: ProveVerifyCache,
+  ) {
+    let model = model.first().unwrap();
+    let input = inputs[0].first().unwrap();
+    let n = input.raw.len();
+    let N = model.raw.len();
+    assert!(n <= N);
+    let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
+
+    let key = format!("{:?}_{}", self, input.raw.len());
+    let mut guard = batch_prove_state.lock().unwrap();
+    match guard.get_mut(&key) {
+      Some(value) => {
+        let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, affines, polys, rngs, _, _)) = value;
+        let beta = if rngs.len() == 0 { Fr::rand(rng) } else { rngs[0] };
+        let B_i: Vec<Fr> = input.raw.iter().map(|x| (*x + beta).inverse().unwrap()).collect();
+        let f_poly = input.poly.clone() + DensePolynomial::from_coefficients_vec(vec![beta]);
+        let B_poly = &polys[0] + &Evaluations::from_vec_and_domain(B_i.clone(), domain_n).interpolate();
+        let f_prod = &polys[1];
+        let diff = &polys[2].mul(&f_poly) + f_prod;
+        let f_prod = f_poly.mul(f_prod);
+        let new_polys = vec![B_poly, f_prod, diff];
+        // avoid cloning
+        *value = (
+          Box::new(self.clone()),
+          BatchProveStateValues::CQ(*n, m_i.clone(), *T_x_2, affines.to_vec(), new_polys, vec![beta], vec![], vec![]),
+        )
+      }
+      _ => {}
+    };
+  }
+
+  fn batch_prove_third(
+    &self,
+    srs: &SRS,
+    setup: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<DensePolynomial<Fr>>),
+    batch_prove_state: &mut BatchProveState,
+    model: &ArrayD<Data>,
+    inputs: &Vec<&ArrayD<Data>>,
+    _outputs: &Vec<&ArrayD<Data>>,
+    rng: &mut StdRng,
+    _cache: ProveVerifyCache,
+  ) {
+    let model = model.first().unwrap();
+    let input = inputs[0].first().unwrap();
+    let n = input.raw.len();
+    let N = model.raw.len();
+
+    // gen(N, t):
+    let Q_i_x_1 = &setup.0[..N];
+    let L_i_x_1 = &setup.0[N..2 * N];
+    let L_i_0_x_1 = &setup.0[2 * N..];
+
+    assert!(n <= N);
+    let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
+    let key = format!("{:?}_{}", self, input.raw.len());
+    let mut guard = batch_prove_state.lock().unwrap();
+    match guard.get_mut(&key) {
+      Some(value) => {
+        let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, affines, polys, rngs, proof_0, proof_2)) = value;
+
+        let proof = if proof_0.len() == 0 {
+          let B_poly = &polys[0];
+          let f_prod = &polys[1];
+          let diff = &polys[2];
+
+          let B_Q_poly = B_poly.mul(f_prod).sub(diff).divide_by_vanishing_poly(domain_n).unwrap().0;
+          let B_x = util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs);
+          let B_Q_x = util::msm::<G1Projective>(&srs.X1A, &B_Q_poly.coeffs);
+          let B_zero_div = if B_poly.is_zero() {
+            G1Projective::zero()
+          } else {
+            util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs[1..])
+          };
+          let B_DC = util::msm::<G1Projective>(&srs.X1A[N - *n..], &B_poly.coeffs);
+
+          let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
+          let m_x = util::msm::<G1Projective>(&temp, &temp2);
+
+          // Calculate A
+          // element to m/(t + beta)
+          let beta = rngs[0];
+          let A_i: HashMap<usize, Fr> = m_i.iter().map(|(i, y)| (*i, Fr::from(*y as u32) * (model.raw[*i] + beta).inverse().unwrap())).collect();
+          // lagrange basis of value
+          let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_x_1[*i], *y)).unzip();
+          // msm basis with A(x)
+          let A_x = util::msm::<G1Projective>(&temp, &temp2);
+          let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (Q_i_x_1[*i], *y)).unzip();
+          let A_Q_x = util::msm::<G1Projective>(&temp, &temp2);
+          let A_zero = srs.X1P[0] * (Fr::from(N as u32).inverse().unwrap() * A_i.iter().map(|(_, y)| *y).sum::<Fr>());
+          let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_0_x_1[*i], *y)).unzip();
+          let A_zero_div = util::msm::<G1Projective>(&temp, &temp2);
+
+          let mut rng2 = StdRng::from_entropy();
+          let r: Vec<_> = (0..9).map(|_| Fr::rand(&mut rng2)).collect();
+          let commits = vec![m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC];
+          let mut commits: Vec<G1Projective> = commits.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r[i]).collect();
+          let mut C = vec![
+            -(srs.X1P[N] - srs.X1P[0]) * r[2] + model.g1 * r[1] + A_x * model.r + (srs.Y1P * model.r * r[1]) + srs.X1P[0] * (r[1] * beta - r[0]),
+            -srs.X1P[1] * r[4] + srs.X1P[0] * (r[1] - r[3]),
+            -srs.X1P[1] * r[7] + srs.X1P[0] * (r[5] - r[3] * Fr::from(N as u32) * Fr::from(*n as u32).inverse().unwrap()),
+            -srs.X1P[0] * r[8] + srs.X1P[N - *n] * r[5],
+          ];
+          commits.append(&mut C);
+          commits
+        } else {
+          proof_0.clone()
+        };
+
+        let zeta = if rngs.len() == 1 { Fr::rand(rng) } else { rngs[1] };
+        let mu = if rngs.len() == 1 { Fr::rand(rng) } else { rngs[2] };
+        let mu_pow = if rngs.len() == 1 { mu } else { rngs[3] * mu };
+        let q1_poly: DensePolynomial<Fr> = &polys[3] + &input.poly.mul(mu_pow);
+        let f_z = input.poly.evaluate(&zeta);
+        let mut evals = proof_2.clone();
+        evals.push(f_z);
+        let new_rngs = vec![rngs[0], zeta, mu];
+        let mut new_polys = polys[..3].to_vec();
+        new_polys.push(q1_poly);
+        *value = (
+          Box::new(self.clone()),
+          BatchProveStateValues::CQ(*n, m_i.clone(), *T_x_2, affines.to_vec(), new_polys, new_rngs, proof, evals),
+        )
+      }
+      _ => {}
+    }
+  }
+
+  fn batch_prove(&self, srs: &SRS, batch_prove_values: &BatchProveStateValues, _rng: &mut StdRng) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
+    let BatchProveStateValues::CQ(_, _, T_x_2, _, polys, rngs, proof_0, proof_2) = batch_prove_values;
+    // let model = &model.first().unwrap();
+    // let N = model.raw.len();
+
+    // // gen(N, t):
+    // let Q_i_x_1 = &setup.0[..N];
+    // let L_i_x_1 = &setup.0[N..2 * N];
+    // let L_i_0_x_1 = &setup.0[2 * N..];
+
+    // assert!(n <= N);
+    // let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
+
+    // let B_poly = &polys[0];
+    // let f_prod = &polys[1];
+    // let diff = &polys[2];
+
+    // // let diffs: Vec<_> = f_polys.iter().map(|x| &f_prod / &x).collect();
+    // // let diff = diffs.iter().fold(DensePolynomial::zero(), |acc, p| &acc + p);
+    // let B_Q_poly = B_poly.mul(f_prod).sub(diff).divide_by_vanishing_poly(domain_n).unwrap().0;
+    // let B_x = util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs);
+    // let B_Q_x = util::msm::<G1Projective>(&srs.X1A, &B_Q_poly.coeffs);
+    // let B_zero_div = if B_poly.is_zero() {
+    //   G1Projective::zero()
+    // } else {
+    //   util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs[1..])
+    // };
+    // let B_DC = util::msm::<G1Projective>(&srs.X1A[N - n..], &B_poly.coeffs);
+
+    // let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
+    // let m_x = util::msm::<G1Projective>(&temp, &temp2);
+
+    // // Calculate A
+    // // element to m/(t + beta)
+    // let beta = beta_opt.unwrap();
+    // let A_i: HashMap<usize, Fr> = m_i.iter().map(|(i, y)| (*i, Fr::from(*y as u32) * (model.raw[*i] + beta).inverse().unwrap())).collect();
+    // // lagrange basis of value
+    // let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_x_1[*i], *y)).unzip();
+    // // msm basis with A(x)
+    // let A_x = util::msm::<G1Projective>(&temp, &temp2);
+    // let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (Q_i_x_1[*i], *y)).unzip();
+    // let A_Q_x = util::msm::<G1Projective>(&temp, &temp2);
+    // let A_zero = srs.X1P[0] * (Fr::from(N as u32).inverse().unwrap() * A_i.iter().map(|(_, y)| *y).sum::<Fr>());
+    // let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_0_x_1[*i], *y)).unzip();
+    // let A_zero_div = util::msm::<G1Projective>(&temp, &temp2);
+
+    // let zeta = Fr::rand(rng);
+    // let f_zs: Vec<_> = f_polys.iter().map(|p| p.evaluate(&zeta)).collect();
+
+    let zeta = rngs[1];
+    // let v = Fr::rand(rng);
+    // let vs = util::calc_pow(v, f_polys.len());
+    // let q1_poly: DensePolynomial<Fr> = f_polys.iter().enumerate().fold(DensePolynomial::zero(), |acc, (i, p)| acc + p.mul(vs[i]));
+    let q1_poly = &polys[3];
+    let q1_z = q1_poly.evaluate(&zeta);
+    let q1_z_poly = DensePolynomial { coeffs: vec![q1_z] };
+    let q1_V = DensePolynomial {
+      coeffs: vec![-zeta, Fr::one()],
+    };
+    let W_poly = &q1_poly.sub(&q1_z_poly) / &q1_V;
+    let W_x = util::msm::<G1Projective>(&srs.X1A, &W_poly.coeffs);
+
+    // Blinding
+    // let mut rng2 = StdRng::from_entropy();
+    // let r: Vec<_> = (0..9).map(|_| Fr::rand(&mut rng2)).collect();
+    // let proof: Vec<G1Projective> = vec![m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC, W_x];
+    // let mut proof: Vec<G1Projective> = proof.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r[i]).collect();
+    // let mut C = vec![
+    //   -(srs.X1P[N] - srs.X1P[0]) * r[2] + model.g1 * r[1] + A_x * model.r + (srs.Y1P * model.r * r[1]) + srs.X1P[0] * (r[1] * beta - r[0]),
+    //   -srs.X1P[1] * r[4] + srs.X1P[0] * (r[1] - r[3]),
+    //   -srs.X1P[1] * r[7] + srs.X1P[0] * (r[5] - r[3] * Fr::from(N as u32) * Fr::from(n as u32).inverse().unwrap()),
+    //   -srs.X1P[0] * r[8] + srs.X1P[N - n] * r[5],
+    // ];
+    // proof.append(&mut C);
+    let mut proof = proof_0.clone();
+    proof.push(W_x);
+    (proof, vec![*T_x_2], proof_2.clone())
+  }
+
   fn verify(
     &self,
     srs: &SRS,
@@ -237,6 +537,107 @@ impl BasicBlock for CQBasicBlock {
 
     // Degree check B
     checks.push(vec![(B_x, srs.X2A[N - n]), (-B_DC, srs.X2A[0]), (-C5, srs.Y2A)]);
+    checks
+  }
+
+  fn batch_verify_first(
+    &self,
+    batch_verify_state: &mut BatchVerifyState,
+    _model: &ArrayD<DataEnc>,
+    inputs: &Vec<&ArrayD<DataEnc>>,
+    _outputs: &Vec<&ArrayD<DataEnc>>,
+    _rng: &mut StdRng,
+    _cache: ProveVerifyCache,
+  ) {
+    let input = inputs[0].first().unwrap();
+    let key = format!("{:?}_{}", self, input.len);
+    let mut guard = batch_verify_state.lock().unwrap();
+    match guard.get_mut(&key) {
+      Some(value) => {
+        let (_, BatchVerifyStateValues::CQ(n, g1s)) = value;
+        let mut new_g1s = g1s.clone();
+        new_g1s.push(input.g1);
+        *value = (Box::new(self.clone()), BatchVerifyStateValues::CQ(*n, new_g1s))
+      }
+      _ => {
+        guard.insert(key, (Box::new(self.clone()), BatchVerifyStateValues::CQ(input.len, vec![input.g1])));
+      }
+    };
+  }
+
+  fn batch_verify(
+    &self,
+    srs: &SRS,
+    model: &ArrayD<DataEnc>,
+    inputs: &Vec<&ArrayD<DataEnc>>,
+    _outputs: &Vec<&ArrayD<DataEnc>>,
+    proof: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>),
+    batch_verify_values: &BatchVerifyStateValues,
+    rng: &mut StdRng,
+    _cache: ProveVerifyCache,
+  ) -> Vec<PairingCheck> {
+    let mut checks = Vec::new();
+    let N = model.first().unwrap().len;
+    let n = inputs[0].first().unwrap().len;
+    let [m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC, W_x, C1, C2, C3, C4, C5, C6] = proof.0[..] else {
+      panic!("Wrong proof format")
+    };
+    let [T_x_2] = proof.1[..] else { panic!("Wrong proof format") };
+    let f_zs = proof.2;
+
+    let beta = Fr::rand(rng);
+    let zeta = Fr::rand(rng);
+    let mu = Fr::rand(rng);
+
+    let BatchVerifyStateValues::CQ(_, f_xs) = batch_verify_values;
+
+    let zetas = util::calc_pow(zeta, f_zs.len());
+    let mus = util::calc_pow(mu, f_zs.len());
+    let fz_sum: Fr = f_zs.iter().enumerate().map(|(i, x)| *x * mus[i]).sum();
+    let fz_prod = f_zs.iter().product();
+    let diff: Fr = f_zs.iter().map(|x| &fz_prod / x).sum();
+    let f_sum: G1Projective = f_xs.iter().enumerate().map(|(i, x)| (*x + srs.X1A[0] * beta) * mus[i]).sum();
+
+    // Check A(x) (A_i = m_i/(t_i+beta))
+    checks.push(vec![
+      (A_x, T_x_2),
+      ((A_x * beta - m_x).into(), srs.X2A[0]),
+      (-A_Q_x, (srs.X2A[N] - srs.X2A[0]).into()),
+      (-C1, srs.Y2A),
+    ]);
+
+    // Check T_x_2 is the G2 equivalent of the model
+    checks.push(vec![(model.first().unwrap().g1, srs.X2A[0]), (srs.X1A[0], -T_x_2)]);
+
+    // Check A(x) - A(0) is divisible by x
+    checks.push(vec![((A_x - A_zero).into(), srs.X2A[0]), (-A_zero_div, srs.X2A[1]), (-C2, srs.Y2A)]);
+
+    // Assume B(0) = A(0)*N/n (which assumes ∑A=∑B)
+    let B_0: G1Affine = (A_zero * (Fr::from(N as u32) * Fr::from(n as u32).inverse().unwrap())).into();
+
+    // Check B(x) - B(0) is divisible by x
+    checks.push(vec![((B_x - B_0).into(), srs.X2A[0]), (-B_zero_div, srs.X2A[1]), (-C3, srs.Y2A)]);
+
+    // Degree check B
+    checks.push(vec![(B_x, srs.X2A[N - n]), (-B_DC, srs.X2A[0]), (-C4, srs.Y2A)]);
+
+    // Check B(x) (B_i = sum ())
+    // add C5
+    checks.push(vec![
+      (
+        (B_x * fz_prod - srs.X1A[0] * diff - B_Q_x * (zetas[n - 1] - Fr::one())).into(),
+        srs.X2A[0],
+      ),
+      (-C5, srs.Y2A),
+    ]);
+
+    // add C6
+    checks.push(vec![
+      ((W_x, (srs.X2P[1] - srs.X2A[0] * zeta).into())),
+      ((f_sum - srs.X1A[0] * fz_sum).into(), srs.X2A[0]),
+      (-C6, srs.Y2A),
+    ]);
+
     checks
   }
 }

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -370,8 +370,6 @@ impl BasicBlock for CQBasicBlock {
   fn batch_prove(&self, srs: &SRS, batch_prove_values: &BatchProveStateValues, _rng: &mut StdRng) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     if let BatchProveStateValues::CQ(n, _, g2s, polys, rngs, proof_0, proof_2) = batch_prove_values {
       let zeta = rngs[1];
-      // let diff = &polys[2];
-      // let f_prod = &polys[1];
       let q1_poly = &polys[3];
       let q1_z = q1_poly.evaluate(&zeta);
       let q1_z_poly = DensePolynomial { coeffs: vec![q1_z] };
@@ -382,7 +380,7 @@ impl BasicBlock for CQBasicBlock {
       let W_x = util::msm::<G1Projective>(&srs.X1A, &W_poly.coeffs);
 
       let p_ref = proof_2.borrow();
-      let f_zs = &p_ref[6..];
+      let f_zs = &p_ref[7..];
       let mut rng2 = StdRng::from_entropy();
       // [input0.r, input1.r, B_x, B_Q_x, diff_x, f_prod]
       let r = &p_ref[..6];

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -5,7 +5,11 @@ use super::{
   ProveVerifyCache, SRS,
 };
 use crate::util;
-use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
+use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
+use ark_ec::{
+  pairing::{Pairing, PairingOutput},
+  CurveGroup,
+};
 use ark_ff::Field;
 use ark_poly::{
   evaluations::univariate::Evaluations, univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain, Polynomial,
@@ -22,7 +26,6 @@ use std::{
   cmp::max,
   collections::HashMap,
   sync::{Arc, Mutex},
-  time::Instant,
 };
 
 #[derive(Debug, Clone)]
@@ -130,7 +133,7 @@ impl BasicBlock for CQBasicBlock {
     let mut state_mut_ref = batch_prove_state.borrow_mut();
     match state_mut_ref.get_mut(&key) {
       Some(value) => {
-        if let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, polys, _, _, proof_2)) = value {
+        if let (_, BatchProveStateValues::CQ(n, m_i, g2s, polys, _, _, proof_2)) = value {
           for x in input.raw.iter() {
             if !table_dict.contains_key(x) {
               println!("{:?},{:?}", x, -*x);
@@ -144,7 +147,15 @@ impl BasicBlock for CQBasicBlock {
           drop(p_ref);
           *value = (
             Box::new(self.clone()),
-            BatchProveStateValues::CQ(*n, RefCell::clone(m_i), *T_x_2, polys.clone(), vec![], vec![], RefCell::clone(proof_2)),
+            BatchProveStateValues::CQ(
+              *n,
+              RefCell::clone(m_i),
+              g2s.clone(),
+              polys.clone(),
+              vec![],
+              vec![],
+              RefCell::clone(proof_2),
+            ),
           );
         } else {
         }
@@ -164,7 +175,7 @@ impl BasicBlock for CQBasicBlock {
             BatchProveStateValues::CQ(
               n,
               RefCell::new(m_i),
-              setup.1[0].into(),
+              vec![setup.1[0].into()],
               vec![
                 DensePolynomial::from_coefficients_vec(vec![Fr::zero()]),
                 DensePolynomial::from_coefficients_vec(vec![Fr::one()]),
@@ -203,21 +214,26 @@ impl BasicBlock for CQBasicBlock {
     let mut state_mut_ref = batch_prove_state.borrow_mut();
     match state_mut_ref.get_mut(&key) {
       Some(value) => {
-        if let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, polys, rngs, _, proof_2)) = value {
+        if let (_, BatchProveStateValues::CQ(n, m_i, g2s, polys, rngs, _, proof_2)) = value {
           let beta = if rngs.len() == 0 { Fr::rand(rng) } else { rngs[0] };
           let B_i: Vec<Fr> = input.raw.iter().map(|x| (*x + beta).inverse().unwrap()).collect();
           let f_poly = &input.poly + &DensePolynomial::from_coefficients_vec(vec![beta]);
           let B_poly = &polys[0] + &Evaluations::from_vec_and_domain(B_i.clone(), domain_n).interpolate();
           let f_prod = &polys[1];
-          let start = Instant::now();
           let diff = &polys[2].mul(&f_poly) + f_prod;
-          let duration = start.elapsed();
-          println!("diff deg {}, time: {:?}", diff.degree(), duration);
           let f_prod = f_poly.mul(f_prod);
           let new_polys = vec![B_poly, f_prod, diff];
           *value = (
             Box::new(self.clone()),
-            BatchProveStateValues::CQ(*n, RefCell::clone(m_i), *T_x_2, new_polys, vec![beta], vec![], RefCell::clone(proof_2)),
+            BatchProveStateValues::CQ(
+              *n,
+              RefCell::clone(m_i),
+              g2s.clone(),
+              new_polys,
+              vec![beta],
+              vec![],
+              RefCell::clone(proof_2),
+            ),
           )
         } else {
         }
@@ -253,8 +269,8 @@ impl BasicBlock for CQBasicBlock {
     let mut state_mut_ref = batch_prove_state.borrow_mut();
     match state_mut_ref.get_mut(&key) {
       Some(value) => {
-        if let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, polys, rngs, proof_0, proof_2)) = value {
-          let (proof, proof_2) = if proof_0.len() == 0 {
+        if let (_, BatchProveStateValues::CQ(n, m_i, g2s, polys, rngs, proof_0, proof_2)) = value {
+          let (proof, proof_2, f_prod_x) = if proof_0.len() == 0 {
             let B_poly = &polys[0];
             let f_prod = &polys[1];
             let diff = &polys[2];
@@ -262,13 +278,16 @@ impl BasicBlock for CQBasicBlock {
             let B_Q_poly = B_poly.mul(f_prod).sub(diff).divide_by_vanishing_poly(domain_n).unwrap().0;
             let B_x = util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs);
             let B_Q_x = util::msm::<G1Projective>(&srs.X1A, &B_Q_poly.coeffs);
-            // let diff_x = util::msm::<G1Projective>(&srs.X1A, &diff.coeffs);
             let B_zero_div = if B_poly.is_zero() {
               G1Projective::zero()
             } else {
               util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs[1..])
             };
             let B_DC = util::msm::<G1Projective>(&srs.X1A[N - *n..], &B_poly.coeffs);
+
+            let f_prod_x_2 = util::msm::<G2Projective>(&srs.X2A, &f_prod.coeffs);
+            let f_prod_x = util::msm::<G1Projective>(&srs.X1A, &f_prod.coeffs);
+            let diff_x = util::msm::<G1Projective>(&srs.X1A, &diff.coeffs);
 
             let m_ref = m_i.borrow();
             let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_ref.iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
@@ -277,8 +296,6 @@ impl BasicBlock for CQBasicBlock {
             // Calculate A
             // element to m/(t + beta)
             let beta = rngs[0];
-            // let betas = util::calc_pow(beta, *n);
-            // assert!(&B_poly.evaluate(&beta) * &f_prod.evaluate(&beta) - Fr::one() == *&B_Q_poly.evaluate(&beta) * (betas[*n - 1] - Fr::one()));
 
             let A_i: HashMap<usize, Fr> = m_ref.iter().map(|(i, y)| (*i, Fr::from(*y as u32) * (model.raw[*i] + beta).inverse().unwrap())).collect();
             // lagrange basis of value
@@ -292,9 +309,10 @@ impl BasicBlock for CQBasicBlock {
             let A_zero_div = util::msm::<G1Projective>(&temp, &temp2);
 
             let mut rng2 = StdRng::from_entropy();
-            let r: Vec<_> = (0..9).map(|_| Fr::rand(&mut rng2)).collect();
-            let commits = vec![m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC];
+            let r: Vec<_> = (0..11).map(|_| Fr::rand(&mut rng2)).collect();
+            let commits = vec![m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC, diff_x, f_prod_x];
             let mut commits: Vec<G1Projective> = commits.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r[i]).collect();
+            println!("B_x, B_Q_x: {:?}, {:?}", commits[5].into_affine(), commits[6].into_affine());
             let mut C = vec![
               -(srs.X1P[N] - srs.X1P[0]) * r[2] + model.g1 * r[1] + A_x * model.r + (srs.Y1P * model.r * r[1]) + srs.X1P[0] * (r[1] * beta - r[0]),
               -srs.X1P[1] * r[4] + srs.X1P[0] * (r[1] - r[3]),
@@ -304,11 +322,11 @@ impl BasicBlock for CQBasicBlock {
             if proof_2.borrow().len() < 2 {
               proof_2.borrow_mut().push(Fr::zero());
             }
-            proof_2.borrow_mut().append(&mut vec![r[5], r[6], Fr::zero()]);
+            proof_2.borrow_mut().append(&mut vec![r[5], r[6], r[9], r[10], Fr::zero()]);
             commits.append(&mut C);
-            (commits, proof_2)
+            (commits, proof_2, f_prod_x_2 + srs.Y2P * r[10])
           } else {
-            (proof_0.clone(), &mut RefCell::clone(proof_2))
+            (proof_0.clone(), &mut RefCell::clone(proof_2), g2s[1])
           };
 
           let beta = rngs[0];
@@ -323,8 +341,8 @@ impl BasicBlock for CQBasicBlock {
           };
 
           let f_z = f_poly.evaluate(&zeta);
-          let agg_r = proof_2.borrow()[4];
-          proof_2.borrow_mut()[4] = agg_r + input.r * mu_pow;
+          let agg_r = proof_2.borrow()[6];
+          proof_2.borrow_mut()[6] = agg_r + input.r * mu_pow;
           proof_2.borrow_mut().push(f_z);
 
           let new_rngs = vec![rngs[0], zeta, mu, mu_pow];
@@ -332,7 +350,15 @@ impl BasicBlock for CQBasicBlock {
           new_polys.push(q1_poly);
           *value = (
             Box::new(self.clone()),
-            BatchProveStateValues::CQ(*n, RefCell::clone(m_i), *T_x_2, new_polys, new_rngs, proof, RefCell::clone(proof_2)),
+            BatchProveStateValues::CQ(
+              *n,
+              RefCell::clone(m_i),
+              vec![g2s[0], f_prod_x],
+              new_polys,
+              new_rngs,
+              proof,
+              RefCell::clone(proof_2),
+            ),
           )
         } else {
         }
@@ -342,7 +368,7 @@ impl BasicBlock for CQBasicBlock {
   }
 
   fn batch_prove(&self, srs: &SRS, batch_prove_values: &BatchProveStateValues, _rng: &mut StdRng) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
-    if let BatchProveStateValues::CQ(n, _, T_x_2, polys, rngs, proof_0, proof_2) = batch_prove_values {
+    if let BatchProveStateValues::CQ(n, _, g2s, polys, rngs, proof_0, proof_2) = batch_prove_values {
       let zeta = rngs[1];
       // let diff = &polys[2];
       // let f_prod = &polys[1];
@@ -356,28 +382,18 @@ impl BasicBlock for CQBasicBlock {
       let W_x = util::msm::<G1Projective>(&srs.X1A, &W_poly.coeffs);
 
       let p_ref = proof_2.borrow();
-      let f_zs = &p_ref[5..];
-      let fz_prod: Fr = f_zs.iter().product();
+      let f_zs = &p_ref[6..];
       let mut rng2 = StdRng::from_entropy();
-      // [input0.r, input1.r, B_x, B_Q_x]
-      let r = &p_ref[..4];
-      let r_sum = p_ref[4];
-      let zetas = util::calc_pow(zeta, *n);
-      let diff_r = if f_zs.len() == 1 {
-        Fr::zero()
-      } else {
-        let diff_prod: Fr = f_zs[1..].iter().product();
-        let diffs: Vec<_> = f_zs[1..].iter().map(|x| diff_prod / x).collect();
-        let diffs_sum: Fr = diffs.iter().sum();
-        diffs_sum * r[0] + diffs[0] * r[1]
-      };
-      let C5 = srs.X1P[0] * (fz_prod * r[2] - diff_r - (zetas[n - 1] - Fr::one()) * r[3]);
+      // [input0.r, input1.r, B_x, B_Q_x, diff_x, f_prod]
+      let r = &p_ref[..6];
+      let r_sum = p_ref[6];
+      let C5 = -srs.X1P[0] * r[4] - (srs.X1P[*n] - srs.X1P[0]) * r[3] + (proof_0[5] - srs.Y1P * r[2]) * r[5] + proof_0[10] * r[2];
       let r = Fr::rand(&mut rng2);
       let C6 = -(srs.X1P[1] - srs.X1P[0] * zeta) * r + srs.X1P[0] * r_sum;
 
       let mut proof = proof_0.clone();
       proof.append(&mut vec![W_x + srs.Y1P * r, C5, C6]);
-      (proof, vec![*T_x_2], f_zs.to_vec())
+      (proof, g2s.clone(), f_zs.to_vec())
     } else {
       (vec![], vec![], vec![])
     }
@@ -421,10 +437,10 @@ impl BasicBlock for CQBasicBlock {
     rng: &mut StdRng,
   ) -> Vec<PairingCheck> {
     let mut checks = Vec::new();
-    let [m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC, C1, C2, C3, C4, W_x, C5, C6] = proof.0[..] else {
+    let [m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC, diff_x, prod_x, C1, C2, C3, C4, W_x, C5, C6] = proof.0[..] else {
       panic!("Wrong proof format")
     };
-    let [T_x_2] = proof.1[..] else { panic!("Wrong proof format") };
+    let [T_x_2, prod_x_2] = proof.1[..] else { panic!("Wrong proof format") };
     let f_zs = proof.2;
 
     let beta = Fr::rand(rng);
@@ -439,15 +455,9 @@ impl BasicBlock for CQBasicBlock {
     let fz_sum: Fr = f_zs.iter().enumerate().map(|(i, x)| *x * mus[i]).sum();
     let fz_prod: Fr = f_zs.iter().product();
     let f_sum: G1Projective = f_xs.iter().enumerate().map(|(i, x)| (*x + srs.X1A[0] * beta) * mus[i]).sum();
-
-    let diff_g1 = if f_zs.len() == 1 {
-      srs.X1P[0]
-    } else {
-      let diff_prod: Fr = f_zs[1..].iter().product();
-      let diffs: Vec<_> = f_zs[1..].iter().map(|x| diff_prod / x).collect();
-      let diffs_sum: Fr = diffs.iter().sum();
-      (f_xs[0] + srs.X1A[0] * beta) * diffs_sum + (f_xs[1] + srs.X1A[0] * beta) * diffs[0]
-    };
+    println!("B_x, B_Q_x: {:?}, {:?}", B_x, B_Q_x);
+    println!("fz_prod: {:?}", fz_prod);
+    println!("zeta^n: {:?}", zetas[*n - 1]);
 
     // Check A(x) (A_i = m_i/(t_i+beta))
     checks.push(vec![
@@ -474,9 +484,13 @@ impl BasicBlock for CQBasicBlock {
 
     // Check B(x) (B_i = sum ())
     checks.push(vec![
-      ((B_x * fz_prod - diff_g1 - B_Q_x * (zetas[*n - 1] - Fr::one())).into(), srs.X2A[0]),
+      (B_x, prod_x_2),
+      (-diff_x, srs.X2A[0]),
+      (-B_Q_x, (srs.X2A[*n] - srs.X2A[0]).into()),
       (-C5, srs.Y2A),
     ]);
+
+    // Check f_x_2 is the G2 equivalent of the input
 
     // Check W(x) (W(x) = (F(x) - F(zeta)) / (x - zeta))
     // where F(x) is RLC'd input polynomials

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -124,19 +124,20 @@ impl BasicBlock for CQBasicBlock {
     let mut guard = batch_prove_state.lock().unwrap();
     match guard.get_mut(&key) {
       Some(value) => {
-        let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, affines, polys, _, _, _)) = value;
-        let mut m_i = m_i.clone();
-        for x in input.raw.iter() {
-          if !table_dict.contains_key(x) {
-            println!("{:?},{:?}", x, -*x);
+        if let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, polys, _, _, _)) = value {
+          let mut m_i = m_i.clone();
+          for x in input.raw.iter() {
+            if !table_dict.contains_key(x) {
+              println!("{:?},{:?}", x, -*x);
+            }
+            m_i.entry(table_dict.get(x).unwrap().clone()).and_modify(|y| *y += 1).or_insert(1);
           }
-          m_i.entry(table_dict.get(x).unwrap().clone()).and_modify(|y| *y += 1).or_insert(1);
+          *value = (
+            Box::new(self.clone()),
+            BatchProveStateValues::CQ(*n, m_i, *T_x_2, polys.clone(), vec![], vec![], vec![]),
+          );
+        } else {
         }
-        affines.push((input.g1 + srs.Y1P * input.r).into());
-        *value = (
-          Box::new(self.clone()),
-          BatchProveStateValues::CQ(*n, m_i, *T_x_2, affines.clone(), polys.clone(), vec![], vec![], vec![]),
-        )
       }
       _ => {
         let mut m_i = HashMap::new();
@@ -154,7 +155,6 @@ impl BasicBlock for CQBasicBlock {
               n,
               m_i,
               setup.1[0].into(),
-              vec![(input.g1 + srs.Y1P * input.r).into()],
               vec![
                 DensePolynomial::from_coefficients_vec(vec![Fr::zero()]),
                 DensePolynomial::from_coefficients_vec(vec![Fr::one()]),
@@ -193,20 +193,21 @@ impl BasicBlock for CQBasicBlock {
     let mut guard = batch_prove_state.lock().unwrap();
     match guard.get_mut(&key) {
       Some(value) => {
-        let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, affines, polys, rngs, _, _)) = value;
-        let beta = if rngs.len() == 0 { Fr::rand(rng) } else { rngs[0] };
-        let B_i: Vec<Fr> = input.raw.iter().map(|x| (*x + beta).inverse().unwrap()).collect();
-        let f_poly = input.poly.clone() + DensePolynomial::from_coefficients_vec(vec![beta]);
-        let B_poly = &polys[0] + &Evaluations::from_vec_and_domain(B_i.clone(), domain_n).interpolate();
-        let f_prod = &polys[1];
-        let diff = &polys[2].mul(&f_poly) + f_prod;
-        let f_prod = f_poly.mul(f_prod);
-        let new_polys = vec![B_poly, f_prod, diff];
-        // avoid cloning
-        *value = (
-          Box::new(self.clone()),
-          BatchProveStateValues::CQ(*n, m_i.clone(), *T_x_2, affines.to_vec(), new_polys, vec![beta], vec![], vec![]),
-        )
+        if let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, polys, rngs, _, _)) = value {
+          let beta = if rngs.len() == 0 { Fr::rand(rng) } else { rngs[0] };
+          let B_i: Vec<Fr> = input.raw.iter().map(|x| (*x + beta).inverse().unwrap()).collect();
+          let f_poly = input.poly.clone() + DensePolynomial::from_coefficients_vec(vec![beta]);
+          let B_poly = &polys[0] + &Evaluations::from_vec_and_domain(B_i.clone(), domain_n).interpolate();
+          let f_prod = &polys[1];
+          let diff = &polys[2].mul(&f_poly) + f_prod;
+          let f_prod = f_poly.mul(f_prod);
+          let new_polys = vec![B_poly, f_prod, diff];
+          *value = (
+            Box::new(self.clone()),
+            BatchProveStateValues::CQ(*n, m_i.clone(), *T_x_2, new_polys, vec![beta], vec![], vec![]),
+          )
+        } else {
+        }
       }
       _ => {}
     };
@@ -239,114 +240,132 @@ impl BasicBlock for CQBasicBlock {
     let mut guard = batch_prove_state.lock().unwrap();
     match guard.get_mut(&key) {
       Some(value) => {
-        let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, affines, polys, rngs, proof_0, proof_2)) = value;
+        if let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, polys, rngs, proof_0, proof_2)) = value {
+          let (proof, mut proof_2) = if proof_0.len() == 0 {
+            let B_poly = &polys[0];
+            let f_prod = &polys[1];
+            let diff = &polys[2];
 
-        let proof = if proof_0.len() == 0 {
-          let B_poly = &polys[0];
-          let f_prod = &polys[1];
-          let diff = &polys[2];
+            let B_Q_poly = B_poly.mul(f_prod).sub(diff).divide_by_vanishing_poly(domain_n).unwrap().0;
+            let B_x = util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs);
+            let B_Q_x = util::msm::<G1Projective>(&srs.X1A, &B_Q_poly.coeffs);
+            let B_zero_div = if B_poly.is_zero() {
+              G1Projective::zero()
+            } else {
+              util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs[1..])
+            };
+            let B_DC = util::msm::<G1Projective>(&srs.X1A[N - *n..], &B_poly.coeffs);
 
-          let B_Q_poly = B_poly.mul(f_prod).sub(diff).divide_by_vanishing_poly(domain_n).unwrap().0;
-          let B_x = util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs);
-          let B_Q_x = util::msm::<G1Projective>(&srs.X1A, &B_Q_poly.coeffs);
-          let B_zero_div = if B_poly.is_zero() {
-            G1Projective::zero()
+            let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
+            let m_x = util::msm::<G1Projective>(&temp, &temp2);
+
+            // Calculate A
+            // element to m/(t + beta)
+            let beta = rngs[0];
+            let A_i: HashMap<usize, Fr> = m_i.iter().map(|(i, y)| (*i, Fr::from(*y as u32) * (model.raw[*i] + beta).inverse().unwrap())).collect();
+            // lagrange basis of value
+            let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_x_1[*i], *y)).unzip();
+            // msm basis with A(x)
+            let A_x = util::msm::<G1Projective>(&temp, &temp2);
+            let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (Q_i_x_1[*i], *y)).unzip();
+            let A_Q_x = util::msm::<G1Projective>(&temp, &temp2);
+            let A_zero = srs.X1P[0] * (Fr::from(N as u32).inverse().unwrap() * A_i.iter().map(|(_, y)| *y).sum::<Fr>());
+            let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_0_x_1[*i], *y)).unzip();
+            let A_zero_div = util::msm::<G1Projective>(&temp, &temp2);
+
+            let mut rng2 = StdRng::from_entropy();
+            let r: Vec<_> = (0..9).map(|_| Fr::rand(&mut rng2)).collect();
+            let commits = vec![m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC];
+            let mut commits: Vec<G1Projective> = commits.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r[i]).collect();
+            let mut C = vec![
+              -(srs.X1P[N] - srs.X1P[0]) * r[2] + model.g1 * r[1] + A_x * model.r + (srs.Y1P * model.r * r[1]) + srs.X1P[0] * (r[1] * beta - r[0]),
+              -srs.X1P[1] * r[4] + srs.X1P[0] * (r[1] - r[3]),
+              -srs.X1P[1] * r[7] + srs.X1P[0] * (r[5] - r[3] * Fr::from(N as u32) * Fr::from(*n as u32).inverse().unwrap()),
+              -srs.X1P[0] * r[8] + srs.X1P[N - *n] * r[5],
+            ];
+            let proof_2 = vec![r[6], r[5], Fr::zero()];
+            commits.append(&mut C);
+            (commits, proof_2)
           } else {
-            util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs[1..])
+            (proof_0.clone(), proof_2.clone())
           };
-          let B_DC = util::msm::<G1Projective>(&srs.X1A[N - *n..], &B_poly.coeffs);
 
-          let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
-          let m_x = util::msm::<G1Projective>(&temp, &temp2);
-
-          // Calculate A
-          // element to m/(t + beta)
-          let beta = rngs[0];
-          let A_i: HashMap<usize, Fr> = m_i.iter().map(|(i, y)| (*i, Fr::from(*y as u32) * (model.raw[*i] + beta).inverse().unwrap())).collect();
-          // lagrange basis of value
-          let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_x_1[*i], *y)).unzip();
-          // msm basis with A(x)
-          let A_x = util::msm::<G1Projective>(&temp, &temp2);
-          let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (Q_i_x_1[*i], *y)).unzip();
-          let A_Q_x = util::msm::<G1Projective>(&temp, &temp2);
-          let A_zero = srs.X1P[0] * (Fr::from(N as u32).inverse().unwrap() * A_i.iter().map(|(_, y)| *y).sum::<Fr>());
-          let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_0_x_1[*i], *y)).unzip();
-          let A_zero_div = util::msm::<G1Projective>(&temp, &temp2);
-
-          let mut rng2 = StdRng::from_entropy();
-          let r: Vec<_> = (0..9).map(|_| Fr::rand(&mut rng2)).collect();
-          let commits = vec![m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC];
-          let mut commits: Vec<G1Projective> = commits.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r[i]).collect();
-          let mut C = vec![
-            -(srs.X1P[N] - srs.X1P[0]) * r[2] + model.g1 * r[1] + A_x * model.r + (srs.Y1P * model.r * r[1]) + srs.X1P[0] * (r[1] * beta - r[0]),
-            -srs.X1P[1] * r[4] + srs.X1P[0] * (r[1] - r[3]),
-            -srs.X1P[1] * r[7] + srs.X1P[0] * (r[5] - r[3] * Fr::from(N as u32) * Fr::from(*n as u32).inverse().unwrap()),
-            -srs.X1P[0] * r[8] + srs.X1P[N - *n] * r[5],
-          ];
-          commits.append(&mut C);
-          commits
+          let zeta = if rngs.len() == 1 { Fr::rand(rng) } else { rngs[1] };
+          let mu = if rngs.len() == 1 { Fr::rand(rng) } else { rngs[2] };
+          let mu_pow = if rngs.len() == 1 { mu } else { rngs[3] * mu };
+          let q1_poly: DensePolynomial<Fr> = &polys[3] + &input.poly.mul(mu_pow);
+          let f_z = input.poly.evaluate(&zeta);
+          proof_2[2] = proof_2[2] + input.r * mu_pow;
+          let mut evals = proof_2.clone();
+          evals.push(f_z);
+          let new_rngs = vec![rngs[0], zeta, mu, mu_pow];
+          let mut new_polys = polys[..3].to_vec();
+          new_polys.push(q1_poly);
+          *value = (
+            Box::new(self.clone()),
+            BatchProveStateValues::CQ(*n, m_i.clone(), *T_x_2, new_polys, new_rngs, proof, evals),
+          )
         } else {
-          proof_0.clone()
-        };
-
-        let zeta = if rngs.len() == 1 { Fr::rand(rng) } else { rngs[1] };
-        let mu = if rngs.len() == 1 { Fr::rand(rng) } else { rngs[2] };
-        let mu_pow = if rngs.len() == 1 { mu } else { rngs[3] * mu };
-        let q1_poly: DensePolynomial<Fr> = &polys[3] + &input.poly.mul(mu_pow);
-        let f_z = input.poly.evaluate(&zeta);
-        let mut evals = proof_2.clone();
-        evals.push(f_z);
-        let new_rngs = vec![rngs[0], zeta, mu];
-        let mut new_polys = polys[..3].to_vec();
-        new_polys.push(q1_poly);
-        *value = (
-          Box::new(self.clone()),
-          BatchProveStateValues::CQ(*n, m_i.clone(), *T_x_2, affines.to_vec(), new_polys, new_rngs, proof, evals),
-        )
+        }
       }
       _ => {}
     }
   }
 
   fn batch_prove(&self, srs: &SRS, batch_prove_values: &BatchProveStateValues, _rng: &mut StdRng) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
-    let BatchProveStateValues::CQ(_, _, T_x_2, _, polys, rngs, proof_0, proof_2) = batch_prove_values;
+    if let BatchProveStateValues::CQ(n, _, T_x_2, polys, rngs, proof_0, proof_2) = batch_prove_values {
+      let zeta = rngs[1];
+      let q1_poly = &polys[3];
+      let q1_z = q1_poly.evaluate(&zeta);
+      let q1_z_poly = DensePolynomial { coeffs: vec![q1_z] };
+      let q1_V = DensePolynomial {
+        coeffs: vec![-zeta, Fr::one()],
+      };
+      let W_poly = &q1_poly.sub(&q1_z_poly) / &q1_V;
+      let W_x = util::msm::<G1Projective>(&srs.X1A, &W_poly.coeffs);
 
-    let zeta = rngs[1];
-    let q1_poly = &polys[3];
-    let q1_z = q1_poly.evaluate(&zeta);
-    let q1_z_poly = DensePolynomial { coeffs: vec![q1_z] };
-    let q1_V = DensePolynomial {
-      coeffs: vec![-zeta, Fr::one()],
-    };
-    let W_poly = &q1_poly.sub(&q1_z_poly) / &q1_V;
-    let W_x = util::msm::<G1Projective>(&srs.X1A, &W_poly.coeffs);
+      let fz_prod: Fr = proof_2[3..].iter().product();
+      let mut rng2 = StdRng::from_entropy();
+      let r = &proof_2[..2];
+      let r_sum = proof_2[2];
+      let C5 = -(srs.X1P[*n] - srs.X1P[0]) * r[0] + srs.X1P[0] * fz_prod * r[1];
+      let r = Fr::rand(&mut rng2);
+      let C6 = -(srs.X1P[1] - srs.X1P[0] * zeta) * r + srs.X1P[0] * r_sum;
 
-    let mut proof = proof_0.clone();
-    proof.push(W_x);
-    (proof, vec![*T_x_2], proof_2.clone())
+      let mut proof = proof_0.clone();
+      proof.append(&mut vec![W_x, C5, C6]);
+      (proof, vec![*T_x_2], proof_2.clone())
+    } else {
+      (vec![], vec![], vec![])
+    }
   }
 
   fn batch_verify_first(
     &self,
     batch_verify_state: &mut BatchVerifyState,
-    _model: &ArrayD<DataEnc>,
+    model: &ArrayD<DataEnc>,
     inputs: &Vec<&ArrayD<DataEnc>>,
     _outputs: &Vec<&ArrayD<DataEnc>>,
     _rng: &mut StdRng,
     _cache: ProveVerifyCache,
   ) {
     let input = inputs[0].first().unwrap();
+    let model = model.first().unwrap();
     let key = format!("{:?}_{}", self, input.len);
     let mut guard = batch_verify_state.lock().unwrap();
     match guard.get_mut(&key) {
       Some(value) => {
-        let (_, BatchVerifyStateValues::CQ(n, g1s)) = value;
+        let (_, BatchVerifyStateValues::CQ(n, N, _, g1s)) = value;
         let mut new_g1s = g1s.clone();
         new_g1s.push(input.g1);
-        *value = (Box::new(self.clone()), BatchVerifyStateValues::CQ(*n, new_g1s))
+        *value = (Box::new(self.clone()), BatchVerifyStateValues::CQ(*n, *N, model.g1, new_g1s))
       }
       _ => {
-        guard.insert(key, (Box::new(self.clone()), BatchVerifyStateValues::CQ(input.len, vec![input.g1])));
+        let N = model.len;
+        guard.insert(
+          key,
+          (Box::new(self.clone()), BatchVerifyStateValues::CQ(input.len, N, model.g1, vec![input.g1])),
+        );
       }
     };
   }
@@ -354,18 +373,12 @@ impl BasicBlock for CQBasicBlock {
   fn batch_verify(
     &self,
     srs: &SRS,
-    model: &ArrayD<DataEnc>,
-    inputs: &Vec<&ArrayD<DataEnc>>,
-    _outputs: &Vec<&ArrayD<DataEnc>>,
     proof: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>),
     batch_verify_values: &BatchVerifyStateValues,
     rng: &mut StdRng,
-    _cache: ProveVerifyCache,
   ) -> Vec<PairingCheck> {
     let mut checks = Vec::new();
-    let N = model.first().unwrap().len;
-    let n = inputs[0].first().unwrap().len;
-    let [m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC, W_x, C1, C2, C3, C4, C5, C6] = proof.0[..] else {
+    let [m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC, C1, C2, C3, C4, W_x, C5, C6] = proof.0[..] else {
       panic!("Wrong proof format")
     };
     let [T_x_2] = proof.1[..] else { panic!("Wrong proof format") };
@@ -375,7 +388,7 @@ impl BasicBlock for CQBasicBlock {
     let zeta = Fr::rand(rng);
     let mu = Fr::rand(rng);
 
-    let BatchVerifyStateValues::CQ(_, f_xs) = batch_verify_values;
+    let BatchVerifyStateValues::CQ(n, N, model_g1, f_xs) = batch_verify_values;
 
     let zetas = util::calc_pow(zeta, f_zs.len());
     let mus = util::calc_pow(mu, f_zs.len());
@@ -388,18 +401,18 @@ impl BasicBlock for CQBasicBlock {
     checks.push(vec![
       (A_x, T_x_2),
       ((A_x * beta - m_x).into(), srs.X2A[0]),
-      (-A_Q_x, (srs.X2A[N] - srs.X2A[0]).into()),
+      (-A_Q_x, (srs.X2A[*N] - srs.X2A[0]).into()),
       (-C1, srs.Y2A),
     ]);
 
     // Check T_x_2 is the G2 equivalent of the model
-    checks.push(vec![(model.first().unwrap().g1, srs.X2A[0]), (srs.X1A[0], -T_x_2)]);
+    checks.push(vec![(*model_g1, srs.X2A[0]), (srs.X1A[0], -T_x_2)]);
 
     // Check A(x) - A(0) is divisible by x
     checks.push(vec![((A_x - A_zero).into(), srs.X2A[0]), (-A_zero_div, srs.X2A[1]), (-C2, srs.Y2A)]);
 
     // Assume B(0) = A(0)*N/n (which assumes ∑A=∑B)
-    let B_0: G1Affine = (A_zero * (Fr::from(N as u32) * Fr::from(n as u32).inverse().unwrap())).into();
+    let B_0: G1Affine = (A_zero * (Fr::from(*N as u32) * Fr::from(*n as u32).inverse().unwrap())).into();
 
     // Check B(x) - B(0) is divisible by x
     checks.push(vec![((B_x - B_0).into(), srs.X2A[0]), (-B_zero_div, srs.X2A[1]), (-C3, srs.Y2A)]);
@@ -408,7 +421,6 @@ impl BasicBlock for CQBasicBlock {
     checks.push(vec![(B_x, srs.X2A[N - n]), (-B_DC, srs.X2A[0]), (-C4, srs.Y2A)]);
 
     // Check B(x) (B_i = sum ())
-    // add C5
     checks.push(vec![
       (
         (B_x * fz_prod - srs.X1A[0] * diff - B_Q_x * (zetas[n - 1] - Fr::one())).into(),
@@ -417,9 +429,10 @@ impl BasicBlock for CQBasicBlock {
       (-C5, srs.Y2A),
     ]);
 
-    // add C6
+    // Check W(x) (W(x) = (F(x) - F(zeta)) / (x - zeta))
+    // where F(x) is RLC'd input polynomials
     checks.push(vec![
-      ((W_x, (srs.X2P[1] - srs.X2A[0] * zeta).into())),
+      ((-W_x, (srs.X2P[1] - srs.X2A[0] * zeta).into())),
       ((f_sum - srs.X1A[0] * fz_sum).into(), srs.X2A[0]),
       (-C6, srs.Y2A),
     ]);

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -92,103 +92,6 @@ impl BasicBlock for CQBasicBlock {
     return (setup, vec![srs.X2P[0]], Vec::new());
   }
 
-  fn prove(
-    &self,
-    srs: &SRS,
-    setup: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<DensePolynomial<Fr>>),
-    model: &ArrayD<Data>,
-    inputs: &Vec<&ArrayD<Data>>,
-    _outputs: &Vec<&ArrayD<Data>>,
-    rng: &mut StdRng,
-    cache: ProveVerifyCache,
-  ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
-    assert!(inputs.len() == 1 && inputs[0].len() == 1);
-    let model = &model.first().unwrap();
-    let input = &inputs[0].first().unwrap();
-    let N = model.raw.len();
-    let n = input.raw.len();
-    assert!(n <= N);
-    let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
-
-    // gen(N, t):
-    let Q_i_x_1 = &setup.0[..N];
-    let L_i_x_1 = &setup.0[N..2 * N];
-    let L_i_0_x_1 = &setup.0[2 * N..];
-    let m_i = {
-      let mut cache = cache.lock().unwrap();
-      let CacheValues::CQTableDict(table_dict) =
-        cache.entry(format!("cq_table_dict_{:p}", self)).or_insert_with(|| CacheValues::CQTableDict(HashMap::new()))
-      else {
-        panic!("Cache type error")
-      };
-      if table_dict.len() == 0 {
-        for i in 0..N {
-          table_dict.insert(model.raw[i], i);
-        }
-      }
-
-      // Calculate m
-      let mut m_i = HashMap::new();
-      for x in input.raw.iter() {
-        if !table_dict.contains_key(x) {
-          println!("{:?},{:?}", x, -*x);
-        }
-        m_i.entry(table_dict.get(x).unwrap().clone()).and_modify(|y| *y += 1).or_insert(1);
-      }
-      m_i
-    };
-    let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
-    let m_x = util::msm::<G1Projective>(&temp, &temp2);
-
-    let beta = Fr::rand(rng);
-
-    // Calculate A
-    let A_i: HashMap<usize, Fr> = m_i.iter().map(|(i, y)| (*i, Fr::from(*y as u32) * (model.raw[*i] + beta).inverse().unwrap())).collect();
-    let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_x_1[*i], *y)).unzip();
-    let A_x = util::msm::<G1Projective>(&temp, &temp2);
-    let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (Q_i_x_1[*i], *y)).unzip();
-    let A_Q_x = util::msm::<G1Projective>(&temp, &temp2);
-    let A_zero = srs.X1P[0] * (Fr::from(N as u32).inverse().unwrap() * A_i.iter().map(|(_, y)| *y).sum::<Fr>());
-    let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_0_x_1[*i], *y)).unzip();
-    let A_zero_div = util::msm::<G1Projective>(&temp, &temp2);
-
-    // Calculate B
-    let B_i: Vec<Fr> = input.raw.iter().map(|x| (*x + beta).inverse().unwrap()).collect();
-    let B_poly = Evaluations::from_vec_and_domain(B_i.clone(), domain_n).interpolate();
-    let B_Q_poly = B_poly
-      .mul(&(input.poly.clone() + (DensePolynomial::from_coefficients_vec(vec![beta]))))
-      .sub(&DensePolynomial::from_coefficients_vec(vec![Fr::one()]))
-      .divide_by_vanishing_poly(domain_n)
-      .unwrap()
-      .0;
-    let B_x = util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs);
-    let B_Q_x = util::msm::<G1Projective>(&srs.X1A, &B_Q_poly.coeffs);
-    let B_zero_div = if B_poly.is_zero() {
-      G1Projective::zero()
-    } else {
-      util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs[1..])
-    };
-    let B_DC = util::msm::<G1Projective>(&srs.X1A[N - n..], &B_poly.coeffs);
-
-    let f_x_2 = util::msm::<G2Projective>(&srs.X2A, &input.poly.coeffs) + srs.Y2P * input.r;
-
-    // Blinding
-    let mut rng2 = StdRng::from_entropy();
-    let r: Vec<_> = (0..9).map(|_| Fr::rand(&mut rng2)).collect();
-    let proof: Vec<G1Projective> = vec![m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC];
-    let mut proof: Vec<G1Projective> = proof.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r[i]).collect();
-    let mut C = vec![
-      -(srs.X1P[N] - srs.X1P[0]) * r[2] + model.g1 * r[1] + A_x * model.r + (srs.Y1P * model.r * r[1]) + srs.X1P[0] * (r[1] * beta - r[0]),
-      -srs.X1P[1] * r[4] + srs.X1P[0] * (r[1] - r[3]),
-      -(srs.X1P[n] - srs.X1P[0]) * r[6] + input.g1 * r[5] + B_x * input.r + (srs.Y1P * input.r * r[5]) + srs.X1P[0] * (r[5] * beta),
-      -srs.X1P[1] * r[7] + srs.X1P[0] * (r[5] - r[3] * Fr::from(N as u32) * Fr::from(n as u32).inverse().unwrap()),
-      -srs.X1P[0] * r[8] + srs.X1P[N - n] * r[5],
-    ];
-    proof.append(&mut C);
-
-    return (proof, vec![setup.1[0].into(), f_x_2], Vec::new());
-  }
-
   fn batch_prove_first(
     &self,
     srs: &SRS,
@@ -407,57 +310,8 @@ impl BasicBlock for CQBasicBlock {
 
   fn batch_prove(&self, srs: &SRS, batch_prove_values: &BatchProveStateValues, _rng: &mut StdRng) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let BatchProveStateValues::CQ(_, _, T_x_2, _, polys, rngs, proof_0, proof_2) = batch_prove_values;
-    // let model = &model.first().unwrap();
-    // let N = model.raw.len();
-
-    // // gen(N, t):
-    // let Q_i_x_1 = &setup.0[..N];
-    // let L_i_x_1 = &setup.0[N..2 * N];
-    // let L_i_0_x_1 = &setup.0[2 * N..];
-
-    // assert!(n <= N);
-    // let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
-
-    // let B_poly = &polys[0];
-    // let f_prod = &polys[1];
-    // let diff = &polys[2];
-
-    // // let diffs: Vec<_> = f_polys.iter().map(|x| &f_prod / &x).collect();
-    // // let diff = diffs.iter().fold(DensePolynomial::zero(), |acc, p| &acc + p);
-    // let B_Q_poly = B_poly.mul(f_prod).sub(diff).divide_by_vanishing_poly(domain_n).unwrap().0;
-    // let B_x = util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs);
-    // let B_Q_x = util::msm::<G1Projective>(&srs.X1A, &B_Q_poly.coeffs);
-    // let B_zero_div = if B_poly.is_zero() {
-    //   G1Projective::zero()
-    // } else {
-    //   util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs[1..])
-    // };
-    // let B_DC = util::msm::<G1Projective>(&srs.X1A[N - n..], &B_poly.coeffs);
-
-    // let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
-    // let m_x = util::msm::<G1Projective>(&temp, &temp2);
-
-    // // Calculate A
-    // // element to m/(t + beta)
-    // let beta = beta_opt.unwrap();
-    // let A_i: HashMap<usize, Fr> = m_i.iter().map(|(i, y)| (*i, Fr::from(*y as u32) * (model.raw[*i] + beta).inverse().unwrap())).collect();
-    // // lagrange basis of value
-    // let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_x_1[*i], *y)).unzip();
-    // // msm basis with A(x)
-    // let A_x = util::msm::<G1Projective>(&temp, &temp2);
-    // let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (Q_i_x_1[*i], *y)).unzip();
-    // let A_Q_x = util::msm::<G1Projective>(&temp, &temp2);
-    // let A_zero = srs.X1P[0] * (Fr::from(N as u32).inverse().unwrap() * A_i.iter().map(|(_, y)| *y).sum::<Fr>());
-    // let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_0_x_1[*i], *y)).unzip();
-    // let A_zero_div = util::msm::<G1Projective>(&temp, &temp2);
-
-    // let zeta = Fr::rand(rng);
-    // let f_zs: Vec<_> = f_polys.iter().map(|p| p.evaluate(&zeta)).collect();
 
     let zeta = rngs[1];
-    // let v = Fr::rand(rng);
-    // let vs = util::calc_pow(v, f_polys.len());
-    // let q1_poly: DensePolynomial<Fr> = f_polys.iter().enumerate().fold(DensePolynomial::zero(), |acc, (i, p)| acc + p.mul(vs[i]));
     let q1_poly = &polys[3];
     let q1_z = q1_poly.evaluate(&zeta);
     let q1_z_poly = DensePolynomial { coeffs: vec![q1_z] };
@@ -467,77 +321,9 @@ impl BasicBlock for CQBasicBlock {
     let W_poly = &q1_poly.sub(&q1_z_poly) / &q1_V;
     let W_x = util::msm::<G1Projective>(&srs.X1A, &W_poly.coeffs);
 
-    // Blinding
-    // let mut rng2 = StdRng::from_entropy();
-    // let r: Vec<_> = (0..9).map(|_| Fr::rand(&mut rng2)).collect();
-    // let proof: Vec<G1Projective> = vec![m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC, W_x];
-    // let mut proof: Vec<G1Projective> = proof.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r[i]).collect();
-    // let mut C = vec![
-    //   -(srs.X1P[N] - srs.X1P[0]) * r[2] + model.g1 * r[1] + A_x * model.r + (srs.Y1P * model.r * r[1]) + srs.X1P[0] * (r[1] * beta - r[0]),
-    //   -srs.X1P[1] * r[4] + srs.X1P[0] * (r[1] - r[3]),
-    //   -srs.X1P[1] * r[7] + srs.X1P[0] * (r[5] - r[3] * Fr::from(N as u32) * Fr::from(n as u32).inverse().unwrap()),
-    //   -srs.X1P[0] * r[8] + srs.X1P[N - n] * r[5],
-    // ];
-    // proof.append(&mut C);
     let mut proof = proof_0.clone();
     proof.push(W_x);
     (proof, vec![*T_x_2], proof_2.clone())
-  }
-
-  fn verify(
-    &self,
-    srs: &SRS,
-    model: &ArrayD<DataEnc>,
-    inputs: &Vec<&ArrayD<DataEnc>>,
-    _outputs: &Vec<&ArrayD<DataEnc>>,
-    proof: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>),
-    rng: &mut StdRng,
-    _cache: ProveVerifyCache,
-  ) -> Vec<PairingCheck> {
-    let mut checks = Vec::new();
-    let N = model.first().unwrap().len;
-    let n = inputs[0].first().unwrap().len;
-    let [m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC, C1, C2, C3, C4, C5] = proof.0[..] else {
-      panic!("Wrong proof format")
-    };
-    let [T_x_2, f_x_2] = proof.1[..] else { panic!("Wrong proof format") };
-
-    let beta = Fr::rand(rng);
-
-    // Check A(x) (A_i = m_i/(t_i+beta))
-    checks.push(vec![
-      (A_x, T_x_2),
-      ((A_x * beta - m_x).into(), srs.X2A[0]),
-      (-A_Q_x, (srs.X2A[N] - srs.X2A[0]).into()),
-      (-C1, srs.Y2A),
-    ]);
-
-    // Check T_x_2 is the G2 equivalent of the model
-    checks.push(vec![(model.first().unwrap().g1, srs.X2A[0]), (srs.X1A[0], -T_x_2)]);
-
-    // Check A(x) - A(0) is divisible by x
-    checks.push(vec![((A_x - A_zero).into(), srs.X2A[0]), (-A_zero_div, srs.X2A[1]), (-C2, srs.Y2A)]);
-
-    // Check B(x) (B_i = 1/(f_i+beta))
-    checks.push(vec![
-      (B_x, f_x_2),
-      ((B_x * beta - srs.X1A[0]).into(), srs.X2A[0]),
-      (-B_Q_x, (srs.X2A[n] - srs.X2A[0]).into()),
-      (-C3, srs.Y2A),
-    ]);
-
-    // Check f_x_2 is the G2 equivalent of the input
-    checks.push(vec![(inputs[0].first().unwrap().g1, srs.X2A[0]), (srs.X1A[0], -f_x_2)]);
-
-    // Assume B(0) = A(0)*N/n (which assumes ∑A=∑B)
-    let B_0: G1Affine = (A_zero * (Fr::from(N as u32) * Fr::from(n as u32).inverse().unwrap())).into();
-
-    // Check B(x) - B(0) is divisible by x
-    checks.push(vec![((B_x - B_0).into(), srs.X2A[0]), (-B_zero_div, srs.X2A[1]), (-C4, srs.Y2A)]);
-
-    // Degree check B
-    checks.push(vec![(B_x, srs.X2A[N - n]), (-B_DC, srs.X2A[0]), (-C5, srs.Y2A)]);
-    checks
   }
 
   fn batch_verify_first(

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -22,6 +22,7 @@ use std::{
   cmp::max,
   collections::HashMap,
   sync::{Arc, Mutex},
+  time::Instant,
 };
 
 #[derive(Debug, Clone)]
@@ -208,7 +209,10 @@ impl BasicBlock for CQBasicBlock {
           let f_poly = &input.poly + &DensePolynomial::from_coefficients_vec(vec![beta]);
           let B_poly = &polys[0] + &Evaluations::from_vec_and_domain(B_i.clone(), domain_n).interpolate();
           let f_prod = &polys[1];
+          let start = Instant::now();
           let diff = &polys[2].mul(&f_poly) + f_prod;
+          let duration = start.elapsed();
+          println!("diff deg {}, time: {:?}", diff.degree(), duration);
           let f_prod = f_poly.mul(f_prod);
           let new_polys = vec![B_poly, f_prod, diff];
           *value = (
@@ -273,6 +277,9 @@ impl BasicBlock for CQBasicBlock {
             // Calculate A
             // element to m/(t + beta)
             let beta = rngs[0];
+            // let betas = util::calc_pow(beta, *n);
+            // assert!(&B_poly.evaluate(&beta) * &f_prod.evaluate(&beta) - Fr::one() == *&B_Q_poly.evaluate(&beta) * (betas[*n - 1] - Fr::one()));
+
             let A_i: HashMap<usize, Fr> = m_ref.iter().map(|(i, y)| (*i, Fr::from(*y as u32) * (model.raw[*i] + beta).inverse().unwrap())).collect();
             // lagrange basis of value
             let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_x_1[*i], *y)).unzip();
@@ -285,7 +292,7 @@ impl BasicBlock for CQBasicBlock {
             let A_zero_div = util::msm::<G1Projective>(&temp, &temp2);
 
             let mut rng2 = StdRng::from_entropy();
-            let r: Vec<_> = (0..10).map(|_| Fr::rand(&mut rng2)).collect();
+            let r: Vec<_> = (0..9).map(|_| Fr::rand(&mut rng2)).collect();
             let commits = vec![m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC];
             let mut commits: Vec<G1Projective> = commits.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r[i]).collect();
             let mut C = vec![
@@ -294,6 +301,9 @@ impl BasicBlock for CQBasicBlock {
               -srs.X1P[1] * r[7] + srs.X1P[0] * (r[5] - r[3] * Fr::from(N as u32) * Fr::from(*n as u32).inverse().unwrap()),
               -srs.X1P[0] * r[8] + srs.X1P[N - *n] * r[5],
             ];
+            if proof_2.borrow().len() < 2 {
+              proof_2.borrow_mut().push(Fr::zero());
+            }
             proof_2.borrow_mut().append(&mut vec![r[5], r[6], Fr::zero()]);
             commits.append(&mut C);
             (commits, proof_2)
@@ -305,10 +315,6 @@ impl BasicBlock for CQBasicBlock {
           let zeta = if rngs.len() == 1 { Fr::rand(rng) } else { rngs[1] };
           let mu = if rngs.len() == 1 { Fr::rand(rng) } else { rngs[2] };
           let mu_pow = if rngs.len() == 1 { mu } else { rngs[3] * mu };
-          // println!("beta {:?}", beta);
-          // println!("zeta {:?}", zeta);
-          // println!("mu {:?}", mu);
-          // println!("mu_pow {:?}", mu_pow);
           let f_poly = &input.poly + &DensePolynomial::from_coefficients_vec(vec![beta]);
           let q1_poly: DensePolynomial<Fr> = if polys.len() < 4 {
             f_poly.mul(mu_pow)
@@ -352,21 +358,20 @@ impl BasicBlock for CQBasicBlock {
       let p_ref = proof_2.borrow();
       let f_zs = &p_ref[5..];
       let fz_prod: Fr = f_zs.iter().product();
-      let diff_prod: Fr = f_zs[1..].iter().product();
-      let diffs: Vec<_> = f_zs[1..].iter().map(|x| diff_prod / x).collect();
-      let diffs_sum: Fr = diffs.iter().sum();
-      // println!("diff_prod {:?}", diff_prod);
-      // println!("diffs {:?}", diffs);
-      // println!("diffs_sum {:?}", diffs_sum);
-      // println!("fz_prod {:?}", fz_prod);
-      // println!("f_prod {:?}", f_prod.evaluate(&zeta));
-      // println!("diff: {:?}", diff.evaluate(&zeta));
       let mut rng2 = StdRng::from_entropy();
       // [input0.r, input1.r, B_x, B_Q_x]
       let r = &p_ref[..4];
       let r_sum = p_ref[4];
       let zetas = util::calc_pow(zeta, *n);
-      let C5 = -srs.X1P[0] * (zetas[n - 1] - Fr::one()) * r[3] + srs.X1P[0] * (fz_prod * r[2] - diffs_sum * r[0] - diffs[0] * r[1]);
+      let diff_r = if f_zs.len() == 1 {
+        Fr::zero()
+      } else {
+        let diff_prod: Fr = f_zs[1..].iter().product();
+        let diffs: Vec<_> = f_zs[1..].iter().map(|x| diff_prod / x).collect();
+        let diffs_sum: Fr = diffs.iter().sum();
+        diffs_sum * r[0] + diffs[0] * r[1]
+      };
+      let C5 = srs.X1P[0] * (fz_prod * r[2] - diff_r - (zetas[n - 1] - Fr::one()) * r[3]);
       let r = Fr::rand(&mut rng2);
       let C6 = -(srs.X1P[1] - srs.X1P[0] * zeta) * r + srs.X1P[0] * r_sum;
 
@@ -433,16 +438,16 @@ impl BasicBlock for CQBasicBlock {
     let mus = util::calc_pow(mu, m);
     let fz_sum: Fr = f_zs.iter().enumerate().map(|(i, x)| *x * mus[i]).sum();
     let fz_prod: Fr = f_zs.iter().product();
-    // println!("fz_prod {:?}", fz_prod);
-    // println!("diff {:?}", diff);
     let f_sum: G1Projective = f_xs.iter().enumerate().map(|(i, x)| (*x + srs.X1A[0] * beta) * mus[i]).sum();
 
-    let diff_prod: Fr = f_zs[1..].iter().product();
-    let diffs: Vec<_> = f_zs[1..].iter().map(|x| diff_prod / x).collect();
-    let diffs_sum: Fr = diffs.iter().sum();
-    println!("diff_prod {:?}", diff_prod);
-    println!("diffs_sum {:?}", diffs_sum);
-    let diff_g1 = (f_xs[0] + srs.X1A[0] * beta) * diffs_sum + (f_xs[1] + srs.X1A[0] * beta) * diffs[0];
+    let diff_g1 = if f_zs.len() == 1 {
+      srs.X1P[0]
+    } else {
+      let diff_prod: Fr = f_zs[1..].iter().product();
+      let diffs: Vec<_> = f_zs[1..].iter().map(|x| diff_prod / x).collect();
+      let diffs_sum: Fr = diffs.iter().sum();
+      (f_xs[0] + srs.X1A[0] * beta) * diffs_sum + (f_xs[1] + srs.X1A[0] * beta) * diffs[0]
+    };
 
     // Check A(x) (A_i = m_i/(t_i+beta))
     checks.push(vec![

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -17,7 +17,12 @@ use ark_std::{
 use ndarray::{Array1, ArrayD};
 use rand::{rngs::StdRng, SeedableRng};
 use rayon::prelude::*;
-use std::{cmp::max, collections::HashMap};
+use std::{
+  cell::RefCell,
+  cmp::max,
+  collections::HashMap,
+  sync::{Arc, Mutex},
+};
 
 #[derive(Debug, Clone)]
 pub struct CQBasicBlock {
@@ -94,7 +99,7 @@ impl BasicBlock for CQBasicBlock {
 
   fn batch_prove_first(
     &self,
-    srs: &SRS,
+    _srs: &SRS,
     setup: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<DensePolynomial<Fr>>),
     batch_prove_state: &mut BatchProveState,
     model: &ArrayD<Data>,
@@ -125,16 +130,15 @@ impl BasicBlock for CQBasicBlock {
     match guard.get_mut(&key) {
       Some(value) => {
         if let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, polys, _, _, _)) = value {
-          let mut m_i = m_i.clone();
           for x in input.raw.iter() {
             if !table_dict.contains_key(x) {
               println!("{:?},{:?}", x, -*x);
             }
-            m_i.entry(table_dict.get(x).unwrap().clone()).and_modify(|y| *y += 1).or_insert(1);
+            m_i.borrow_mut().entry(table_dict.get(x).unwrap().clone()).and_modify(|y| *y += 1).or_insert(1);
           }
           *value = (
             Box::new(self.clone()),
-            BatchProveStateValues::CQ(*n, m_i, *T_x_2, polys.clone(), vec![], vec![], vec![]),
+            BatchProveStateValues::CQ(*n, RefCell::clone(m_i), *T_x_2, polys.clone(), vec![], vec![], RefCell::new(vec![])),
           );
         } else {
         }
@@ -153,7 +157,7 @@ impl BasicBlock for CQBasicBlock {
             Box::new(self.clone()),
             BatchProveStateValues::CQ(
               n,
-              m_i,
+              RefCell::new(m_i),
               setup.1[0].into(),
               vec![
                 DensePolynomial::from_coefficients_vec(vec![Fr::zero()]),
@@ -163,7 +167,7 @@ impl BasicBlock for CQBasicBlock {
               ],
               vec![],
               vec![],
-              vec![],
+              RefCell::new(vec![]),
             ),
           ),
         );
@@ -196,15 +200,20 @@ impl BasicBlock for CQBasicBlock {
         if let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, polys, rngs, _, _)) = value {
           let beta = if rngs.len() == 0 { Fr::rand(rng) } else { rngs[0] };
           let B_i: Vec<Fr> = input.raw.iter().map(|x| (*x + beta).inverse().unwrap()).collect();
-          let f_poly = input.poly.clone() + DensePolynomial::from_coefficients_vec(vec![beta]);
+          let f_poly = &input.poly + &DensePolynomial::from_coefficients_vec(vec![beta]);
           let B_poly = &polys[0] + &Evaluations::from_vec_and_domain(B_i.clone(), domain_n).interpolate();
           let f_prod = &polys[1];
           let diff = &polys[2].mul(&f_poly) + f_prod;
           let f_prod = f_poly.mul(f_prod);
+          // let f_prod_0 = if polys.len() < 3 {
+          //   DensePolynomial::from_coefficients_vec(vec![Fr::one()])
+          // } else {
+          //   f_poly.mul(&polys[3])
+          // };
           let new_polys = vec![B_poly, f_prod, diff];
           *value = (
             Box::new(self.clone()),
-            BatchProveStateValues::CQ(*n, m_i.clone(), *T_x_2, new_polys, vec![beta], vec![], vec![]),
+            BatchProveStateValues::CQ(*n, RefCell::clone(m_i), *T_x_2, new_polys, vec![beta], vec![], RefCell::new(vec![])),
           )
         } else {
         }
@@ -241,7 +250,7 @@ impl BasicBlock for CQBasicBlock {
     match guard.get_mut(&key) {
       Some(value) => {
         if let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, polys, rngs, proof_0, proof_2)) = value {
-          let (proof, mut proof_2) = if proof_0.len() == 0 {
+          let (proof, proof_2) = if proof_0.len() == 0 {
             let B_poly = &polys[0];
             let f_prod = &polys[1];
             let diff = &polys[2];
@@ -249,6 +258,7 @@ impl BasicBlock for CQBasicBlock {
             let B_Q_poly = B_poly.mul(f_prod).sub(diff).divide_by_vanishing_poly(domain_n).unwrap().0;
             let B_x = util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs);
             let B_Q_x = util::msm::<G1Projective>(&srs.X1A, &B_Q_poly.coeffs);
+            // let diff_x = util::msm::<G1Projective>(&srs.X1A, &diff.coeffs);
             let B_zero_div = if B_poly.is_zero() {
               G1Projective::zero()
             } else {
@@ -256,13 +266,14 @@ impl BasicBlock for CQBasicBlock {
             };
             let B_DC = util::msm::<G1Projective>(&srs.X1A[N - *n..], &B_poly.coeffs);
 
-            let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
+            let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.borrow().iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
             let m_x = util::msm::<G1Projective>(&temp, &temp2);
 
             // Calculate A
             // element to m/(t + beta)
             let beta = rngs[0];
-            let A_i: HashMap<usize, Fr> = m_i.iter().map(|(i, y)| (*i, Fr::from(*y as u32) * (model.raw[*i] + beta).inverse().unwrap())).collect();
+            let A_i: HashMap<usize, Fr> =
+              m_i.borrow().iter().map(|(i, y)| (*i, Fr::from(*y as u32) * (model.raw[*i] + beta).inverse().unwrap())).collect();
             // lagrange basis of value
             let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_x_1[*i], *y)).unzip();
             // msm basis with A(x)
@@ -274,7 +285,7 @@ impl BasicBlock for CQBasicBlock {
             let A_zero_div = util::msm::<G1Projective>(&temp, &temp2);
 
             let mut rng2 = StdRng::from_entropy();
-            let r: Vec<_> = (0..9).map(|_| Fr::rand(&mut rng2)).collect();
+            let r: Vec<_> = (0..10).map(|_| Fr::rand(&mut rng2)).collect();
             let commits = vec![m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC];
             let mut commits: Vec<G1Projective> = commits.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r[i]).collect();
             let mut C = vec![
@@ -283,27 +294,39 @@ impl BasicBlock for CQBasicBlock {
               -srs.X1P[1] * r[7] + srs.X1P[0] * (r[5] - r[3] * Fr::from(N as u32) * Fr::from(*n as u32).inverse().unwrap()),
               -srs.X1P[0] * r[8] + srs.X1P[N - *n] * r[5],
             ];
-            let proof_2 = vec![r[6], r[5], Fr::zero()];
+            let proof_2 = RefCell::new(vec![r[5], r[6], Fr::zero()]);
             commits.append(&mut C);
             (commits, proof_2)
           } else {
-            (proof_0.clone(), proof_2.clone())
+            (proof_0.clone(), RefCell::clone(proof_2))
           };
 
+          let beta = rngs[0];
           let zeta = if rngs.len() == 1 { Fr::rand(rng) } else { rngs[1] };
           let mu = if rngs.len() == 1 { Fr::rand(rng) } else { rngs[2] };
           let mu_pow = if rngs.len() == 1 { mu } else { rngs[3] * mu };
-          let q1_poly: DensePolynomial<Fr> = &polys[3] + &input.poly.mul(mu_pow);
-          let f_z = input.poly.evaluate(&zeta);
-          proof_2[2] = proof_2[2] + input.r * mu_pow;
-          let mut evals = proof_2.clone();
-          evals.push(f_z);
+          // println!("beta {:?}", beta);
+          // println!("zeta {:?}", zeta);
+          // println!("mu {:?}", mu);
+          // println!("mu_pow {:?}", mu_pow);
+          let f_poly = &input.poly + &DensePolynomial::from_coefficients_vec(vec![beta]);
+          let q1_poly: DensePolynomial<Fr> = if polys.len() < 4 {
+            f_poly.mul(mu_pow)
+          } else {
+            &polys[3] + &input.poly.mul(mu_pow)
+          };
+
+          let f_z = f_poly.evaluate(&zeta);
+          let agg_r = proof_2.borrow()[2];
+          proof_2.borrow_mut()[2] = agg_r + input.r * mu_pow;
+          proof_2.borrow_mut().push(f_z);
+
           let new_rngs = vec![rngs[0], zeta, mu, mu_pow];
           let mut new_polys = polys[..3].to_vec();
           new_polys.push(q1_poly);
           *value = (
             Box::new(self.clone()),
-            BatchProveStateValues::CQ(*n, m_i.clone(), *T_x_2, new_polys, new_rngs, proof, evals),
+            BatchProveStateValues::CQ(*n, RefCell::clone(m_i), *T_x_2, new_polys, new_rngs, proof, proof_2),
           )
         } else {
         }
@@ -315,6 +338,8 @@ impl BasicBlock for CQBasicBlock {
   fn batch_prove(&self, srs: &SRS, batch_prove_values: &BatchProveStateValues, _rng: &mut StdRng) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     if let BatchProveStateValues::CQ(n, _, T_x_2, polys, rngs, proof_0, proof_2) = batch_prove_values {
       let zeta = rngs[1];
+      // let diff = &polys[2];
+      // let f_prod = &polys[1];
       let q1_poly = &polys[3];
       let q1_z = q1_poly.evaluate(&zeta);
       let q1_z_poly = DensePolynomial { coeffs: vec![q1_z] };
@@ -324,17 +349,21 @@ impl BasicBlock for CQBasicBlock {
       let W_poly = &q1_poly.sub(&q1_z_poly) / &q1_V;
       let W_x = util::msm::<G1Projective>(&srs.X1A, &W_poly.coeffs);
 
-      let fz_prod: Fr = proof_2[3..].iter().product();
+      let fz_prod: Fr = proof_2.borrow()[3..].iter().product();
+      // println!("fz_prod {:?}", fz_prod);
+      // println!("f_prod {:?}", f_prod.evaluate(&zeta));
+      // println!("diff: {:?}", diff.evaluate(&zeta));
       let mut rng2 = StdRng::from_entropy();
-      let r = &proof_2[..2];
-      let r_sum = proof_2[2];
-      let C5 = -(srs.X1P[*n] - srs.X1P[0]) * r[0] + srs.X1P[0] * fz_prod * r[1];
+      let r = &proof_2.borrow()[..2];
+      let r_sum = proof_2.borrow()[2];
+      let zetas = util::calc_pow(zeta, *n);
+      let C5 = -srs.X1P[0] * (zetas[n - 1] - Fr::one()) * r[1] + srs.X1P[0] * fz_prod * r[0];
       let r = Fr::rand(&mut rng2);
       let C6 = -(srs.X1P[1] - srs.X1P[0] * zeta) * r + srs.X1P[0] * r_sum;
 
       let mut proof = proof_0.clone();
-      proof.append(&mut vec![W_x, C5, C6]);
-      (proof, vec![*T_x_2], proof_2.clone())
+      proof.append(&mut vec![W_x + srs.Y1P * r, C5, C6]);
+      (proof, vec![*T_x_2], proof_2.borrow()[3..].to_vec())
     } else {
       (vec![], vec![], vec![])
     }
@@ -390,11 +419,14 @@ impl BasicBlock for CQBasicBlock {
 
     let BatchVerifyStateValues::CQ(n, N, model_g1, f_xs) = batch_verify_values;
 
-    let zetas = util::calc_pow(zeta, f_zs.len());
-    let mus = util::calc_pow(mu, f_zs.len());
+    let m = f_zs.len();
+    let zetas = util::calc_pow(zeta, *n);
+    let mus = util::calc_pow(mu, m);
     let fz_sum: Fr = f_zs.iter().enumerate().map(|(i, x)| *x * mus[i]).sum();
     let fz_prod = f_zs.iter().product();
+    // println!("fz_prod {:?}", fz_prod);
     let diff: Fr = f_zs.iter().map(|x| &fz_prod / x).sum();
+    // println!("diff {:?}", diff);
     let f_sum: G1Projective = f_xs.iter().enumerate().map(|(i, x)| (*x + srs.X1A[0] * beta) * mus[i]).sum();
 
     // Check A(x) (A_i = m_i/(t_i+beta))
@@ -423,7 +455,7 @@ impl BasicBlock for CQBasicBlock {
     // Check B(x) (B_i = sum ())
     checks.push(vec![
       (
-        (B_x * fz_prod - srs.X1A[0] * diff - B_Q_x * (zetas[n - 1] - Fr::one())).into(),
+        (B_x * fz_prod - srs.X1A[0] * diff - B_Q_x * (zetas[*n - 1] - Fr::one())).into(),
         srs.X2A[0],
       ),
       (-C5, srs.Y2A),

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -126,19 +126,24 @@ impl BasicBlock for CQBasicBlock {
         table_dict.insert(model.raw[i], i);
       }
     }
-    let mut guard = batch_prove_state.lock().unwrap();
-    match guard.get_mut(&key) {
+    let mut state_mut_ref = batch_prove_state.borrow_mut();
+    match state_mut_ref.get_mut(&key) {
       Some(value) => {
-        if let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, polys, _, _, _)) = value {
+        if let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, polys, _, _, proof_2)) = value {
           for x in input.raw.iter() {
             if !table_dict.contains_key(x) {
               println!("{:?},{:?}", x, -*x);
             }
             m_i.borrow_mut().entry(table_dict.get(x).unwrap().clone()).and_modify(|y| *y += 1).or_insert(1);
           }
+          let mut p_ref = proof_2.borrow_mut();
+          if p_ref.len() < 2 {
+            p_ref.push(input.r);
+          }
+          drop(p_ref);
           *value = (
             Box::new(self.clone()),
-            BatchProveStateValues::CQ(*n, RefCell::clone(m_i), *T_x_2, polys.clone(), vec![], vec![], RefCell::new(vec![])),
+            BatchProveStateValues::CQ(*n, RefCell::clone(m_i), *T_x_2, polys.clone(), vec![], vec![], RefCell::clone(proof_2)),
           );
         } else {
         }
@@ -151,7 +156,7 @@ impl BasicBlock for CQBasicBlock {
           }
           m_i.entry(table_dict.get(x).unwrap().clone()).and_modify(|y| *y += 1).or_insert(1);
         }
-        guard.insert(
+        state_mut_ref.insert(
           key,
           (
             Box::new(self.clone()),
@@ -167,7 +172,7 @@ impl BasicBlock for CQBasicBlock {
               ],
               vec![],
               vec![],
-              RefCell::new(vec![]),
+              RefCell::new(vec![input.r]),
             ),
           ),
         );
@@ -194,10 +199,10 @@ impl BasicBlock for CQBasicBlock {
     let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
 
     let key = format!("{:?}_{}", self, input.raw.len());
-    let mut guard = batch_prove_state.lock().unwrap();
-    match guard.get_mut(&key) {
+    let mut state_mut_ref = batch_prove_state.borrow_mut();
+    match state_mut_ref.get_mut(&key) {
       Some(value) => {
-        if let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, polys, rngs, _, _)) = value {
+        if let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, polys, rngs, _, proof_2)) = value {
           let beta = if rngs.len() == 0 { Fr::rand(rng) } else { rngs[0] };
           let B_i: Vec<Fr> = input.raw.iter().map(|x| (*x + beta).inverse().unwrap()).collect();
           let f_poly = &input.poly + &DensePolynomial::from_coefficients_vec(vec![beta]);
@@ -205,15 +210,10 @@ impl BasicBlock for CQBasicBlock {
           let f_prod = &polys[1];
           let diff = &polys[2].mul(&f_poly) + f_prod;
           let f_prod = f_poly.mul(f_prod);
-          // let f_prod_0 = if polys.len() < 3 {
-          //   DensePolynomial::from_coefficients_vec(vec![Fr::one()])
-          // } else {
-          //   f_poly.mul(&polys[3])
-          // };
           let new_polys = vec![B_poly, f_prod, diff];
           *value = (
             Box::new(self.clone()),
-            BatchProveStateValues::CQ(*n, RefCell::clone(m_i), *T_x_2, new_polys, vec![beta], vec![], RefCell::new(vec![])),
+            BatchProveStateValues::CQ(*n, RefCell::clone(m_i), *T_x_2, new_polys, vec![beta], vec![], RefCell::clone(proof_2)),
           )
         } else {
         }
@@ -246,8 +246,8 @@ impl BasicBlock for CQBasicBlock {
     assert!(n <= N);
     let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
     let key = format!("{:?}_{}", self, input.raw.len());
-    let mut guard = batch_prove_state.lock().unwrap();
-    match guard.get_mut(&key) {
+    let mut state_mut_ref = batch_prove_state.borrow_mut();
+    match state_mut_ref.get_mut(&key) {
       Some(value) => {
         if let (_, BatchProveStateValues::CQ(n, m_i, T_x_2, polys, rngs, proof_0, proof_2)) = value {
           let (proof, proof_2) = if proof_0.len() == 0 {
@@ -266,14 +266,14 @@ impl BasicBlock for CQBasicBlock {
             };
             let B_DC = util::msm::<G1Projective>(&srs.X1A[N - *n..], &B_poly.coeffs);
 
-            let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.borrow().iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
+            let m_ref = m_i.borrow();
+            let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_ref.iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
             let m_x = util::msm::<G1Projective>(&temp, &temp2);
 
             // Calculate A
             // element to m/(t + beta)
             let beta = rngs[0];
-            let A_i: HashMap<usize, Fr> =
-              m_i.borrow().iter().map(|(i, y)| (*i, Fr::from(*y as u32) * (model.raw[*i] + beta).inverse().unwrap())).collect();
+            let A_i: HashMap<usize, Fr> = m_ref.iter().map(|(i, y)| (*i, Fr::from(*y as u32) * (model.raw[*i] + beta).inverse().unwrap())).collect();
             // lagrange basis of value
             let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_x_1[*i], *y)).unzip();
             // msm basis with A(x)
@@ -294,11 +294,11 @@ impl BasicBlock for CQBasicBlock {
               -srs.X1P[1] * r[7] + srs.X1P[0] * (r[5] - r[3] * Fr::from(N as u32) * Fr::from(*n as u32).inverse().unwrap()),
               -srs.X1P[0] * r[8] + srs.X1P[N - *n] * r[5],
             ];
-            let proof_2 = RefCell::new(vec![r[5], r[6], Fr::zero()]);
+            proof_2.borrow_mut().append(&mut vec![r[5], r[6], Fr::zero()]);
             commits.append(&mut C);
             (commits, proof_2)
           } else {
-            (proof_0.clone(), RefCell::clone(proof_2))
+            (proof_0.clone(), &mut RefCell::clone(proof_2))
           };
 
           let beta = rngs[0];
@@ -317,8 +317,8 @@ impl BasicBlock for CQBasicBlock {
           };
 
           let f_z = f_poly.evaluate(&zeta);
-          let agg_r = proof_2.borrow()[2];
-          proof_2.borrow_mut()[2] = agg_r + input.r * mu_pow;
+          let agg_r = proof_2.borrow()[4];
+          proof_2.borrow_mut()[4] = agg_r + input.r * mu_pow;
           proof_2.borrow_mut().push(f_z);
 
           let new_rngs = vec![rngs[0], zeta, mu, mu_pow];
@@ -326,7 +326,7 @@ impl BasicBlock for CQBasicBlock {
           new_polys.push(q1_poly);
           *value = (
             Box::new(self.clone()),
-            BatchProveStateValues::CQ(*n, RefCell::clone(m_i), *T_x_2, new_polys, new_rngs, proof, proof_2),
+            BatchProveStateValues::CQ(*n, RefCell::clone(m_i), *T_x_2, new_polys, new_rngs, proof, RefCell::clone(proof_2)),
           )
         } else {
         }
@@ -349,21 +349,30 @@ impl BasicBlock for CQBasicBlock {
       let W_poly = &q1_poly.sub(&q1_z_poly) / &q1_V;
       let W_x = util::msm::<G1Projective>(&srs.X1A, &W_poly.coeffs);
 
-      let fz_prod: Fr = proof_2.borrow()[3..].iter().product();
+      let p_ref = proof_2.borrow();
+      let f_zs = &p_ref[5..];
+      let fz_prod: Fr = f_zs.iter().product();
+      let diff_prod: Fr = f_zs[1..].iter().product();
+      let diffs: Vec<_> = f_zs[1..].iter().map(|x| diff_prod / x).collect();
+      let diffs_sum: Fr = diffs.iter().sum();
+      // println!("diff_prod {:?}", diff_prod);
+      // println!("diffs {:?}", diffs);
+      // println!("diffs_sum {:?}", diffs_sum);
       // println!("fz_prod {:?}", fz_prod);
       // println!("f_prod {:?}", f_prod.evaluate(&zeta));
       // println!("diff: {:?}", diff.evaluate(&zeta));
       let mut rng2 = StdRng::from_entropy();
-      let r = &proof_2.borrow()[..2];
-      let r_sum = proof_2.borrow()[2];
+      // [input0.r, input1.r, B_x, B_Q_x]
+      let r = &p_ref[..4];
+      let r_sum = p_ref[4];
       let zetas = util::calc_pow(zeta, *n);
-      let C5 = -srs.X1P[0] * (zetas[n - 1] - Fr::one()) * r[1] + srs.X1P[0] * fz_prod * r[0];
+      let C5 = -srs.X1P[0] * (zetas[n - 1] - Fr::one()) * r[3] + srs.X1P[0] * (fz_prod * r[2] - diffs_sum * r[0] - diffs[0] * r[1]);
       let r = Fr::rand(&mut rng2);
       let C6 = -(srs.X1P[1] - srs.X1P[0] * zeta) * r + srs.X1P[0] * r_sum;
 
       let mut proof = proof_0.clone();
       proof.append(&mut vec![W_x + srs.Y1P * r, C5, C6]);
-      (proof, vec![*T_x_2], proof_2.borrow()[3..].to_vec())
+      (proof, vec![*T_x_2], f_zs.to_vec())
     } else {
       (vec![], vec![], vec![])
     }
@@ -381,8 +390,8 @@ impl BasicBlock for CQBasicBlock {
     let input = inputs[0].first().unwrap();
     let model = model.first().unwrap();
     let key = format!("{:?}_{}", self, input.len);
-    let mut guard = batch_verify_state.lock().unwrap();
-    match guard.get_mut(&key) {
+    let mut state_mut_ref = batch_verify_state.borrow_mut();
+    match state_mut_ref.get_mut(&key) {
       Some(value) => {
         let (_, BatchVerifyStateValues::CQ(n, N, _, g1s)) = value;
         let mut new_g1s = g1s.clone();
@@ -391,7 +400,7 @@ impl BasicBlock for CQBasicBlock {
       }
       _ => {
         let N = model.len;
-        guard.insert(
+        state_mut_ref.insert(
           key,
           (Box::new(self.clone()), BatchVerifyStateValues::CQ(input.len, N, model.g1, vec![input.g1])),
         );
@@ -423,11 +432,17 @@ impl BasicBlock for CQBasicBlock {
     let zetas = util::calc_pow(zeta, *n);
     let mus = util::calc_pow(mu, m);
     let fz_sum: Fr = f_zs.iter().enumerate().map(|(i, x)| *x * mus[i]).sum();
-    let fz_prod = f_zs.iter().product();
+    let fz_prod: Fr = f_zs.iter().product();
     // println!("fz_prod {:?}", fz_prod);
-    let diff: Fr = f_zs.iter().map(|x| &fz_prod / x).sum();
     // println!("diff {:?}", diff);
     let f_sum: G1Projective = f_xs.iter().enumerate().map(|(i, x)| (*x + srs.X1A[0] * beta) * mus[i]).sum();
+
+    let diff_prod: Fr = f_zs[1..].iter().product();
+    let diffs: Vec<_> = f_zs[1..].iter().map(|x| diff_prod / x).collect();
+    let diffs_sum: Fr = diffs.iter().sum();
+    println!("diff_prod {:?}", diff_prod);
+    println!("diffs_sum {:?}", diffs_sum);
+    let diff_g1 = (f_xs[0] + srs.X1A[0] * beta) * diffs_sum + (f_xs[1] + srs.X1A[0] * beta) * diffs[0];
 
     // Check A(x) (A_i = m_i/(t_i+beta))
     checks.push(vec![
@@ -454,10 +469,7 @@ impl BasicBlock for CQBasicBlock {
 
     // Check B(x) (B_i = sum ())
     checks.push(vec![
-      (
-        (B_x * fz_prod - srs.X1A[0] * diff - B_Q_x * (zetas[*n - 1] - Fr::one())).into(),
-        srs.X2A[0],
-      ),
+      ((B_x * fz_prod - diff_g1 - B_Q_x * (zetas[*n - 1] - Fr::one())).into(), srs.X2A[0]),
       (-C5, srs.Y2A),
     ]);
 

--- a/src/basic_block/cq2.rs
+++ b/src/basic_block/cq2.rs
@@ -1,10 +1,13 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{BasicBlock, BatchProveStateValues, BatchVerifyStateValues, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use crate::basic_block::*;
 use crate::util;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
-use ark_poly::{evaluations::univariate::Evaluations, univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain};
+use ark_poly::{
+  evaluations::univariate::Evaluations, univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain, Polynomial,
+};
 use ark_std::{
   ops::{Mul, Sub},
   One, UniformRand, Zero,
@@ -14,18 +17,101 @@ use rand::{rngs::StdRng, SeedableRng};
 use rayon::prelude::*;
 use std::collections::HashMap;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+pub enum CQ2BasicBlockOps {
+  Ceil(usize, usize),
+  ChangeSF(usize, usize),
+  Clip(f32, f32),
+  Cos(usize, usize),
+  DivConst(f32),
+  Erf(usize, usize),
+  Exp(usize, usize),
+  GeLU(usize, usize),
+  Log(usize, usize),
+  ModConst(u32),
+  Reciprocal(usize, usize),
+  ReLU(usize, usize),
+  Sigmoid(usize, usize),
+  Sin(usize, usize),
+  Sqrt(usize, usize),
+  Tan(usize, usize),
+  Tanh(usize, usize),
+}
+
+fn enum_to_bb(bb: &CQ2BasicBlockOps) -> Box<dyn BasicBlock> {
+  match bb {
+    CQ2BasicBlockOps::Ceil(input_SF, output_SF) => Box::new(CeilBasicBlock {
+      input_SF: *input_SF,
+      output_SF: *output_SF,
+    }),
+    CQ2BasicBlockOps::ChangeSF(input_SF, output_SF) => Box::new(ChangeSFBasicBlock {
+      input_SF: *input_SF,
+      output_SF: *output_SF,
+    }),
+    CQ2BasicBlockOps::Cos(input_SF, output_SF) => Box::new(CosBasicBlock {
+      input_SF: *input_SF,
+      output_SF: *output_SF,
+    }),
+    CQ2BasicBlockOps::Clip(min, max) => Box::new(ClipBasicBlock { min: *min, max: *max }),
+    CQ2BasicBlockOps::DivConst(c) => Box::new(DivConstBasicBlock { c: *c }),
+    CQ2BasicBlockOps::Erf(input_SF, output_SF) => Box::new(ErfBasicBlock {
+      input_SF: *input_SF,
+      output_SF: *output_SF,
+    }),
+    CQ2BasicBlockOps::Exp(input_SF, output_SF) => Box::new(ExpBasicBlock {
+      input_SF: *input_SF,
+      output_SF: *output_SF,
+    }),
+    CQ2BasicBlockOps::GeLU(input_SF, output_SF) => Box::new(GeLUBasicBlock {
+      input_SF: *input_SF,
+      output_SF: *output_SF,
+    }),
+    CQ2BasicBlockOps::Log(input_SF, output_SF) => Box::new(LogBasicBlock {
+      input_SF: *input_SF,
+      output_SF: *output_SF,
+    }),
+    CQ2BasicBlockOps::ModConst(c) => Box::new(ModConstBasicBlock { c: *c }),
+    CQ2BasicBlockOps::Reciprocal(input_SF, output_SF) => Box::new(ReciprocalBasicBlock {
+      input_SF: *input_SF,
+      output_SF: *output_SF,
+    }),
+    CQ2BasicBlockOps::ReLU(input_SF, output_SF) => Box::new(ReLUBasicBlock {
+      input_SF: *input_SF,
+      output_SF: *output_SF,
+    }),
+    CQ2BasicBlockOps::Sigmoid(input_SF, output_SF) => Box::new(SigmoidBasicBlock {
+      input_SF: *input_SF,
+      output_SF: *output_SF,
+    }),
+    CQ2BasicBlockOps::Sin(input_SF, output_SF) => Box::new(SinBasicBlock {
+      input_SF: *input_SF,
+      output_SF: *output_SF,
+    }),
+    CQ2BasicBlockOps::Sqrt(input_SF, output_SF) => Box::new(SqrtBasicBlock {
+      input_SF: *input_SF,
+      output_SF: *output_SF,
+    }),
+    CQ2BasicBlockOps::Tan(input_SF, output_SF) => Box::new(TanBasicBlock {
+      input_SF: *input_SF,
+      output_SF: *output_SF,
+    }),
+    CQ2BasicBlockOps::Tanh(input_SF, output_SF) => Box::new(TanhBasicBlock {
+      input_SF: *input_SF,
+      output_SF: *output_SF,
+    }),
+  }
+}
+
+#[derive(Debug, Clone)]
 pub struct CQ2BasicBlock {
-  pub setup: Option<(Box<dyn BasicBlock>, i128, usize)>,
+  pub op: CQ2BasicBlockOps,
+  pub offset: i128,
+  pub size: usize,
 }
 
 impl BasicBlock for CQ2BasicBlock {
   fn genModel(&self) -> ArrayD<Fr> {
-    util::gen_cq_table(
-      &(self.setup.as_ref().unwrap().0),
-      self.setup.as_ref().unwrap().1,
-      self.setup.as_ref().unwrap().2,
-    )
+    util::gen_cq_table(&enum_to_bb(&self.op), self.offset, self.size)
   }
 
   fn run(&self, model: &ArrayD<Fr>, inputs: &Vec<&ArrayD<Fr>>) -> Result<Vec<ArrayD<Fr>>, util::CQOutOfRangeError> {
@@ -33,17 +119,15 @@ impl BasicBlock for CQ2BasicBlock {
       return Ok(vec![]);
     }
     assert!(inputs.len() == 2);
-    if self.setup.is_some() {
-      for x in inputs[0].iter().zip(inputs[1].iter()) {
-        let temp = (*x.0, *x.1);
-        let x_0_int = util::fr_to_int(temp.0);
-        let low = self.setup.as_ref().unwrap().1;
-        let high = low + self.setup.as_ref().unwrap().2 as i128;
-        if x_0_int < low || x_0_int >= high {
-          let temp_ints = (util::fr_to_int(temp.0), util::fr_to_int(temp.1));
-          println!("{:?}, {:?}", temp_ints, temp);
-          return Err(util::CQOutOfRangeError { input: temp_ints.0 });
-        }
+    for x in inputs[0].iter().zip(inputs[1].iter()) {
+      let temp = (*x.0, *x.1);
+      let x_0_int = util::fr_to_int(temp.0);
+      let low = self.offset;
+      let high = low + self.size as i128;
+      if x_0_int < low || x_0_int >= high {
+        let temp_ints = (util::fr_to_int(temp.0), util::fr_to_int(temp.1));
+        println!("{:?}, {:?}", temp_ints, temp);
+        return Err(util::CQOutOfRangeError { input: temp_ints.0 });
       }
     }
 
@@ -109,28 +193,152 @@ impl BasicBlock for CQ2BasicBlock {
     return (setup, setup2, Vec::new());
   }
 
-  fn prove(
+  fn batch_prove_first(
     &self,
-    srs: &SRS,
+    _srs: &SRS,
     setup: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<DensePolynomial<Fr>>),
+    batch_prove_state: &mut BatchProveState,
     model: &ArrayD<Data>,
     inputs: &Vec<&ArrayD<Data>>,
     _outputs: &Vec<&ArrayD<Data>>,
-    rng: &mut StdRng,
+    _rng: &mut StdRng,
     cache: ProveVerifyCache,
-  ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
+  ) {
+    println!("cq2 first");
     assert!(inputs.len() == 2 && inputs[0].len() == 1 && inputs[1].len() == 1);
     let N = model[0].raw.len();
     let inputs = vec![inputs[0].first().unwrap(), inputs[1].first().unwrap()];
     assert!(inputs[0].raw.len() == inputs[1].raw.len());
     let n = inputs[0].raw.len();
+
+    let key = format!("{:?}_{}", self, inputs[0].raw.len());
+    let mut cache = cache.lock().unwrap();
+    let CacheValues::CQ2TableDict(table_dict) =
+      cache.entry(format!("cq2_table_dict_{:p}", self)).or_insert_with(|| CacheValues::CQ2TableDict(HashMap::new()))
+    else {
+      panic!("Cache type error")
+    };
+    if table_dict.len() == 0 {
+      for i in 0..N {
+        println!("insert {:?}", (model[0].raw[i], model[1].raw[i]));
+        table_dict.insert((model[0].raw[i], model[1].raw[i]), i);
+      }
+    }
+    let mut guard = batch_prove_state.lock().unwrap();
+    match guard.get_mut(&key) {
+      Some(value) => {
+        if let (_, BatchProveStateValues::CQ2(n, m_i, T_x_2, polys, _, _, _)) = value {
+          let mut m_i = m_i.clone();
+          for x in inputs[0].raw.iter().zip(inputs[1].raw.iter()) {
+            let temp = (*x.0, *x.1);
+            if !table_dict.contains_key(&temp) {
+              println!("{:?}", temp);
+            }
+            m_i.entry(table_dict.get(&temp).unwrap().clone()).and_modify(|y| *y += 1).or_insert(1);
+          }
+          *value = (
+            Box::new(self.clone()),
+            BatchProveStateValues::CQ2(*n, m_i, *T_x_2, polys.clone(), vec![], vec![], vec![]),
+          )
+        } else {
+        }
+      }
+      _ => {
+        let mut m_i = HashMap::new();
+        for x in inputs[0].raw.iter().zip(inputs[1].raw.iter()) {
+          let temp = (*x.0, *x.1);
+          if !table_dict.contains_key(&temp) {
+            println!("{:?}", temp);
+            m_i.entry(table_dict.get(&temp).unwrap().clone()).and_modify(|y| *y += 1).or_insert(1);
+          }
+          println!("cq2 1");
+          guard.insert(
+            key.to_string(),
+            (
+              Box::new(self.clone()),
+              BatchProveStateValues::CQ2(
+                n,
+                m_i.clone(),
+                setup.1[0].into(),
+                vec![
+                  DensePolynomial::from_coefficients_vec(vec![Fr::zero()]),
+                  DensePolynomial::from_coefficients_vec(vec![Fr::one()]),
+                  DensePolynomial::from_coefficients_vec(vec![Fr::zero()]),
+                  DensePolynomial::from_coefficients_vec(vec![Fr::zero()]),
+                ],
+                vec![],
+                vec![],
+                vec![],
+              ),
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  fn batch_prove_second(
+    &self,
+    srs: &SRS,
+    _setup: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<DensePolynomial<Fr>>),
+    batch_prove_state: &mut BatchProveState,
+    model: &ArrayD<Data>,
+    inputs: &Vec<&ArrayD<Data>>,
+    _outputs: &Vec<&ArrayD<Data>>,
+    rng: &mut StdRng,
+    _cache: ProveVerifyCache,
+  ) {
+    println!("cq2 second");
+    let model = model.first().unwrap();
+    let inputs = vec![inputs[0].first().unwrap(), inputs[1].first().unwrap()];
+    let n = inputs[0].raw.len();
+    let N = model.raw.len();
+    assert!(n <= N);
     let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
-    let alpha = Fr::rand(rng);
-    let agg_input: Vec<_> = inputs[0].raw.iter().zip(inputs[1].raw.iter()).map(|(x, y)| *x + *y * alpha).collect();
-    let mut agg_input = Data::new(srs, &agg_input); // Unnecessary msm
-    agg_input.r = inputs[0].r + inputs[1].r * alpha;
-    let agg_model_g1 = model[0].g1 + model[1].g1 * alpha;
-    let agg_model_r = model[0].r + model[1].r * alpha;
+
+    let key = format!("{:?}_{}", self, inputs[0].raw.len());
+    let mut guard = batch_prove_state.lock().unwrap();
+    match guard.get_mut(&key) {
+      Some(value) => {
+        if let (_, BatchProveStateValues::CQ2(n, m_i, T_x_2, polys, rngs, _, _)) = value {
+          println!("cq2 2");
+          let alpha = if rngs.len() == 0 { Fr::rand(rng) } else { rngs[0] };
+          let beta = if rngs.len() == 0 { Fr::rand(rng) } else { rngs[1] };
+          let agg_input: Vec<_> = inputs[0].raw.iter().zip(inputs[1].raw.iter()).map(|(x, y)| *x + *y * alpha).collect();
+          let agg_input = Data::new(srs, &agg_input); // Unnecessary msm
+
+          let B_i: Vec<Fr> = agg_input.raw.iter().map(|x| (*x + beta).inverse().unwrap()).collect();
+          let f_poly = agg_input.poly.clone() + DensePolynomial::from_coefficients_vec(vec![beta]);
+          let B_poly = &polys[0] + &Evaluations::from_vec_and_domain(B_i.clone(), domain_n).interpolate();
+          let f_prod = &polys[1];
+          let diff = &polys[2].mul(&f_poly) + f_prod;
+          let f_prod = f_poly.mul(f_prod);
+          let new_polys = vec![B_poly, f_prod, diff];
+          *value = (
+            Box::new(self.clone()),
+            BatchProveStateValues::CQ2(*n, m_i.clone(), *T_x_2, new_polys, vec![alpha, beta], vec![], vec![]),
+          )
+        } else {
+        }
+      }
+      _ => {}
+    };
+  }
+
+  fn batch_prove_third(
+    &self,
+    srs: &SRS,
+    setup: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<DensePolynomial<Fr>>),
+    batch_prove_state: &mut BatchProveState,
+    model: &ArrayD<Data>,
+    inputs: &Vec<&ArrayD<Data>>,
+    _outputs: &Vec<&ArrayD<Data>>,
+    rng: &mut StdRng,
+    _cache: ProveVerifyCache,
+  ) {
+    let inputs = vec![inputs[0].first().unwrap(), inputs[1].first().unwrap()];
+    let n = inputs[0].raw.len();
+    let N = model[0].raw.len();
 
     // gen(N, t):
     let Q_i_x_1_A = &setup.0[..N];
@@ -138,153 +346,232 @@ impl BasicBlock for CQ2BasicBlock {
     let L_i_x_1 = &setup.0[2 * N..3 * N];
     let L_i_0_x_1 = &setup.0[3 * N..];
 
-    let m_i = {
-      let mut cache = cache.lock().unwrap();
-      let CacheValues::CQ2TableDict(table_dict) =
-        cache.entry(format!("cq2_table_dict_{:p}", self)).or_insert_with(|| CacheValues::CQ2TableDict(HashMap::new()))
-      else {
-        panic!("Cache type error")
+    assert!(n <= N);
+    let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
+    let key = format!("{:?}_{}", self, n);
+    let mut guard = batch_prove_state.lock().unwrap();
+    match guard.get_mut(&key) {
+      Some(value) => {
+        if let (_, BatchProveStateValues::CQ2(n, m_i, T_x_2, polys, rngs, proof_0, proof_2)) = value {
+          println!("cq2 3");
+          let alpha = rngs[0];
+          let beta = rngs[1];
+          let (proof, mut proof_2) = if proof_0.len() == 0 {
+            let B_poly = &polys[0];
+            let f_prod = &polys[1];
+            let diff = &polys[2];
+
+            let agg_model_g1 = model[0].g1 + model[1].g1 * alpha;
+            let agg_model_r = model[0].r + model[1].r * alpha;
+
+            let B_Q_poly = B_poly.mul(f_prod).sub(diff).divide_by_vanishing_poly(domain_n).unwrap().0;
+            let B_x = util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs);
+            let B_Q_x = util::msm::<G1Projective>(&srs.X1A, &B_Q_poly.coeffs);
+            let B_zero_div = if B_poly.is_zero() {
+              G1Projective::zero()
+            } else {
+              util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs[1..])
+            };
+            let B_DC = util::msm::<G1Projective>(&srs.X1A[N - *n..], &B_poly.coeffs);
+
+            let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
+            let m_x = util::msm::<G1Projective>(&temp, &temp2);
+
+            // Calculate A
+            // element to m/(t + beta)
+            let A_i: HashMap<usize, Fr> = m_i
+              .iter()
+              .map(|(i, y)| {
+                (
+                  *i,
+                  Fr::from(*y as u32) * (model[0].raw[*i] + model[1].raw[*i] * alpha + beta).inverse().unwrap(),
+                )
+              })
+              .collect();
+            // lagrange basis of value
+            let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_x_1[*i], *y)).unzip();
+            // msm basis with A(x)
+            let A_x = util::msm::<G1Projective>(&temp, &temp2);
+            let temp: Vec<G1Projective> = A_i.iter().map(|(i, _)| Q_i_x_1_A[*i] + Q_i_x_1_B[*i] * alpha).collect();
+            let temp: Vec<G1Affine> = temp.iter().map(|x| (*x).into()).collect();
+            let A_Q_x = util::msm::<G1Projective>(&temp, &temp2);
+            let A_zero = srs.X1P[0] * (Fr::from(N as u32).inverse().unwrap() * A_i.iter().map(|(_, y)| *y).sum::<Fr>());
+            let temp: Vec<G1Affine> = A_i.iter().map(|(i, _)| L_i_0_x_1[*i]).collect();
+            let A_zero_div = util::msm::<G1Projective>(&temp, &temp2);
+
+            let mut rng2 = StdRng::from_entropy();
+            let r: Vec<_> = (0..9).map(|_| Fr::rand(&mut rng2)).collect();
+            let commits = vec![m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC];
+            let mut commits: Vec<G1Projective> = commits.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r[i]).collect();
+            let mut C = vec![
+              -(srs.X1P[N] - srs.X1P[0]) * r[2]
+                + agg_model_g1 * r[1]
+                + A_x * agg_model_r
+                + (srs.Y1P * agg_model_r * r[1])
+                + srs.X1P[0] * (r[1] * beta - r[0]),
+              -srs.X1P[1] * r[4] + srs.X1P[0] * (r[1] - r[3]),
+              -srs.X1P[1] * r[7] + srs.X1P[0] * (r[5] - r[3] * Fr::from(N as u32) * Fr::from(*n as u32).inverse().unwrap()),
+              -srs.X1P[0] * r[8] + srs.X1P[N - *n] * r[5],
+            ];
+            let proof_2 = vec![r[6], r[5], Fr::zero()];
+            commits.append(&mut C);
+            (commits, proof_2)
+          } else {
+            (proof_0.clone(), proof_2.clone())
+          };
+
+          let zeta = if rngs.len() == 2 { Fr::rand(rng) } else { rngs[2] };
+          let mu = if rngs.len() == 2 { Fr::rand(rng) } else { rngs[3] };
+          let mu_pow = if rngs.len() == 2 { mu } else { rngs[4] * mu };
+          let agg_input: Vec<_> = inputs[0].raw.iter().zip(inputs[1].raw.iter()).map(|(x, y)| *x + *y * alpha).collect();
+          let mut agg_input = Data::new(srs, &agg_input);
+          agg_input.r = inputs[0].r + inputs[1].r * alpha;
+          let q1_poly: DensePolynomial<Fr> = if polys.len() < 4 {
+            agg_input.poly.mul(mu_pow)
+          } else {
+            &polys[3] + &agg_input.poly.mul(mu_pow)
+          };
+          let f_z = agg_input.poly.evaluate(&zeta);
+          proof_2[2] = proof_2[2] + agg_input.r * mu_pow;
+          let mut evals = proof_2.clone();
+          evals.push(f_z);
+          let new_rngs = vec![rngs[0], rngs[1], zeta, mu, mu_pow];
+          let mut new_polys = polys[..3].to_vec();
+          new_polys.push(q1_poly);
+          *value = (
+            Box::new(self.clone()),
+            BatchProveStateValues::CQ2(*n, m_i.clone(), *T_x_2, new_polys, new_rngs, proof, evals),
+          )
+        } else {
+        }
+      }
+      _ => {}
+    }
+  }
+
+  fn batch_prove(&self, srs: &SRS, batch_prove_values: &BatchProveStateValues, _rng: &mut StdRng) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
+    if let BatchProveStateValues::CQ2(n, _, T_x_2, polys, rngs, proof_0, proof_2) = batch_prove_values {
+      let zeta = rngs[2];
+      let q1_poly = &polys[3];
+      let q1_z = q1_poly.evaluate(&zeta);
+      let q1_z_poly = DensePolynomial { coeffs: vec![q1_z] };
+      let q1_V = DensePolynomial {
+        coeffs: vec![-zeta, Fr::one()],
       };
-      if table_dict.len() == 0 {
-        for i in 0..N {
-          table_dict.insert((model[0].raw[i], model[1].raw[i]), i);
-        }
-      }
+      let W_poly = &q1_poly.sub(&q1_z_poly) / &q1_V;
+      let W_x = util::msm::<G1Projective>(&srs.X1A, &W_poly.coeffs);
 
-      // Calculate m
-      let mut m_i = HashMap::new();
-      for x in inputs[0].raw.iter().zip(inputs[1].raw.iter()) {
-        let temp = (*x.0, *x.1);
-        if !table_dict.contains_key(&temp) {
-          println!("{:?}", temp);
-        }
-        m_i.entry(table_dict.get(&temp).unwrap().clone()).and_modify(|y| *y += 1).or_insert(1);
-      }
-      m_i
-    };
-    let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
-    let m_x = util::msm::<G1Projective>(&temp, &temp2);
+      let fz_prod: Fr = proof_2[3..].iter().product();
+      let mut rng2 = StdRng::from_entropy();
+      let r = &proof_2[..2];
+      let r_sum = proof_2[2];
+      let C5 = -(srs.X1P[*n] - srs.X1P[0]) * r[0] + srs.X1P[0] * fz_prod * r[1];
+      let r = Fr::rand(&mut rng2);
+      let C6 = -(srs.X1P[1] - srs.X1P[0] * zeta) * r + srs.X1P[0] * r_sum;
 
-    let beta = Fr::rand(rng);
-
-    // Calculate A
-    let A_i: HashMap<usize, Fr> = m_i
-      .iter()
-      .map(|(i, y)| {
-        (
-          *i,
-          Fr::from(*y as u32) * (model[0].raw[*i] + model[1].raw[*i] * alpha + beta).inverse().unwrap(),
-        )
-      })
-      .collect();
-    let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = A_i.iter().map(|(i, y)| (L_i_x_1[*i], *y)).unzip();
-    let A_x = util::msm::<G1Projective>(&temp, &temp2);
-    let temp: Vec<G1Projective> = A_i.iter().map(|(i, _)| Q_i_x_1_A[*i] + Q_i_x_1_B[*i] * alpha).collect();
-    let temp: Vec<G1Affine> = temp.iter().map(|x| (*x).into()).collect();
-    let A_Q_x = util::msm::<G1Projective>(&temp, &temp2);
-    let A_zero = srs.X1P[0] * (Fr::from(N as u32).inverse().unwrap() * A_i.iter().map(|(_, y)| *y).sum::<Fr>());
-    let temp: Vec<G1Affine> = A_i.iter().map(|(i, _)| L_i_0_x_1[*i]).collect();
-    let A_zero_div = util::msm::<G1Projective>(&temp, &temp2);
-
-    // Calculate B
-    let B_i: Vec<Fr> = agg_input.raw.iter().map(|x| (*x + beta).inverse().unwrap()).collect();
-    let B_poly = Evaluations::from_vec_and_domain(B_i.clone(), domain_n).interpolate();
-    let B_Q_poly = B_poly
-      .mul(&(agg_input.poly.clone() + (DensePolynomial::from_coefficients_vec(vec![beta]))))
-      .sub(&DensePolynomial::from_coefficients_vec(vec![Fr::one()]))
-      .divide_by_vanishing_poly(domain_n)
-      .unwrap()
-      .0;
-    let B_x = util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs);
-    let B_Q_x = util::msm::<G1Projective>(&srs.X1A, &B_Q_poly.coeffs);
-    let B_zero_div = if B_poly.is_zero() {
-      G1Projective::zero()
+      let mut proof = proof_0.clone();
+      proof.append(&mut vec![W_x, C5, C6]);
+      (proof, vec![*T_x_2], proof_2.clone())
     } else {
-      util::msm::<G1Projective>(&srs.X1A, &B_poly.coeffs[1..])
-    };
-    let B_DC = util::msm::<G1Projective>(&srs.X1A[N - n..], &B_poly.coeffs);
-
-    let f_x_2 = util::msm::<G2Projective>(&srs.X2A, &agg_input.poly.coeffs) + srs.Y2P * agg_input.r;
-
-    // Blinding
-    let mut rng2 = StdRng::from_entropy();
-    let r: Vec<_> = (0..9).map(|_| Fr::rand(&mut rng2)).collect();
-    let proof: Vec<G1Projective> = vec![m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC];
-    let mut proof: Vec<G1Projective> = proof.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r[i]).collect();
-    let mut C = vec![
-      -(srs.X1P[N] - srs.X1P[0]) * r[2]
-        + agg_model_g1 * r[1]
-        + A_x * agg_model_r
-        + (srs.Y1P * agg_model_r * r[1])
-        + srs.X1P[0] * (r[1] * beta - r[0]),
-      -srs.X1P[1] * r[4] + srs.X1P[0] * (r[1] - r[3]),
-      -(srs.X1P[n] - srs.X1P[0]) * r[6] + agg_input.g1 * r[5] + B_x * agg_input.r + (srs.Y1P * agg_input.r * r[5]) + srs.X1P[0] * (r[5] * beta),
-      -srs.X1P[1] * r[7] + srs.X1P[0] * (r[5] - r[3] * Fr::from(N as u32) * Fr::from(n as u32).inverse().unwrap()),
-      -srs.X1P[0] * r[8] + srs.X1P[N - n] * r[5],
-    ];
-    proof.append(&mut C);
-
-    return (proof, vec![(setup.1[0] + setup.1[1] * alpha).into(), f_x_2], Vec::new());
+      (vec![], vec![], vec![])
+    }
   }
 
-  fn verify(
-    &self,
-    srs: &SRS,
-    model: &ArrayD<DataEnc>,
-    inputs: &Vec<&ArrayD<DataEnc>>,
-    _outputs: &Vec<&ArrayD<DataEnc>>,
-    proof: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>),
-    rng: &mut StdRng,
-    _cache: ProveVerifyCache,
-  ) -> Vec<PairingCheck> {
-    let mut checks = Vec::new();
-    let inputs = vec![inputs[0].first().unwrap(), inputs[1].first().unwrap()];
-    let N = model[0].len;
-    let n = inputs[0].len;
-    let alpha = Fr::rand(rng);
-    let [m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC, C1, C2, C3, C4, C5] = proof.0[..] else {
-      panic!("Wrong proof format")
-    };
-    let [T_x_2, f_x_2] = proof.1[..] else { panic!("Wrong proof format") };
-    let agg_input = (inputs[0].g1 + (inputs[1].g1 * alpha)).into();
-    let agg_model = (model[0].g1 + (model[1].g1 * alpha)).into();
+  // fn batch_verify_first(
+  //   &self,
+  //   batch_verify_state: &mut BatchVerifyState,
+  //   model: &ArrayD<DataEnc>,
+  //   inputs: &Vec<&ArrayD<DataEnc>>,
+  //   _outputs: &Vec<&ArrayD<DataEnc>>,
+  //   _rng: &mut StdRng,
+  //   _cache: ProveVerifyCache,
+  // ) {
+  //   let input = inputs[0].first().unwrap();
+  //   let model = model.first().unwrap();
+  //   let key = format!("{:?}_{}", self, input.len);
+  //   let mut guard = batch_verify_state.lock().unwrap();
+  //   match guard.get_mut(&key) {
+  //     Some(value) => {
+  //       let (_, BatchVerifyStateValues::CQ(n, N, _, g1s)) = value;
+  //       let mut new_g1s = g1s.clone();
+  //       new_g1s.push(input.g1);
+  //       *value = (Box::new(self.clone()), BatchVerifyStateValues::CQ(*n, *N, model.g1, new_g1s))
+  //     }
+  //     _ => {
+  //       let N = model.len;
+  //       guard.insert(
+  //         key,
+  //         (Box::new(self.clone()), BatchVerifyStateValues::CQ(input.len, N, model.g1, vec![input.g1])),
+  //       );
+  //     }
+  //   };
+  // }
 
-    let beta = Fr::rand(rng);
+  // fn batch_verify(
+  //   &self,
+  //   srs: &SRS,
+  //   proof: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>),
+  //   batch_verify_values: &BatchVerifyStateValues,
+  //   rng: &mut StdRng,
+  // ) -> Vec<PairingCheck> {
+  //   let mut checks = Vec::new();
+  //   let [m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC, C1, C2, C3, C4, W_x, C5, C6] = proof.0[..] else {
+  //     panic!("Wrong proof format")
+  //   };
+  //   let [T_x_2] = proof.1[..] else { panic!("Wrong proof format") };
+  //   let f_zs = proof.2;
 
-    // Check A(x) (A_i = m_i/(t_i+beta))
-    checks.push(vec![
-      (A_x, T_x_2),
-      ((A_x * beta - m_x).into(), srs.X2A[0]),
-      (-A_Q_x, (srs.X2A[N] - srs.X2A[0]).into()),
-      (-C1, srs.Y2A),
-    ]);
+  //   let beta = Fr::rand(rng);
+  //   let zeta = Fr::rand(rng);
+  //   let mu = Fr::rand(rng);
 
-    // Check T_x_2 is the G2 equivalent of the model
-    checks.push(vec![(agg_model, srs.X2A[0]), (srs.X1A[0], -T_x_2)]);
+  //   let BatchVerifyStateValues::CQ(n, N, model_g1, f_xs) = batch_verify_values;
 
-    // Check A(x) - A(0) is divisible by x
-    checks.push(vec![((A_x - A_zero).into(), srs.X2A[0]), (-A_zero_div, srs.X2A[1]), (-C2, srs.Y2A)]);
+  //   let zetas = util::calc_pow(zeta, f_zs.len());
+  //   let mus = util::calc_pow(mu, f_zs.len());
+  //   let fz_sum: Fr = f_zs.iter().enumerate().map(|(i, x)| *x * mus[i]).sum();
+  //   let fz_prod = f_zs.iter().product();
+  //   let diff: Fr = f_zs.iter().map(|x| &fz_prod / x).sum();
+  //   let f_sum: G1Projective = f_xs.iter().enumerate().map(|(i, x)| (*x + srs.X1A[0] * beta) * mus[i]).sum();
 
-    // Check B(x) (B_i = 1/(f_i+beta))
-    checks.push(vec![
-      (B_x, f_x_2),
-      ((B_x * beta - srs.X1A[0]).into(), srs.X2A[0]),
-      (-B_Q_x, (srs.X2A[n] - srs.X2A[0]).into()),
-      (-C3, srs.Y2A),
-    ]);
+  //   // Check A(x) (A_i = m_i/(t_i+beta))
+  //   checks.push(vec![
+  //     (A_x, T_x_2),
+  //     ((A_x * beta - m_x).into(), srs.X2A[0]),
+  //     (-A_Q_x, (srs.X2A[*N] - srs.X2A[0]).into()),
+  //     (-C1, srs.Y2A),
+  //   ]);
 
-    // Check f_x_2 is the G2 equivalent of the input
-    checks.push(vec![(agg_input, srs.X2A[0]), (srs.X1A[0], -f_x_2)]);
+  //   // Check T_x_2 is the G2 equivalent of the model
+  //   checks.push(vec![(*model_g1, srs.X2A[0]), (srs.X1A[0], -T_x_2)]);
 
-    // Assume B(0) = A(0)*N/n (which assumes ∑A=∑B)
-    let B_0: G1Affine = (A_zero * (Fr::from(N as u32) * Fr::from(n as u32).inverse().unwrap())).into();
+  //   // Check A(x) - A(0) is divisible by x
+  //   checks.push(vec![((A_x - A_zero).into(), srs.X2A[0]), (-A_zero_div, srs.X2A[1]), (-C2, srs.Y2A)]);
 
-    // Check B(x) - B(0) is divisible by x
-    checks.push(vec![((B_x - B_0).into(), srs.X2A[0]), (-B_zero_div, srs.X2A[1]), (-C4, srs.Y2A)]);
+  //   // Assume B(0) = A(0)*N/n (which assumes ∑A=∑B)
+  //   let B_0: G1Affine = (A_zero * (Fr::from(*N as u32) * Fr::from(*n as u32).inverse().unwrap())).into();
 
-    // Degree check B
-    checks.push(vec![(B_x, srs.X2A[N - n]), (-B_DC, srs.X2A[0]), (-C5, srs.Y2A)]);
+  //   // Check B(x) - B(0) is divisible by x
+  //   checks.push(vec![((B_x - B_0).into(), srs.X2A[0]), (-B_zero_div, srs.X2A[1]), (-C3, srs.Y2A)]);
 
-    checks
-  }
+  //   // Degree check B
+  //   checks.push(vec![(B_x, srs.X2A[N - n]), (-B_DC, srs.X2A[0]), (-C4, srs.Y2A)]);
+
+  //   // Check B(x) (B_i = sum ())
+  //   checks.push(vec![
+  //     (
+  //       (B_x * fz_prod - srs.X1A[0] * diff - B_Q_x * (zetas[n - 1] - Fr::one())).into(),
+  //       srs.X2A[0],
+  //     ),
+  //     (-C5, srs.Y2A),
+  //   ]);
+
+  //   checks.push(vec![
+  //     ((-W_x, (srs.X2P[1] - srs.X2A[0] * zeta).into())),
+  //     ((f_sum - srs.X1A[0] * fz_sum).into(), srs.X2A[0]),
+  //     (-C6, srs.Y2A),
+  //   ]);
+
+  //   checks
+  // }
 }

--- a/src/basic_block/cq2.rs
+++ b/src/basic_block/cq2.rs
@@ -204,7 +204,6 @@ impl BasicBlock for CQ2BasicBlock {
     _rng: &mut StdRng,
     cache: ProveVerifyCache,
   ) {
-    println!("cq2 first");
     assert!(inputs.len() == 2 && inputs[0].len() == 1 && inputs[1].len() == 1);
     let N = model[0].raw.len();
     let inputs = vec![inputs[0].first().unwrap(), inputs[1].first().unwrap()];
@@ -220,7 +219,6 @@ impl BasicBlock for CQ2BasicBlock {
     };
     if table_dict.len() == 0 {
       for i in 0..N {
-        println!("insert {:?}", (model[0].raw[i], model[1].raw[i]));
         table_dict.insert((model[0].raw[i], model[1].raw[i]), i);
       }
     }
@@ -228,17 +226,16 @@ impl BasicBlock for CQ2BasicBlock {
     match guard.get_mut(&key) {
       Some(value) => {
         if let (_, BatchProveStateValues::CQ2(n, m_i, T_x_2, polys, _, _, _)) = value {
-          let mut m_i = m_i.clone();
           for x in inputs[0].raw.iter().zip(inputs[1].raw.iter()) {
             let temp = (*x.0, *x.1);
             if !table_dict.contains_key(&temp) {
               println!("{:?}", temp);
             }
-            m_i.entry(table_dict.get(&temp).unwrap().clone()).and_modify(|y| *y += 1).or_insert(1);
+            m_i.borrow_mut().entry(table_dict.get(&temp).unwrap().clone()).and_modify(|y| *y += 1).or_insert(1);
           }
           *value = (
             Box::new(self.clone()),
-            BatchProveStateValues::CQ2(*n, m_i, *T_x_2, polys.clone(), vec![], vec![], vec![]),
+            BatchProveStateValues::CQ2(*n, RefCell::clone(m_i), *T_x_2, polys.clone(), vec![], vec![], RefCell::new(vec![])),
           )
         } else {
         }
@@ -251,35 +248,34 @@ impl BasicBlock for CQ2BasicBlock {
             println!("{:?}", temp);
             m_i.entry(table_dict.get(&temp).unwrap().clone()).and_modify(|y| *y += 1).or_insert(1);
           }
-          println!("cq2 1");
-          guard.insert(
-            key.to_string(),
-            (
-              Box::new(self.clone()),
-              BatchProveStateValues::CQ2(
-                n,
-                m_i.clone(),
-                setup.1[0].into(),
-                vec![
-                  DensePolynomial::from_coefficients_vec(vec![Fr::zero()]),
-                  DensePolynomial::from_coefficients_vec(vec![Fr::one()]),
-                  DensePolynomial::from_coefficients_vec(vec![Fr::zero()]),
-                  DensePolynomial::from_coefficients_vec(vec![Fr::zero()]),
-                ],
-                vec![],
-                vec![],
-                vec![],
-              ),
-            ),
-          );
         }
+        guard.insert(
+          key.to_string(),
+          (
+            Box::new(self.clone()),
+            BatchProveStateValues::CQ2(
+              n,
+              RefCell::new(m_i),
+              setup.1[0].into(),
+              vec![
+                DensePolynomial::from_coefficients_vec(vec![Fr::zero()]),
+                DensePolynomial::from_coefficients_vec(vec![Fr::one()]),
+                DensePolynomial::from_coefficients_vec(vec![Fr::zero()]),
+                DensePolynomial::from_coefficients_vec(vec![Fr::zero()]),
+              ],
+              vec![],
+              vec![],
+              RefCell::new(vec![]),
+            ),
+          ),
+        );
       }
     }
   }
 
   fn batch_prove_second(
     &self,
-    srs: &SRS,
+    _srs: &SRS,
     _setup: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<DensePolynomial<Fr>>),
     batch_prove_state: &mut BatchProveState,
     model: &ArrayD<Data>,
@@ -288,7 +284,6 @@ impl BasicBlock for CQ2BasicBlock {
     rng: &mut StdRng,
     _cache: ProveVerifyCache,
   ) {
-    println!("cq2 second");
     let model = model.first().unwrap();
     let inputs = vec![inputs[0].first().unwrap(), inputs[1].first().unwrap()];
     let n = inputs[0].raw.len();
@@ -301,22 +296,29 @@ impl BasicBlock for CQ2BasicBlock {
     match guard.get_mut(&key) {
       Some(value) => {
         if let (_, BatchProveStateValues::CQ2(n, m_i, T_x_2, polys, rngs, _, _)) = value {
-          println!("cq2 2");
           let alpha = if rngs.len() == 0 { Fr::rand(rng) } else { rngs[0] };
           let beta = if rngs.len() == 0 { Fr::rand(rng) } else { rngs[1] };
           let agg_input: Vec<_> = inputs[0].raw.iter().zip(inputs[1].raw.iter()).map(|(x, y)| *x + *y * alpha).collect();
-          let agg_input = Data::new(srs, &agg_input); // Unnecessary msm
 
-          let B_i: Vec<Fr> = agg_input.raw.iter().map(|x| (*x + beta).inverse().unwrap()).collect();
-          let f_poly = agg_input.poly.clone() + DensePolynomial::from_coefficients_vec(vec![beta]);
-          let B_poly = &polys[0] + &Evaluations::from_vec_and_domain(B_i.clone(), domain_n).interpolate();
+          let B_i: Vec<Fr> = agg_input.iter().map(|x| (*x + beta).inverse().unwrap()).collect();
+          let agg_input_poly = DensePolynomial::from_coefficients_vec(domain_n.ifft(&agg_input));
+          let f_poly = agg_input_poly + DensePolynomial::from_coefficients_vec(vec![beta]);
+          let B_poly = &polys[0] + &Evaluations::from_vec_and_domain(B_i, domain_n).interpolate();
           let f_prod = &polys[1];
           let diff = &polys[2].mul(&f_poly) + f_prod;
           let f_prod = f_poly.mul(f_prod);
           let new_polys = vec![B_poly, f_prod, diff];
           *value = (
             Box::new(self.clone()),
-            BatchProveStateValues::CQ2(*n, m_i.clone(), *T_x_2, new_polys, vec![alpha, beta], vec![], vec![]),
+            BatchProveStateValues::CQ2(
+              *n,
+              RefCell::clone(m_i),
+              *T_x_2,
+              new_polys,
+              vec![alpha, beta],
+              vec![],
+              RefCell::new(vec![]),
+            ),
           )
         } else {
         }
@@ -353,10 +355,9 @@ impl BasicBlock for CQ2BasicBlock {
     match guard.get_mut(&key) {
       Some(value) => {
         if let (_, BatchProveStateValues::CQ2(n, m_i, T_x_2, polys, rngs, proof_0, proof_2)) = value {
-          println!("cq2 3");
           let alpha = rngs[0];
           let beta = rngs[1];
-          let (proof, mut proof_2) = if proof_0.len() == 0 {
+          let (proof, proof_2) = if proof_0.len() == 0 {
             let B_poly = &polys[0];
             let f_prod = &polys[1];
             let diff = &polys[2];
@@ -374,12 +375,13 @@ impl BasicBlock for CQ2BasicBlock {
             };
             let B_DC = util::msm::<G1Projective>(&srs.X1A[N - *n..], &B_poly.coeffs);
 
-            let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
+            let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.borrow().iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
             let m_x = util::msm::<G1Projective>(&temp, &temp2);
 
             // Calculate A
             // element to m/(t + beta)
             let A_i: HashMap<usize, Fr> = m_i
+              .borrow()
               .iter()
               .map(|(i, y)| {
                 (
@@ -401,8 +403,11 @@ impl BasicBlock for CQ2BasicBlock {
 
             let mut rng2 = StdRng::from_entropy();
             let r: Vec<_> = (0..9).map(|_| Fr::rand(&mut rng2)).collect();
-            let commits = vec![m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC];
-            let mut commits: Vec<G1Projective> = commits.iter().enumerate().map(|(i, x)| (*x) + srs.Y1P * r[i]).collect();
+            let mut proof: Vec<_> = vec![m_x, A_x, A_Q_x, A_zero, A_zero_div, B_x, B_Q_x, B_zero_div, B_DC]
+              .iter()
+              .enumerate()
+              .map(|(i, x)| (*x) + srs.Y1P * r[i])
+              .collect();
             let mut C = vec![
               -(srs.X1P[N] - srs.X1P[0]) * r[2]
                 + agg_model_g1 * r[1]
@@ -413,34 +418,42 @@ impl BasicBlock for CQ2BasicBlock {
               -srs.X1P[1] * r[7] + srs.X1P[0] * (r[5] - r[3] * Fr::from(N as u32) * Fr::from(*n as u32).inverse().unwrap()),
               -srs.X1P[0] * r[8] + srs.X1P[N - *n] * r[5],
             ];
-            let proof_2 = vec![r[6], r[5], Fr::zero()];
-            commits.append(&mut C);
-            (commits, proof_2)
+            proof.append(&mut C);
+            (proof, &mut RefCell::new(vec![r[6], r[5], Fr::zero()]))
           } else {
-            (proof_0.clone(), proof_2.clone())
+            (proof_0.clone(), proof_2)
           };
 
           let zeta = if rngs.len() == 2 { Fr::rand(rng) } else { rngs[2] };
           let mu = if rngs.len() == 2 { Fr::rand(rng) } else { rngs[3] };
           let mu_pow = if rngs.len() == 2 { mu } else { rngs[4] * mu };
           let agg_input: Vec<_> = inputs[0].raw.iter().zip(inputs[1].raw.iter()).map(|(x, y)| *x + *y * alpha).collect();
-          let mut agg_input = Data::new(srs, &agg_input);
-          agg_input.r = inputs[0].r + inputs[1].r * alpha;
+          let agg_input_r = inputs[0].r + inputs[1].r * alpha;
+          let agg_input_poly = DensePolynomial::from_coefficients_vec(domain_n.ifft(&agg_input));
           let q1_poly: DensePolynomial<Fr> = if polys.len() < 4 {
-            agg_input.poly.mul(mu_pow)
+            agg_input_poly.mul(mu_pow)
           } else {
-            &polys[3] + &agg_input.poly.mul(mu_pow)
+            &polys[3] + &agg_input_poly.mul(mu_pow)
           };
-          let f_z = agg_input.poly.evaluate(&zeta);
-          proof_2[2] = proof_2[2] + agg_input.r * mu_pow;
-          let mut evals = proof_2.clone();
-          evals.push(f_z);
+          let f_z = agg_input_poly.evaluate(&zeta);
+          let agg_r = proof_2.borrow()[2];
+          proof_2.borrow_mut()[2] = agg_r + agg_input_r * mu_pow;
+          proof_2.borrow_mut().push(f_z);
+
           let new_rngs = vec![rngs[0], rngs[1], zeta, mu, mu_pow];
           let mut new_polys = polys[..3].to_vec();
           new_polys.push(q1_poly);
           *value = (
             Box::new(self.clone()),
-            BatchProveStateValues::CQ2(*n, m_i.clone(), *T_x_2, new_polys, new_rngs, proof, evals),
+            BatchProveStateValues::CQ2(
+              *n,
+              RefCell::clone(m_i),
+              *T_x_2,
+              new_polys,
+              new_rngs,
+              proof.clone(),
+              RefCell::clone(proof_2),
+            ),
           )
         } else {
         }
@@ -461,17 +474,17 @@ impl BasicBlock for CQ2BasicBlock {
       let W_poly = &q1_poly.sub(&q1_z_poly) / &q1_V;
       let W_x = util::msm::<G1Projective>(&srs.X1A, &W_poly.coeffs);
 
-      let fz_prod: Fr = proof_2[3..].iter().product();
+      let fz_prod: Fr = proof_2.borrow()[3..].iter().product();
       let mut rng2 = StdRng::from_entropy();
-      let r = &proof_2[..2];
-      let r_sum = proof_2[2];
+      let r = &proof_2.borrow()[..2];
+      let r_sum = proof_2.borrow()[2];
       let C5 = -(srs.X1P[*n] - srs.X1P[0]) * r[0] + srs.X1P[0] * fz_prod * r[1];
       let r = Fr::rand(&mut rng2);
       let C6 = -(srs.X1P[1] - srs.X1P[0] * zeta) * r + srs.X1P[0] * r_sum;
 
       let mut proof = proof_0.clone();
       proof.append(&mut vec![W_x, C5, C6]);
-      (proof, vec![*T_x_2], proof_2.clone())
+      (proof, vec![*T_x_2], proof_2.borrow().to_vec())
     } else {
       (vec![], vec![], vec![])
     }

--- a/src/basic_block/cq2.rs
+++ b/src/basic_block/cq2.rs
@@ -222,8 +222,8 @@ impl BasicBlock for CQ2BasicBlock {
         table_dict.insert((model[0].raw[i], model[1].raw[i]), i);
       }
     }
-    let mut guard = batch_prove_state.lock().unwrap();
-    match guard.get_mut(&key) {
+    let mut state_mut_ref = batch_prove_state.borrow_mut();
+    match state_mut_ref.get_mut(&key) {
       Some(value) => {
         if let (_, BatchProveStateValues::CQ2(n, m_i, T_x_2, polys, _, _, _)) = value {
           for x in inputs[0].raw.iter().zip(inputs[1].raw.iter()) {
@@ -249,7 +249,7 @@ impl BasicBlock for CQ2BasicBlock {
             m_i.entry(table_dict.get(&temp).unwrap().clone()).and_modify(|y| *y += 1).or_insert(1);
           }
         }
-        guard.insert(
+        state_mut_ref.insert(
           key.to_string(),
           (
             Box::new(self.clone()),
@@ -292,8 +292,8 @@ impl BasicBlock for CQ2BasicBlock {
     let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
 
     let key = format!("{:?}_{}", self, inputs[0].raw.len());
-    let mut guard = batch_prove_state.lock().unwrap();
-    match guard.get_mut(&key) {
+    let mut state_mut_ref = batch_prove_state.borrow_mut();
+    match state_mut_ref.get_mut(&key) {
       Some(value) => {
         if let (_, BatchProveStateValues::CQ2(n, m_i, T_x_2, polys, rngs, _, _)) = value {
           let alpha = if rngs.len() == 0 { Fr::rand(rng) } else { rngs[0] };
@@ -351,8 +351,8 @@ impl BasicBlock for CQ2BasicBlock {
     assert!(n <= N);
     let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
     let key = format!("{:?}_{}", self, n);
-    let mut guard = batch_prove_state.lock().unwrap();
-    match guard.get_mut(&key) {
+    let mut state_mut_ref = batch_prove_state.borrow_mut();
+    match state_mut_ref.get_mut(&key) {
       Some(value) => {
         if let (_, BatchProveStateValues::CQ2(n, m_i, T_x_2, polys, rngs, proof_0, proof_2)) = value {
           let alpha = rngs[0];
@@ -375,13 +375,13 @@ impl BasicBlock for CQ2BasicBlock {
             };
             let B_DC = util::msm::<G1Projective>(&srs.X1A[N - *n..], &B_poly.coeffs);
 
-            let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_i.borrow().iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
+            let m_ref = m_i.borrow();
+            let (temp, temp2): (Vec<G1Affine>, Vec<Fr>) = m_ref.iter().map(|(i, y)| (L_i_x_1[*i], Fr::from(*y as u32))).unzip();
             let m_x = util::msm::<G1Projective>(&temp, &temp2);
 
             // Calculate A
             // element to m/(t + beta)
-            let A_i: HashMap<usize, Fr> = m_i
-              .borrow()
+            let A_i: HashMap<usize, Fr> = m_ref
               .iter()
               .map(|(i, y)| {
                 (
@@ -474,17 +474,18 @@ impl BasicBlock for CQ2BasicBlock {
       let W_poly = &q1_poly.sub(&q1_z_poly) / &q1_V;
       let W_x = util::msm::<G1Projective>(&srs.X1A, &W_poly.coeffs);
 
-      let fz_prod: Fr = proof_2.borrow()[3..].iter().product();
+      let p_ref = proof_2.borrow();
+      let fz_prod: Fr = p_ref[3..].iter().product();
       let mut rng2 = StdRng::from_entropy();
-      let r = &proof_2.borrow()[..2];
-      let r_sum = proof_2.borrow()[2];
+      let r = &p_ref[..2];
+      let r_sum = p_ref[2];
       let C5 = -(srs.X1P[*n] - srs.X1P[0]) * r[0] + srs.X1P[0] * fz_prod * r[1];
       let r = Fr::rand(&mut rng2);
       let C6 = -(srs.X1P[1] - srs.X1P[0] * zeta) * r + srs.X1P[0] * r_sum;
 
       let mut proof = proof_0.clone();
       proof.append(&mut vec![W_x, C5, C6]);
-      (proof, vec![*T_x_2], proof_2.borrow().to_vec())
+      (proof, vec![*T_x_2], p_ref[3..].to_vec())
     } else {
       (vec![], vec![], vec![])
     }

--- a/src/basic_block/repeater.rs
+++ b/src/basic_block/repeater.rs
@@ -1,4 +1,4 @@
-use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{BasicBlock, BatchProveState, BatchProveStateValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
 use crate::{ndarr_azip, util};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_poly::univariate::DensePolynomial;
@@ -159,6 +159,76 @@ impl BasicBlock for RepeaterBasicBlock {
       proof.0.into_iter().flatten().collect(),
       proof.1.into_iter().flatten().collect(),
       proof.2.into_iter().flatten().collect(),
+    );
+    proof
+  }
+
+  fn batch_prove_first(
+    &self,
+    srs: &SRS,
+    setup: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<DensePolynomial<Fr>>),
+    mut batch_prove_state: &mut BatchProveState,
+    model: &ArrayD<Data>,
+    inputs: &Vec<&ArrayD<Data>>,
+    outputs: &Vec<&ArrayD<Data>>,
+    rng: &mut StdRng,
+    cache: ProveVerifyCache,
+  ) {
+    let mut temp = broadcastN(inputs, Some(outputs), self.N - 1);
+    ndarr_azip!(((localInputs, localOutputs) in &mut temp) {
+      let localInputs: Vec<_> = localInputs.iter().map(|y| y).collect();
+      let localOutputs: Vec<_> = localOutputs.as_ref().unwrap().iter().map(|y| y).collect();
+      let mut rng = rng.clone();
+      let _ = self.basic_block.batch_prove_first(srs, setup, &mut batch_prove_state, model, &localInputs, &localOutputs, &mut rng, cache.clone());
+    });
+  }
+
+  fn batch_prove_second(
+    &self,
+    srs: &SRS,
+    setup: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<DensePolynomial<Fr>>),
+    mut batch_prove_state: &mut BatchProveState,
+    model: &ArrayD<Data>,
+    inputs: &Vec<&ArrayD<Data>>,
+    outputs: &Vec<&ArrayD<Data>>,
+    rng: &mut StdRng,
+    cache: ProveVerifyCache,
+  ) {
+    let mut temp = broadcastN(inputs, Some(outputs), self.N - 1);
+    ndarr_azip!(((localInputs, localOutputs) in &mut temp) {
+      let localInputs: Vec<_> = localInputs.iter().map(|y| y).collect();
+      let localOutputs: Vec<_> = localOutputs.as_ref().unwrap().iter().map(|y| y).collect();
+      let mut rng = rng.clone();
+      let _ = self.basic_block.batch_prove_second(srs, setup, &mut batch_prove_state, model, &localInputs, &localOutputs, &mut rng, cache.clone());
+    });
+  }
+
+  fn batch_prove_third(
+    &self,
+    srs: &SRS,
+    setup: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<DensePolynomial<Fr>>),
+    mut batch_prove_state: &mut BatchProveState,
+    model: &ArrayD<Data>,
+    inputs: &Vec<&ArrayD<Data>>,
+    outputs: &Vec<&ArrayD<Data>>,
+    rng: &mut StdRng,
+    cache: ProveVerifyCache,
+  ) {
+    let mut temp = broadcastN(inputs, Some(outputs), self.N - 1);
+    ndarr_azip!(((localInputs, localOutputs) in &mut temp) {
+      let localInputs: Vec<_> = localInputs.iter().map(|y| y).collect();
+      let localOutputs: Vec<_> = localOutputs.as_ref().unwrap().iter().map(|y| y).collect();
+      let mut rng = rng.clone();
+      let _ = self.basic_block.batch_prove_third(srs, setup, &mut batch_prove_state, model, &localInputs, &localOutputs, &mut rng, cache.clone());
+    });
+  }
+
+  fn batch_prove(&self, srs: &SRS, batch_prove_values: &BatchProveStateValues, rng: &mut StdRng) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
+    let proof = self.basic_block.batch_prove(srs, &batch_prove_values, rng);
+    let proof = (
+      proof.0.into_iter().collect(),
+      proof.1.into_iter().collect(),
+      proof.2.into_iter().collect(),
     );
     proof
   }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -11,6 +11,7 @@ use ark_std::Zero;
 use ndarray::ArrayD;
 use plonky2::{timed, util::timing::TimingTree};
 use rand::rngs::StdRng;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs::File;
 use std::sync::{Arc, Mutex};
@@ -246,7 +247,7 @@ impl Graph {
     assert!(self.nodes.len() == self.precomputable.prove_and_verify.len());
     let cache = Arc::new(Mutex::new(HashMap::new()));
 
-    let mut batch_prove_state = Arc::new(Mutex::new(HashMap::new()));
+    let mut batch_prove_state = RefCell::new(HashMap::new());
     let _: Vec<_> = self
       .nodes
       .iter()
@@ -383,8 +384,8 @@ impl Graph {
       })
       .collect();
 
-    let guard = batch_prove_state.lock().unwrap();
-    guard
+    let state_ref = batch_prove_state.borrow();
+    state_ref
       .iter()
       .map(|x| {
         let prove_id = format!("| batch prove {:?}", x.0);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -247,132 +247,147 @@ impl Graph {
     let cache = Arc::new(Mutex::new(HashMap::new()));
 
     let mut batch_prove_state = Arc::new(Mutex::new(HashMap::new()));
-    let _ = self.nodes.iter().enumerate().map(|(i, n)| {
-      let precomputable = self.precomputable.prove_and_verify[i];
-      if precomputable {
-        // Skip proving for some layers if they are precomputable.
-        // These layers require no proving and verifying as their inputs are known (i.e., constants) during graph construction.
-        println!(
-          "{} | skipping proving for {i} {:?} because this layer is precomputable given the constant inputs",
-          self.layer_names[i], self.basic_blocks[n.basic_block]
-        );
-      } else {
-        let prove_id = format!("{} | proving first round {i} {:?}", self.layer_names[i], self.basic_blocks[n.basic_block]);
-        println!("{}", prove_id);
-        let myInputs = n
-          .inputs
-          .iter()
-          .map(|(basicblock_idx, output_idx)| {
-            if *basicblock_idx < 0 {
-              inputs[*output_idx + (-basicblock_idx - 1) as usize]
-            } else {
-              &(outputs[*basicblock_idx as usize][*output_idx])
-            }
-          })
-          .collect();
-        timed!(
-          timing,
-          &prove_id,
-          self.basic_blocks[n.basic_block].batch_prove_first(
-            srs,
-            setups[n.basic_block],
-            &mut batch_prove_state,
-            models[n.basic_block],
-            &myInputs,
-            outputs[i],
-            rng,
-            cache.clone(),
-          )
-        );
-      }
-    });
-    let _ = self.nodes.iter().enumerate().map(|(i, n)| {
-      let precomputable = self.precomputable.prove_and_verify[i];
-      if precomputable {
-        // Skip proving for some layers if they are precomputable.
-        // These layers require no proving and verifying as their inputs are known (i.e., constants) during graph construction.
-        println!(
-          "{} | skipping proving for {i} {:?} because this layer is precomputable given the constant inputs",
-          self.layer_names[i], self.basic_blocks[n.basic_block]
-        );
-      } else {
-        let prove_id = format!(
-          "{} | proving second round {i} {:?}",
-          self.layer_names[i], self.basic_blocks[n.basic_block]
-        );
-        println!("{}", prove_id);
-        let myInputs = n
-          .inputs
-          .iter()
-          .map(|(basicblock_idx, output_idx)| {
-            if *basicblock_idx < 0 {
-              inputs[*output_idx + (-basicblock_idx - 1) as usize]
-            } else {
-              &(outputs[*basicblock_idx as usize][*output_idx])
-            }
-          })
-          .collect();
-        timed!(
-          timing,
-          &prove_id,
-          self.basic_blocks[n.basic_block].batch_prove_second(
-            srs,
-            setups[n.basic_block],
-            &mut batch_prove_state,
-            models[n.basic_block],
-            &myInputs,
-            outputs[i],
-            rng,
-            cache.clone(),
-          )
-        );
-      }
-    });
-    let _ = self.nodes.iter().enumerate().map(|(i, n)| {
-      let precomputable = self.precomputable.prove_and_verify[i];
-      if precomputable {
-        // Skip proving for some layers if they are precomputable.
-        // These layers require no proving and verifying as their inputs are known (i.e., constants) during graph construction.
-        println!(
-          "{} | skipping proving for {i} {:?} because this layer is precomputable given the constant inputs",
-          self.layer_names[i], self.basic_blocks[n.basic_block]
-        );
-      } else {
-        let prove_id = format!("{} | proving third round {i} {:?}", self.layer_names[i], self.basic_blocks[n.basic_block]);
-        println!("{}", prove_id);
-        let myInputs = n
-          .inputs
-          .iter()
-          .map(|(basicblock_idx, output_idx)| {
-            if *basicblock_idx < 0 {
-              inputs[*output_idx + (-basicblock_idx - 1) as usize]
-            } else {
-              &(outputs[*basicblock_idx as usize][*output_idx])
-            }
-          })
-          .collect();
-        timed!(
-          timing,
-          &prove_id,
-          self.basic_blocks[n.basic_block].batch_prove_third(
-            srs,
-            setups[n.basic_block],
-            &mut batch_prove_state,
-            models[n.basic_block],
-            &myInputs,
-            outputs[i],
-            rng,
-            cache.clone(),
-          )
-        );
-      }
-    });
+    let _: Vec<_> = self
+      .nodes
+      .iter()
+      .enumerate()
+      .map(|(i, n)| {
+        let precomputable = self.precomputable.prove_and_verify[i];
+        if precomputable {
+          // Skip proving for some layers if they are precomputable.
+          // These layers require no proving and verifying as their inputs are known (i.e., constants) during graph construction.
+          println!(
+            "{} | skipping proving for {i} {:?} because this layer is precomputable given the constant inputs",
+            self.layer_names[i], self.basic_blocks[n.basic_block]
+          );
+        } else {
+          let prove_id = format!("{} | proving first round {i} {:?}", self.layer_names[i], self.basic_blocks[n.basic_block]);
+          println!("{}", prove_id);
+          let myInputs = n
+            .inputs
+            .iter()
+            .map(|(basicblock_idx, output_idx)| {
+              if *basicblock_idx < 0 {
+                inputs[*output_idx + (-basicblock_idx - 1) as usize]
+              } else {
+                &(outputs[*basicblock_idx as usize][*output_idx])
+              }
+            })
+            .collect();
+          timed!(
+            timing,
+            &prove_id,
+            self.basic_blocks[n.basic_block].batch_prove_first(
+              srs,
+              setups[n.basic_block],
+              &mut batch_prove_state,
+              models[n.basic_block],
+              &myInputs,
+              outputs[i],
+              rng,
+              cache.clone(),
+            )
+          );
+        }
+      })
+      .collect();
+    let _: Vec<_> = self
+      .nodes
+      .iter()
+      .enumerate()
+      .map(|(i, n)| {
+        let precomputable = self.precomputable.prove_and_verify[i];
+        if precomputable {
+          // Skip proving for some layers if they are precomputable.
+          // These layers require no proving and verifying as their inputs are known (i.e., constants) during graph construction.
+          println!(
+            "{} | skipping proving for {i} {:?} because this layer is precomputable given the constant inputs",
+            self.layer_names[i], self.basic_blocks[n.basic_block]
+          );
+        } else {
+          let prove_id = format!(
+            "{} | proving second round {i} {:?}",
+            self.layer_names[i], self.basic_blocks[n.basic_block]
+          );
+          println!("{}", prove_id);
+          let myInputs = n
+            .inputs
+            .iter()
+            .map(|(basicblock_idx, output_idx)| {
+              if *basicblock_idx < 0 {
+                inputs[*output_idx + (-basicblock_idx - 1) as usize]
+              } else {
+                &(outputs[*basicblock_idx as usize][*output_idx])
+              }
+            })
+            .collect();
+          timed!(
+            timing,
+            &prove_id,
+            self.basic_blocks[n.basic_block].batch_prove_second(
+              srs,
+              setups[n.basic_block],
+              &mut batch_prove_state,
+              models[n.basic_block],
+              &myInputs,
+              outputs[i],
+              rng,
+              cache.clone(),
+            )
+          );
+        }
+      })
+      .collect();
+    let _: Vec<_> = self
+      .nodes
+      .iter()
+      .enumerate()
+      .map(|(i, n)| {
+        let precomputable = self.precomputable.prove_and_verify[i];
+        if precomputable {
+          // Skip proving for some layers if they are precomputable.
+          // These layers require no proving and verifying as their inputs are known (i.e., constants) during graph construction.
+          println!(
+            "{} | skipping proving for {i} {:?} because this layer is precomputable given the constant inputs",
+            self.layer_names[i], self.basic_blocks[n.basic_block]
+          );
+        } else {
+          let prove_id = format!("{} | proving third round {i} {:?}", self.layer_names[i], self.basic_blocks[n.basic_block]);
+          println!("{}", prove_id);
+          let myInputs = n
+            .inputs
+            .iter()
+            .map(|(basicblock_idx, output_idx)| {
+              if *basicblock_idx < 0 {
+                inputs[*output_idx + (-basicblock_idx - 1) as usize]
+              } else {
+                &(outputs[*basicblock_idx as usize][*output_idx])
+              }
+            })
+            .collect();
+          timed!(
+            timing,
+            &prove_id,
+            self.basic_blocks[n.basic_block].batch_prove_third(
+              srs,
+              setups[n.basic_block],
+              &mut batch_prove_state,
+              models[n.basic_block],
+              &myInputs,
+              outputs[i],
+              rng,
+              cache.clone(),
+            )
+          );
+        }
+      })
+      .collect();
 
     let guard = batch_prove_state.lock().unwrap();
-    let prove_id = format!("| proving ");
     guard
       .iter()
       .map(|x| {
+        let prove_id = format!("| batch prove {:?}", x.0);
         let proof = timed!(timing, &prove_id, x.1 .0.batch_prove(srs, &x.1 .1, rng));
         let proof: (Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>) = (
           proof.0.iter().map(|x| (*x).into()).collect(),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -233,6 +233,107 @@ impl Graph {
       .collect()
   }
 
+  pub fn batch_prove(
+    &mut self,
+    srs: &SRS,
+    setups: &Vec<(&Vec<G1Affine>, &Vec<G2Affine>, &Vec<DensePolynomial<Fr>>)>,
+    models: &Vec<&ArrayD<Data>>,
+    inputs: &Vec<&ArrayD<Data>>,
+    outputs: &Vec<&Vec<&ArrayD<Data>>>,
+    rng: &mut StdRng,
+    timing: &mut TimingTree,
+  ) -> Vec<(Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>)> {
+    assert!(self.nodes.len() == self.precomputable.prove_and_verify.len());
+    let cache = Arc::new(Mutex::new(HashMap::new()));
+
+    let mut batch_prove_state = Arc::new(Mutex::new(HashMap::new()));
+    let _ = self.nodes.iter().enumerate().map(|(i, n)| {
+      let precomputable = self.precomputable.prove_and_verify[i];
+      if precomputable {
+        // Skip proving for some layers if they are precomputable.
+        // These layers require no proving and verifying as their inputs are known (i.e., constants) during graph construction.
+        println!(
+          "{} | skipping proving for {i} {:?} because this layer is precomputable given the constant inputs",
+          self.layer_names[i], self.basic_blocks[n.basic_block]
+        );
+      } else {
+        let prove_id = format!("{} | proving {i} {:?}", self.layer_names[i], self.basic_blocks[n.basic_block]);
+        println!("{}", prove_id);
+        let myInputs = n
+          .inputs
+          .iter()
+          .map(|(basicblock_idx, output_idx)| {
+            if *basicblock_idx < 0 {
+              inputs[*output_idx + (-basicblock_idx - 1) as usize]
+            } else {
+              &(outputs[*basicblock_idx as usize][*output_idx])
+            }
+          })
+          .collect();
+        timed!(
+          timing,
+          &prove_id,
+          self.basic_blocks[n.basic_block].batch_prove_first(
+            srs,
+            setups[n.basic_block],
+            &mut batch_prove_state,
+            models[n.basic_block],
+            &myInputs,
+            outputs[i],
+            rng,
+            cache.clone(),
+          )
+        );
+        timed!(
+          timing,
+          &prove_id,
+          self.basic_blocks[n.basic_block].batch_prove_second(
+            srs,
+            setups[n.basic_block],
+            &mut batch_prove_state,
+            models[n.basic_block],
+            &myInputs,
+            outputs[i],
+            rng,
+            cache.clone(),
+          )
+        );
+        timed!(
+          timing,
+          &prove_id,
+          self.basic_blocks[n.basic_block].batch_prove_third(
+            srs,
+            setups[n.basic_block],
+            &mut batch_prove_state,
+            models[n.basic_block],
+            &myInputs,
+            outputs[i],
+            rng,
+            cache.clone(),
+          )
+        );
+      }
+    });
+
+    let guard = batch_prove_state.lock().unwrap();
+    let prove_id = format!("| proving ");
+    guard
+      .iter()
+      .map(|x| {
+        let proof = timed!(timing, &prove_id, x.1 .0.batch_prove(srs, &x.1 .1, rng));
+        let proof: (Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>) = (
+          proof.0.iter().map(|x| (*x).into()).collect(),
+          proof.1.iter().map(|x| (*x).into()).collect(),
+          proof.2.iter().map(|x| (*x).into()).collect(),
+        );
+        let mut bytes = Vec::new();
+        proof.serialize_uncompressed(&mut bytes).unwrap();
+        util::add_randomness(rng, bytes);
+        proof
+      })
+      .collect()
+  }
+
   pub fn verify(
     &self,
     srs: &SRS,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -257,7 +257,7 @@ impl Graph {
           self.layer_names[i], self.basic_blocks[n.basic_block]
         );
       } else {
-        let prove_id = format!("{} | proving {i} {:?}", self.layer_names[i], self.basic_blocks[n.basic_block]);
+        let prove_id = format!("{} | proving first round {i} {:?}", self.layer_names[i], self.basic_blocks[n.basic_block]);
         println!("{}", prove_id);
         let myInputs = n
           .inputs
@@ -284,6 +284,34 @@ impl Graph {
             cache.clone(),
           )
         );
+      }
+    });
+    let _ = self.nodes.iter().enumerate().map(|(i, n)| {
+      let precomputable = self.precomputable.prove_and_verify[i];
+      if precomputable {
+        // Skip proving for some layers if they are precomputable.
+        // These layers require no proving and verifying as their inputs are known (i.e., constants) during graph construction.
+        println!(
+          "{} | skipping proving for {i} {:?} because this layer is precomputable given the constant inputs",
+          self.layer_names[i], self.basic_blocks[n.basic_block]
+        );
+      } else {
+        let prove_id = format!(
+          "{} | proving second round {i} {:?}",
+          self.layer_names[i], self.basic_blocks[n.basic_block]
+        );
+        println!("{}", prove_id);
+        let myInputs = n
+          .inputs
+          .iter()
+          .map(|(basicblock_idx, output_idx)| {
+            if *basicblock_idx < 0 {
+              inputs[*output_idx + (-basicblock_idx - 1) as usize]
+            } else {
+              &(outputs[*basicblock_idx as usize][*output_idx])
+            }
+          })
+          .collect();
         timed!(
           timing,
           &prove_id,
@@ -298,6 +326,31 @@ impl Graph {
             cache.clone(),
           )
         );
+      }
+    });
+    let _ = self.nodes.iter().enumerate().map(|(i, n)| {
+      let precomputable = self.precomputable.prove_and_verify[i];
+      if precomputable {
+        // Skip proving for some layers if they are precomputable.
+        // These layers require no proving and verifying as their inputs are known (i.e., constants) during graph construction.
+        println!(
+          "{} | skipping proving for {i} {:?} because this layer is precomputable given the constant inputs",
+          self.layer_names[i], self.basic_blocks[n.basic_block]
+        );
+      } else {
+        let prove_id = format!("{} | proving third round {i} {:?}", self.layer_names[i], self.basic_blocks[n.basic_block]);
+        println!("{}", prove_id);
+        let myInputs = n
+          .inputs
+          .iter()
+          .map(|(basicblock_idx, output_idx)| {
+            if *basicblock_idx < 0 {
+              inputs[*output_idx + (-basicblock_idx - 1) as usize]
+            } else {
+              &(outputs[*basicblock_idx as usize][*output_idx])
+            }
+          })
+          .collect();
         timed!(
           timing,
           &prove_id,

--- a/src/layer/cast.rs
+++ b/src/layer/cast.rs
@@ -31,26 +31,16 @@ impl Layer for CastLayer {
     };
     let change_sf_check = if input_shapes[0].len() == 0 {
       graph.addBB(Box::new(CQ2BasicBlock {
-        setup: Some((
-          Box::new(ChangeSFBasicBlock {
-            input_SF: input_SF,
-            output_SF: output_SF,
-          }),
-          *onnx::CQ_RANGE_LOWER,
-          *onnx::CQ_RANGE,
-        )),
+        op: cq2::CQ2BasicBlockOps::ChangeSF(input_SF, output_SF),
+        offset: *onnx::CQ_RANGE_LOWER,
+        size: *onnx::CQ_RANGE,
       }))
     } else {
       graph.addBB(Box::new(RepeaterBasicBlock {
         basic_block: Box::new(CQ2BasicBlock {
-          setup: Some((
-            Box::new(ChangeSFBasicBlock {
-              input_SF: input_SF,
-              output_SF: output_SF,
-            }),
-            *onnx::CQ_RANGE_LOWER,
-            *onnx::CQ_RANGE,
-          )),
+          op: cq2::CQ2BasicBlockOps::ChangeSF(input_SF, output_SF),
+          offset: *onnx::CQ_RANGE_LOWER,
+          size: *onnx::CQ_RANGE,
         }),
         N: 1,
       }))

--- a/src/layer/clip.rs
+++ b/src/layer/clip.rs
@@ -20,11 +20,13 @@ impl Layer for ClipLayer {
     let min = util::fr_to_int(constants[1].unwrap().0.as_slice().unwrap()[0]) as f32;
     let max = util::fr_to_int(constants[2].unwrap().0.as_slice().unwrap()[0]) as f32;
 
-    let clip = graph.addBB(Box::new(ClipBasicBlock { min: min, max: max }));
+    let clip = graph.addBB(Box::new(ClipBasicBlock { min, max }));
     let clip_output = graph.addNode(clip, vec![(-1, 0)]);
     let clip_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
-        setup: Some((Box::new(ClipBasicBlock { min: min, max: max }), *onnx::CQ_RANGE_LOWER, *onnx::CQ_RANGE)),
+        op: cq2::CQ2BasicBlockOps::Clip(min, max),
+        offset: *onnx::CQ_RANGE_LOWER,
+        size: *onnx::CQ_RANGE,
       }),
       N: 1,
     }));

--- a/src/layer/conv.rs
+++ b/src/layer/conv.rs
@@ -99,16 +99,16 @@ fn splat_input(
 }
 
 // Splats weights into shape (inp_channels * kernel_dims product x out_channels) such that each row corresponds to flattened kernels for each input channel
-fn splat_weights(weights: &ArrayD<Fr>, is_transpose: bool) -> Vec<Vec<Fr>> {
+fn splat_weights(weights_shape: &Vec<usize>, weights: &ArrayD<Fr>, is_transpose: bool) -> Vec<Vec<Fr>> {
   let mut weights_cells = vec![];
   let mut weight_row_idx = 0;
 
   // Input and output channel positions are swapped between Conv and ConvTranspose
-  let out_channels = if is_transpose { weights.shape()[1] } else { weights.shape()[0] };
-  let in_channels = if is_transpose { weights.shape()[0] } else { weights.shape()[1] };
+  let out_channels = if is_transpose { weights_shape[1] } else { weights_shape[0] };
+  let in_channels = if is_transpose { weights_shape[0] } else { weights_shape[1] };
   // (inp_channels * kernel_dims product x out_channels)
   for ck in 0..in_channels {
-    for ch_idx in indices(IxDyn(&weights.shape()[2..])) {
+    for ch_idx in indices(IxDyn(&weights_shape[2..])) {
       weights_cells.push(vec![]);
       for chan_out in 0..out_channels {
         let mut idx = if is_transpose { vec![ck, chan_out] } else { vec![chan_out, ck] };
@@ -136,7 +136,9 @@ pub fn splat_pad<G: Clone>(input: &Vec<Vec<G>>, pad_val: &G) -> ArrayD<G> {
 // 2. Perform matmul between inputs and weights with the resulting shape (out_dims product x out_channels). Each element corresponds to an element of the final output
 // 2a. If 1x1 kernel, the last dimension is out_channels and the rest are unchanged
 // 3. Scale down and add bias if it exists
-// 4. Reshape into the final output shape
+// 4. Reshape into [batch_size, out_h, out_w, outp_channels], skipped if 1x1 kernel
+// 5. Permute into [batch_size, out_h, outp_channels, out_w]
+// 6. Transpose into [batch_size, outp_channels, out_h, out_w]
 macro_rules! create_conv_layer {
   ($layer_name:ident, $is_transpose:expr) => {
     pub struct $layer_name;
@@ -182,7 +184,7 @@ macro_rules! create_conv_layer {
         }));
 
         // Matmul
-        let weights_splatted = splat_weights(constants[1].unwrap().0, $is_transpose);
+        let weights_splatted = splat_weights(&weight_shape, constants[1].unwrap().0, $is_transpose);
         let weights_padded = splat_pad(&weights_splatted, &Fr::zero());
         let cqlin = graph.addBB(Box::new(RepeaterBasicBlock {
           basic_block: Box::new(CQLinBasicBlock { setup: weights_padded }),
@@ -197,14 +199,9 @@ macro_rules! create_conv_layer {
         }));
         let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
           basic_block: Box::new(CQ2BasicBlock {
-            setup: Some((
-              Box::new(ChangeSFBasicBlock {
-                input_SF: sf_log * 2,
-                output_SF: sf_log,
-              }),
-              *onnx::CQ_RANGE_LOWER,
-              *onnx::CQ_RANGE,
-            )),
+            op: cq2::CQ2BasicBlockOps::ChangeSF(sf_log * 2, sf_log),
+            offset: *onnx::CQ_RANGE_LOWER,
+            size: *onnx::CQ_RANGE,
           }),
           N: 1,
         }));
@@ -229,7 +226,6 @@ macro_rules! create_conv_layer {
           }))
         };
 
-        // Only used if 1x1 kernel
         let a = input_shapes[0][1].next_power_of_two();
         let b = input_shapes[0][n - 1].next_power_of_two();
         let transpose1 = ((0..b).map(|x| x * a).collect(), (0..a).collect());
@@ -237,13 +233,8 @@ macro_rules! create_conv_layer {
           basic_block: Box::new(PermuteBasicBlock { permutation: transpose1 }),
           N: 2,
         }));
-        let transpose2 = ((0..a).map(|x| x * b).collect(), (0..b).collect());
-        let permute2 = graph.addBB(Box::new(RepeaterBasicBlock {
-          basic_block: Box::new(PermuteBasicBlock { permutation: transpose2 }),
-          N: 2,
-        }));
 
-        // Reshape matmul into output shape with transpose+permute with 1x1 optimization or with copy constraint otherwise
+        // Reshape matmul into output shape with transpose+permute with 1x1 optimization or with reshape+transpose+permute
         let mut padding = vec![];
         let pads = if $is_transpose {
           conv_transpose_pads(&pads, &ch_dims)
@@ -253,25 +244,28 @@ macro_rules! create_conv_layer {
         for i in 0..dims.len() {
           padding.push([pads[i], pads[dims.len() + i]]);
         }
-        let mut out_dims = out_hw(&dims, &strides, &ch_dims, &padding, $is_transpose);
         let cout = if $is_transpose { weight_shape[1] } else { weight_shape[0] };
+        let out_dims = out_hw(&dims, &strides, &ch_dims, &padding, $is_transpose);
         let mut output_shape = vec![1, cout];
-        output_shape.append(&mut out_dims);
+        output_shape.append(&mut out_dims.clone());
+        let a = cout.next_power_of_two();
+        let b = output_shape[n - 1].next_power_of_two();
+        let transpose2 = ((0..a).map(|x| x * b).collect(), (0..b).collect());
+        let permute2 = graph.addBB(Box::new(RepeaterBasicBlock {
+          basic_block: Box::new(PermuteBasicBlock { permutation: transpose2 }),
+          N: 2,
+        }));
 
-        let cc2 = if kernel_1x1_opt {
-          let mut perm = vec![0, n - 2];
-          let n = input_shapes[0].len();
-          perm.append(&mut (1..n - 2).collect());
-          perm.append(&mut vec![n - 1]);
-          graph.addBB(Box::new(TransposeBasicBlock { perm }))
-        } else {
-          let reshape_permutation = util::get_reshape_indices(vec![permutation.len(), weights_splatted[0].len()], output_shape.clone());
-          graph.addBB(Box::new(CopyConstraintBasicBlock {
-            permutation: reshape_permutation,
-            input_dim: IxDyn(&[permutation.len().next_power_of_two(), weights_splatted[0].len().next_power_of_two()]),
-            padding_partition: copy_constraint::PaddingEnum::Zero,
-          }))
-        };
+        let mut perm = vec![0, n - 2];
+        let n = input_shapes[0].len();
+        perm.append(&mut (1..n - 2).collect());
+        perm.append(&mut vec![n - 1]);
+        let transpose_bb = graph.addBB(Box::new(TransposeBasicBlock { perm }));
+
+        let mut reshape_shape = vec![1];
+        reshape_shape.append(&mut out_dims.iter().map(|x| x.next_power_of_two()).collect());
+        reshape_shape.push(cout.next_power_of_two());
+        let reshape = graph.addBB(Box::new(ReshapeBasicBlock { shape: reshape_shape }));
 
         // Splat input with transpose+permute with 1x1 optimization or with copy constraint otherwise
         let cc_output = if kernel_1x1_opt {
@@ -295,14 +289,16 @@ macro_rules! create_conv_layer {
           }
         };
 
-        // Reshape matmul into output shape with transpose+permute with 1x1 optimization or with copy constraint otherwise
-        let cc2_output = if kernel_1x1_opt {
+        // Reshape matmul into output shape with transpose+permute with 1x1 optimization or with reshape+transpose+permute
+        let reshape_output = if kernel_1x1_opt {
           let trans_output = graph.addNode(permute2, vec![(add_output, 0)]);
-          graph.addNode(cc2, vec![(trans_output, 0)])
+          graph.addNode(transpose_bb, vec![(trans_output, 0)])
         } else {
-          graph.addNode(cc2, vec![(add_output, 0)])
+          let reshapebb_output = graph.addNode(reshape, vec![(add_output, 0)]);
+          let trans_output = graph.addNode(permute2, vec![(reshapebb_output, 0)]);
+          graph.addNode(transpose_bb, vec![(trans_output, 0)])
         };
-        graph.outputs.push((cc2_output, 0));
+        graph.outputs.push((reshape_output, 0));
         (graph, vec![output_shape], vec![input_types[0]])
       }
     }

--- a/src/layer/div.rs
+++ b/src/layer/div.rs
@@ -12,7 +12,7 @@ use tract_onnx::prelude::DatumType;
 // when output_idx equals to 0, the layer returns the quotient. (Div)
 // when output_idx equals to 1, the layer returns the remainder. (Mod)
 macro_rules! create_division_layer {
-  ($layer_name:ident, $const_block:ident, $output_idx:expr) => {
+  ($layer_name:ident, $const_block:ident, $const_enum:ident, $output_idx:expr) => {
     pub struct $layer_name;
 
     impl Layer for $layer_name {
@@ -48,12 +48,16 @@ macro_rules! create_division_layer {
           // Add a basic block for range checking with custom setup
           let const_check = if input_shapes[0].len() == input_shapes[1].len() && input_shapes[0].len() == 0 {
             graph.addBB(Box::new(CQ2BasicBlock {
-              setup: Some((Box::new($const_block { c: c_value as _ }), *onnx::CQ_RANGE_LOWER, *onnx::CQ_RANGE)),
+              op: cq2::CQ2BasicBlockOps::$const_enum(c_value as _),
+              offset: *onnx::CQ_RANGE_LOWER,
+              size: *onnx::CQ_RANGE,
             }))
           } else {
             graph.addBB(Box::new(RepeaterBasicBlock {
               basic_block: Box::new(CQ2BasicBlock {
-                setup: Some((Box::new($const_block { c: c_value as _ }), *onnx::CQ_RANGE_LOWER, *onnx::CQ_RANGE)),
+                op: cq2::CQ2BasicBlockOps::$const_enum(c_value as _),
+                offset: *onnx::CQ_RANGE_LOWER,
+                size: *onnx::CQ_RANGE,
               }),
               N: 1,
             }))
@@ -168,5 +172,5 @@ macro_rules! create_division_layer {
 }
 
 // Create DivLayer and ModLayer using the macro
-create_division_layer!(DivLayer, DivConstBasicBlock, 0);
-create_division_layer!(ModLayer, ModConstBasicBlock, 1);
+create_division_layer!(DivLayer, DivConstBasicBlock, DivConst, 0);
+create_division_layer!(ModLayer, ModConstBasicBlock, ModConst, 1);

--- a/src/layer/einsum.rs
+++ b/src/layer/einsum.rs
@@ -72,14 +72,9 @@ fn vector_outer_product(graph: &mut Graph, input_shapes: &Vec<&Vec<usize>>) -> V
   }));
   let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
     basic_block: Box::new(CQ2BasicBlock {
-      setup: Some((
-        Box::new(ChangeSFBasicBlock {
-          input_SF: sf_log * 2,
-          output_SF: sf_log,
-        }),
-        *onnx::CQ_RANGE_LOWER,
-        *onnx::CQ_RANGE,
-      )),
+      op: cq2::CQ2BasicBlockOps::ChangeSF(sf_log * 2, sf_log),
+      offset: *onnx::CQ_RANGE_LOWER,
+      size: *onnx::CQ_RANGE,
     }),
     N: 1,
   }));
@@ -122,14 +117,9 @@ fn vector_inner_product(graph: &mut Graph, _input_shapes: &Vec<&Vec<usize>>) -> 
   }));
   let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
     basic_block: Box::new(CQ2BasicBlock {
-      setup: Some((
-        Box::new(ChangeSFBasicBlock {
-          input_SF: sf_log * 2,
-          output_SF: sf_log,
-        }),
-        *onnx::CQ_RANGE_LOWER,
-        *onnx::CQ_RANGE,
-      )),
+      op: cq2::CQ2BasicBlockOps::ChangeSF(sf_log * 2, sf_log),
+      offset: *onnx::CQ_RANGE_LOWER,
+      size: *onnx::CQ_RANGE,
     }),
     N: 1,
   }));

--- a/src/layer/gemm.rs
+++ b/src/layer/gemm.rs
@@ -76,14 +76,9 @@ impl Layer for GemmLayer {
     }));
     let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
-        setup: Some((
-          Box::new(ChangeSFBasicBlock {
-            input_SF: sf_log * 2,
-            output_SF: sf_log,
-          }),
-          *onnx::CQ_RANGE_LOWER,
-          *onnx::CQ_RANGE,
-        )),
+        op: cq2::CQ2BasicBlockOps::ChangeSF(sf_log * 2, sf_log),
+        offset: *onnx::CQ_RANGE_LOWER,
+        size: *onnx::CQ_RANGE,
       }),
       N: 1,
     }));

--- a/src/layer/lstm.rs
+++ b/src/layer/lstm.rs
@@ -126,14 +126,9 @@ impl Layer for LSTMLayer {
       }));
       let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
         basic_block: Box::new(CQ2BasicBlock {
-          setup: Some((
-            Box::new(ChangeSFBasicBlock {
-              input_SF: sf_log * 2,
-              output_SF: sf_log,
-            }),
-            *onnx::CQ_RANGE_LOWER,
-            *onnx::CQ_RANGE,
-          )),
+          op: cq2::CQ2BasicBlockOps::ChangeSF(sf_log * 2, sf_log),
+          offset: *onnx::CQ_RANGE_LOWER,
+          size: *onnx::CQ_RANGE,
         }),
         N: 1,
       }));
@@ -203,14 +198,9 @@ impl Layer for LSTMLayer {
       }));
       let sigmoid_check = graph.addBB(Box::new(RepeaterBasicBlock {
         basic_block: Box::new(CQ2BasicBlock {
-          setup: Some((
-            Box::new(SigmoidBasicBlock {
-              input_SF: sf_log * 2,
-              output_SF: sf_log,
-            }),
-            *onnx::CQ_RANGE_LOWER,
-            *onnx::CQ_RANGE,
-          )),
+          op: cq2::CQ2BasicBlockOps::Sigmoid(sf_log * 2, sf_log),
+          offset: *onnx::CQ_RANGE_LOWER,
+          size: *onnx::CQ_RANGE,
         }),
         N: 1,
       }));
@@ -232,14 +222,9 @@ impl Layer for LSTMLayer {
       }));
       let tanh_check = graph.addBB(Box::new(RepeaterBasicBlock {
         basic_block: Box::new(CQ2BasicBlock {
-          setup: Some((
-            Box::new(TanhBasicBlock {
-              input_SF: sf_log * 2,
-              output_SF: sf_log,
-            }),
-            *onnx::CQ_RANGE_LOWER,
-            *onnx::CQ_RANGE,
-          )),
+          op: cq2::CQ2BasicBlockOps::Tanh(sf_log * 2, sf_log),
+          offset: *onnx::CQ_RANGE_LOWER,
+          size: *onnx::CQ_RANGE,
         }),
         N: 1,
       }));

--- a/src/layer/matmul.rs
+++ b/src/layer/matmul.rs
@@ -31,14 +31,9 @@ impl Layer for MatMulLayer {
     }));
     let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
-        setup: Some((
-          Box::new(ChangeSFBasicBlock {
-            input_SF: sf_log * 2,
-            output_SF: sf_log,
-          }),
-          *onnx::CQ_RANGE_LOWER,
-          *onnx::CQ_RANGE,
-        )),
+        op: cq2::CQ2BasicBlockOps::ChangeSF(sf_log * 2, sf_log),
+        offset: *onnx::CQ_RANGE_LOWER,
+        size: *onnx::CQ_RANGE,
       }),
       N: 1,
     }));
@@ -108,14 +103,9 @@ impl Layer for MultiHeadMatMulLayer {
     }));
     let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
-        setup: Some((
-          Box::new(ChangeSFBasicBlock {
-            input_SF: sf_log * 2,
-            output_SF: sf_log,
-          }),
-          *onnx::CQ_RANGE_LOWER,
-          *onnx::CQ_RANGE,
-        )),
+        op: cq2::CQ2BasicBlockOps::ChangeSF(sf_log * 2, sf_log),
+        offset: *onnx::CQ_RANGE_LOWER,
+        size: *onnx::CQ_RANGE,
       }),
       N: 1,
     }));

--- a/src/layer/mul.rs
+++ b/src/layer/mul.rs
@@ -37,26 +37,16 @@ impl Layer for MulLayer {
     }));
     let change_SF_check = if input_shapes[0].len() == input_shapes[1].len() && input_shapes[0].len() == 0 {
       graph.addBB(Box::new(CQ2BasicBlock {
-        setup: Some((
-          Box::new(ChangeSFBasicBlock {
-            input_SF: sf_log * 2,
-            output_SF: sf_log,
-          }),
-          *onnx::CQ_RANGE_LOWER,
-          *onnx::CQ_RANGE,
-        )),
+        op: cq2::CQ2BasicBlockOps::ChangeSF(sf_log * 2, sf_log),
+        offset: *onnx::CQ_RANGE_LOWER,
+        size: *onnx::CQ_RANGE,
       }))
     } else {
       graph.addBB(Box::new(RepeaterBasicBlock {
         basic_block: Box::new(CQ2BasicBlock {
-          setup: Some((
-            Box::new(ChangeSFBasicBlock {
-              input_SF: sf_log * 2,
-              output_SF: sf_log,
-            }),
-            *onnx::CQ_RANGE_LOWER,
-            *onnx::CQ_RANGE,
-          )),
+          op: cq2::CQ2BasicBlockOps::ChangeSF(sf_log * 2, sf_log),
+          offset: *onnx::CQ_RANGE_LOWER,
+          size: *onnx::CQ_RANGE,
         }),
         N: 1,
       }))

--- a/src/layer/nonlinear.rs
+++ b/src/layer/nonlinear.rs
@@ -8,7 +8,7 @@ use tract_onnx::pb::AttributeProto;
 use tract_onnx::prelude::DatumType;
 
 macro_rules! define_nonlinear_layer {
-  ($struct_name:ident, $basic_block:ident) => {
+  ($struct_name:ident, $basic_block:ident, $enum_name:ident) => {
     pub struct $struct_name;
 
     impl Layer for $struct_name {
@@ -26,14 +26,9 @@ macro_rules! define_nonlinear_layer {
         }));
         let layer_check = graph.addBB(Box::new(RepeaterBasicBlock {
           basic_block: Box::new(CQ2BasicBlock {
-            setup: Some((
-              Box::new($basic_block {
-                input_SF: sf_log,
-                output_SF: sf_log,
-              }),
-              *onnx::CQ_RANGE_LOWER,
-              *onnx::CQ_RANGE,
-            )),
+            op: cq2::CQ2BasicBlockOps::$enum_name(sf_log, sf_log),
+            offset: *onnx::CQ_RANGE_LOWER,
+            size: *onnx::CQ_RANGE,
           }),
           N: 1,
         }));
@@ -47,14 +42,14 @@ macro_rules! define_nonlinear_layer {
 }
 
 // Using the macro to define nonlinear layers
-define_nonlinear_layer!(ReLULayer, ReLUBasicBlock);
-define_nonlinear_layer!(CeilLayer, CeilBasicBlock);
-define_nonlinear_layer!(ErfLayer, ErfBasicBlock);
-define_nonlinear_layer!(ExpLayer, ExpBasicBlock);
-define_nonlinear_layer!(SigmoidLayer, SigmoidBasicBlock);
-define_nonlinear_layer!(TanhLayer, TanhBasicBlock);
-define_nonlinear_layer!(CosLayer, CosBasicBlock);
-define_nonlinear_layer!(SinLayer, SinBasicBlock);
-define_nonlinear_layer!(TanLayer, TanBasicBlock);
-define_nonlinear_layer!(ReciprocalLayer, ReciprocalBasicBlock);
-define_nonlinear_layer!(GeLULayer, GeLUBasicBlock);
+define_nonlinear_layer!(ReLULayer, ReLUBasicBlock, ReLU);
+define_nonlinear_layer!(CeilLayer, CeilBasicBlock, Ceil);
+define_nonlinear_layer!(ErfLayer, ErfBasicBlock, Erf);
+define_nonlinear_layer!(ExpLayer, ExpBasicBlock, Exp);
+define_nonlinear_layer!(SigmoidLayer, SigmoidBasicBlock, Sigmoid);
+define_nonlinear_layer!(TanhLayer, TanhBasicBlock, Tanh);
+define_nonlinear_layer!(CosLayer, CosBasicBlock, Cos);
+define_nonlinear_layer!(SinLayer, SinBasicBlock, Sin);
+define_nonlinear_layer!(TanLayer, TanBasicBlock, Tan);
+define_nonlinear_layer!(ReciprocalLayer, ReciprocalBasicBlock, Reciprocal);
+define_nonlinear_layer!(GeLULayer, GeLUBasicBlock, GeLU);

--- a/src/layer/norm.rs
+++ b/src/layer/norm.rs
@@ -89,14 +89,9 @@ impl Layer for BatchNormLayer {
     }));
     let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
-        setup: Some((
-          Box::new(ChangeSFBasicBlock {
-            input_SF: sf_log * 2,
-            output_SF: sf_log,
-          }),
-          *onnx::CQ_RANGE_LOWER,
-          *onnx::CQ_RANGE,
-        )),
+        op: cq2::CQ2BasicBlockOps::ChangeSF(sf_log * 2, sf_log),
+        offset: *onnx::CQ_RANGE_LOWER,
+        size: *onnx::CQ_RANGE,
       }),
       N: 1,
     }));
@@ -363,14 +358,9 @@ impl Layer for InstanceNormLayer {
     }));
     let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
-        setup: Some((
-          Box::new(ChangeSFBasicBlock {
-            input_SF: sf_log * 2,
-            output_SF: sf_log,
-          }),
-          *onnx::CQ_RANGE_LOWER,
-          *onnx::CQ_RANGE,
-        )),
+        op: cq2::CQ2BasicBlockOps::ChangeSF(sf_log * 2, sf_log),
+        offset: *onnx::CQ_RANGE_LOWER,
+        size: *onnx::CQ_RANGE,
       }),
       N: 1,
     }));
@@ -379,13 +369,11 @@ impl Layer for InstanceNormLayer {
     }));
     let div_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
-        setup: Some((
-          Box::new(DivConstBasicBlock {
-            c: (X_shape.into_iter().skip(2).cloned().collect::<Vec<_>>().iter().fold(1, |x, &y| x * y) as f32).sqrt() * ((1 << sf_log) as f32),
-          }),
-          *onnx::CQ_RANGE_LOWER,
-          *onnx::CQ_RANGE,
-        )),
+        op: cq2::CQ2BasicBlockOps::DivConst(
+          (X_shape.into_iter().skip(2).cloned().collect::<Vec<_>>().iter().fold(1, |x, &y| x * y) as f32).sqrt() * ((1 << sf_log) as f32),
+        ),
+        offset: *onnx::CQ_RANGE_LOWER,
+        size: *onnx::CQ_RANGE,
       }),
       N: 1,
     }));

--- a/src/layer/pow.rs
+++ b/src/layer/pow.rs
@@ -106,14 +106,9 @@ impl Layer for PowLayer {
     }));
     let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
-        setup: Some((
-          Box::new(ChangeSFBasicBlock {
-            input_SF: sf_log * 2,
-            output_SF: sf_log,
-          }),
-          *onnx::CQ_RANGE_LOWER,
-          *onnx::CQ_RANGE,
-        )),
+        op: cq2::CQ2BasicBlockOps::ChangeSF(sf_log * 2, sf_log),
+        offset: *onnx::CQ_RANGE_LOWER,
+        size: *onnx::CQ_RANGE,
       }),
       N: 1,
     }));

--- a/src/layer/reducemean.rs
+++ b/src/layer/reducemean.rs
@@ -61,13 +61,9 @@ impl Layer for ReduceMeanLayer {
     }));
     let div_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
-        setup: Some((
-          Box::new(DivConstBasicBlock {
-            c: input_shapes[0][input_shapes[0].len() - 1] as f32,
-          }),
-          *onnx::CQ_RANGE_LOWER,
-          *onnx::CQ_RANGE,
-        )),
+        op: cq2::CQ2BasicBlockOps::DivConst(input_shapes[0][input_shapes[0].len() - 1] as f32),
+        offset: *onnx::CQ_RANGE_LOWER,
+        size: *onnx::CQ_RANGE,
       }),
       N: 1,
     }));

--- a/src/layer/softmax.rs
+++ b/src/layer/softmax.rs
@@ -28,14 +28,9 @@ impl Layer for SoftmaxLayer {
     }));
     let exp_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
-        setup: Some((
-          Box::new(ExpBasicBlock {
-            input_SF: sf_log,
-            output_SF: sf_log,
-          }),
-          (-(*onnx::CQ_RANGE as i32) + 1) as i128,
-          *onnx::CQ_RANGE,
-        )),
+        op: cq2::CQ2BasicBlockOps::Exp(sf_log, sf_log),
+        offset: (-(*onnx::CQ_RANGE as i32) + 1) as i128,
+        size: *onnx::CQ_RANGE,
       }),
       N: 1,
     }));
@@ -49,14 +44,9 @@ impl Layer for SoftmaxLayer {
     }));
     let rec_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
-        setup: Some((
-          Box::new(ReciprocalBasicBlock {
-            input_SF: sf_log,
-            output_SF: sf_log,
-          }),
-          0,
-          *onnx::CQ_RANGE,
-        )),
+        op: cq2::CQ2BasicBlockOps::Reciprocal(sf_log, sf_log),
+        offset: 0,
+        size: *onnx::CQ_RANGE,
       }),
       N: 1,
     }));
@@ -70,14 +60,9 @@ impl Layer for SoftmaxLayer {
     }));
     let change_SF_check = graph.addBB(Box::new(RepeaterBasicBlock {
       basic_block: Box::new(CQ2BasicBlock {
-        setup: Some((
-          Box::new(ChangeSFBasicBlock {
-            input_SF: sf_log * 2,
-            output_SF: sf_log,
-          }),
-          *onnx::CQ_RANGE_LOWER,
-          *onnx::CQ_RANGE,
-        )),
+        op: cq2::CQ2BasicBlockOps::ChangeSF(sf_log * 2, sf_log),
+        offset: *onnx::CQ_RANGE_LOWER,
+        size: *onnx::CQ_RANGE,
       }),
       N: 1,
     }));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,8 +1,9 @@
 use crate::basic_block::*;
 use crate::{ptau, util, util::convert_to_data};
-use ark_bn254::{Bn254, Fr, G1Affine, G2Affine};
+use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine};
 use ark_ec::pairing::{Pairing, PairingOutput};
 use ark_poly::univariate::DensePolynomial;
+use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_std::UniformRand;
 use ark_std::{One, Zero};
 use core::panic;
@@ -89,7 +90,7 @@ fn testBasicBlocks() {
     &a,
     &vec![&a_n],
   );
-  testBasicBlock(CQ2BasicBlock { setup: None }, srs, &ab, &vec![&a_n, &b_n]);
+  // testBasicBlock(CQ2BasicBlock { setup: None }, srs, &ab, &vec![&a_n, &b_n]);
   testBasicBlock(SumBasicBlock {}, srs, &empty, &vec![&a]);
 
   let data_to_split = ArrayD::from_shape_fn(IxDyn(&[4, 2]), |_| Fr::rand(&mut rng));
@@ -139,6 +140,113 @@ fn testBasicBlocks() {
   let b_ind = ArrayD::from_shape_vec(IxDyn(&[4]), vec![3, 2, 1, 0].into_iter().map(|x| Fr::from(x)).collect()).unwrap();
   testBasicBlock(OneToOneBasicBlock {}, srs, &empty, &vec![&a, &a_ind, &b, &b_ind]);
   testBasicBlock(OrderedBasicBlock {}, srs, &empty, &vec![&b]);
+}
+
+fn testBatchProve<BB: BasicBlock>(basic_block: BB, srs: &SRS, model: &ArrayD<Fr>, inputs: &Vec<&ArrayD<Fr>>) {
+  let mut rng = StdRng::from_entropy();
+  let outputs = basic_block.run(model, inputs);
+  let outputs = if outputs.is_ok() { outputs.unwrap() } else { panic!("Error in run") };
+  let outputs: Vec<&ArrayD<Fr>> = outputs.iter().map(|x| x).collect();
+  let model = convert_to_data(srs, model);
+  let setup = basic_block.setup(srs, &model);
+  let setup: (Vec<G1Affine>, Vec<G2Affine>, Vec<DensePolynomial<Fr>>) = (
+    setup.0.iter().map(|y| (*y).into()).collect(),
+    setup.1.iter().map(|y| (*y).into()).collect(),
+    setup.2.iter().map(|y| (y.clone())).collect(),
+  );
+  let setup = (&setup.0, &setup.1, &setup.2);
+  let inputs: Vec<ArrayD<Data>> = inputs.iter().map(|input| convert_to_data(srs, input)).collect();
+  let inputs: Vec<&ArrayD<Data>> = inputs.iter().map(|input| input).collect();
+  let outputs: Vec<ArrayD<Data>> = basic_block.encodeOutputs(srs, &model, &inputs, &outputs);
+  let outputs: Vec<&ArrayD<Data>> = outputs.iter().map(|output| output).collect();
+  let mut rng2 = rng.clone();
+  let cache = Arc::new(Mutex::new(HashMap::new()));
+  let mut batch_prove_state = Arc::new(Mutex::new(HashMap::new()));
+
+  for input in inputs.iter() {
+    basic_block.batch_prove_first(
+      srs,
+      setup,
+      &mut batch_prove_state,
+      &model,
+      &vec![input],
+      &outputs,
+      &mut rng,
+      cache.clone(),
+    );
+  }
+  for input in inputs.iter() {
+    basic_block.batch_prove_second(
+      srs,
+      setup,
+      &mut batch_prove_state,
+      &model,
+      &vec![input],
+      &outputs,
+      &mut rng,
+      cache.clone(),
+    );
+  }
+  let guard = batch_prove_state.lock().unwrap();
+  let proofs: HashMap<_, (Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>)> = guard
+    .keys()
+    .map(|key| {
+      let (bb, values) = guard.get(key).unwrap();
+      let proof = bb.batch_prove(srs, values, &mut rng);
+      let proof = (
+        proof.0.iter().map(|y| (*y).into()).collect(),
+        proof.1.iter().map(|y| (*y).into()).collect(),
+        proof.2.iter().map(|y| (*y)).collect(),
+      );
+      (key, (proof.0, proof.1, proof.2))
+    })
+    .collect();
+  let model = model.map(|x| DataEnc::new(srs, x));
+  let inputs: Vec<ArrayD<DataEnc>> = inputs.iter().map(|x| (*x).map(|y| DataEnc::new(srs, y))).collect();
+  let inputs: Vec<&ArrayD<DataEnc>> = inputs.iter().map(|input| input).collect();
+  let outputs: Vec<ArrayD<DataEnc>> = outputs.iter().map(|x| (*x).map(|y| DataEnc::new(srs, y))).collect();
+  let outputs: Vec<&ArrayD<DataEnc>> = outputs.iter().map(|output| output).collect();
+  let cache = Arc::new(Mutex::new(HashMap::new()));
+
+  let mut batch_verify_state = Arc::new(Mutex::new(HashMap::new()));
+  for input in inputs.iter() {
+    basic_block.batch_verify_first(&mut batch_verify_state, &model, &vec![input], &outputs, &mut rng, cache.clone());
+  }
+  let guard = batch_verify_state.lock().unwrap();
+  let pairings: Vec<_> = guard
+    .keys()
+    .map(|key| {
+      let proof = proofs.get(key).unwrap();
+      let proof: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>) = (
+        &proof.0.iter().map(|y| *y).collect(),
+        &proof.1.iter().map(|y| *y).collect(),
+        &proof.2.iter().map(|y| *y).collect(),
+      );
+      let (bb, values) = guard.get(key).unwrap();
+      bb.batch_verify(srs, proof, values, &mut rng)
+    })
+    .flatten()
+    .collect();
+  let pairings = pairings.iter().map(|x| x).collect();
+  let pairings = util::combine_pairing_checks(&pairings);
+  assert_eq!(Bn254::multi_pairing(pairings.0.iter(), pairings.1.iter()), PairingOutput::zero());
+}
+
+#[test]
+fn test_batch() {
+  let srs = &ptau::load_file("challenge", 7, 7);
+  let mut rng = StdRng::from_entropy();
+  let N: usize = 1 << 6;
+  let a = ArrayD::from_shape_fn(IxDyn(&[N]), |_| Fr::from(rng.gen_range(0..10)));
+  let a_1 = ArrayD::from_shape_fn(IxDyn(&[N]), |_| Fr::from(rng.gen_range(0..10)));
+  testBasicBlock(
+    CQBasicBlock {
+      setup: util::CQArrayType::Custom(((0..N).map(|x| Fr::from(x as i32))).collect::<Vec<_>>()),
+    },
+    srs,
+    &a,
+    &vec![&a, &a_1],
+  );
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,6 +9,7 @@ use ark_std::{One, Zero};
 use core::panic;
 use ndarray::{arr0, concatenate, s, ArrayD, Axis, IxDyn};
 use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -162,7 +163,7 @@ fn testBatchProve<BB: BasicBlock>(basic_block: BB, srs: &SRS, model: &ArrayD<Fr>
   let outputs: Vec<&ArrayD<Data>> = outputs.iter().map(|output| output).collect();
   let mut rng2 = rng.clone();
   let cache = Arc::new(Mutex::new(HashMap::new()));
-  let mut batch_prove_state = Arc::new(Mutex::new(HashMap::new()));
+  let mut batch_prove_state = RefCell::new(HashMap::new());
 
   for input in inputs.iter() {
     basic_block.batch_prove_first(
@@ -200,12 +201,11 @@ fn testBatchProve<BB: BasicBlock>(basic_block: BB, srs: &SRS, model: &ArrayD<Fr>
       cache.clone(),
     );
   }
-  let guard = batch_prove_state.lock().unwrap();
-  println!("keys {:?}", guard.keys());
-  let proofs: HashMap<_, (Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>)> = guard
+  let state_ref = batch_prove_state.borrow();
+  let proofs: HashMap<_, (Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>)> = state_ref
     .keys()
     .map(|key| {
-      let (bb, values) = guard.get(key).unwrap();
+      let (bb, values) = state_ref.get(key).unwrap();
       let proof = bb.batch_prove(srs, values, &mut rng);
       let proof = (
         proof.0.iter().map(|y| (*y).into()).collect(),
@@ -222,13 +222,13 @@ fn testBatchProve<BB: BasicBlock>(basic_block: BB, srs: &SRS, model: &ArrayD<Fr>
   let outputs: Vec<&ArrayD<DataEnc>> = outputs.iter().map(|output| output).collect();
   let cache = Arc::new(Mutex::new(HashMap::new()));
 
-  let mut batch_verify_state = Arc::new(Mutex::new(HashMap::new()));
+  let mut batch_verify_state = RefCell::new(HashMap::new());
   for input in inputs.iter() {
     basic_block.batch_verify_first(&mut batch_verify_state, &model, &vec![input], &outputs, &mut rng2, cache.clone());
   }
-  let guard = batch_verify_state.lock().unwrap();
-  println!("keys {:?}", guard.keys());
-  let pairings: Vec<_> = guard
+
+  let state_ref = batch_verify_state.borrow();
+  let pairings: Vec<_> = state_ref
     .keys()
     .map(|key| {
       let proof = proofs.get(key).unwrap();
@@ -237,7 +237,7 @@ fn testBatchProve<BB: BasicBlock>(basic_block: BB, srs: &SRS, model: &ArrayD<Fr>
         &proof.1.iter().map(|y| *y).collect(),
         &proof.2.iter().map(|y| *y).collect(),
       );
-      let (bb, values) = guard.get(key).unwrap();
+      let (bb, values) = state_ref.get(key).unwrap();
       bb.batch_verify(srs, proof, values, &mut rng2)
     })
     .flatten()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -252,15 +252,17 @@ fn test_batch() {
   let srs = &ptau::load_file("challenge", 7, 7);
   let mut rng = StdRng::from_entropy();
   let N: usize = 1 << 6;
-  let a = ArrayD::from_shape_fn(IxDyn(&[N]), |_| Fr::from(rng.gen_range(0..10)));
-  let a_1 = ArrayD::from_shape_fn(IxDyn(&[N]), |_| Fr::from(rng.gen_range(0..10)));
+  let n: usize = 1 << 1;
+  let a = ArrayD::from_shape_fn(IxDyn(&[n]), |_| Fr::from(rng.gen_range(0..10)));
+  let a_1 = ArrayD::from_shape_fn(IxDyn(&[n]), |_| Fr::from(rng.gen_range(0..10)));
+  let a_2 = ArrayD::from_shape_fn(IxDyn(&[n]), |_| Fr::from(rng.gen_range(0..10)));
   testBatchProve(
     CQBasicBlock {
       setup: util::CQArrayType::Custom(((0..N).map(|x| Fr::from(x as i32))).collect::<Vec<_>>()),
     },
     srs,
     &a,
-    &vec![&a, &a_1],
+    &vec![&a],
   );
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -82,15 +82,6 @@ fn testBasicBlocks() {
   testBasicBlock(SubBasicBlock {}, srs, &empty, &vec![&a_0, &b]);
   testBasicBlock(SubBasicBlock {}, srs, &empty, &vec![&b, &a_0]);
   testBasicBlock(SubBasicBlock {}, srs, &empty, &vec![&a_0, &a_0]);
-  testBasicBlock(
-    CQBasicBlock {
-      setup: util::CQArrayType::Custom(a.iter().map(|x| *x).collect::<Vec<_>>()),
-    },
-    srs,
-    &a,
-    &vec![&a_n],
-  );
-  // testBasicBlock(CQ2BasicBlock { setup: None }, srs, &ab, &vec![&a_n, &b_n]);
   testBasicBlock(SumBasicBlock {}, srs, &empty, &vec![&a]);
 
   let data_to_split = ArrayD::from_shape_fn(IxDyn(&[4, 2]), |_| Fr::rand(&mut rng));
@@ -144,8 +135,18 @@ fn testBasicBlocks() {
 
 fn testBatchProve<BB: BasicBlock>(basic_block: BB, srs: &SRS, model: &ArrayD<Fr>, inputs: &Vec<&ArrayD<Fr>>) {
   let mut rng = StdRng::from_entropy();
-  let outputs = basic_block.run(model, inputs);
-  let outputs = if outputs.is_ok() { outputs.unwrap() } else { panic!("Error in run") };
+  let outputs: Vec<_> = inputs.iter().map(|input| basic_block.run(model, &vec![input])).collect();
+  let outputs: Vec<_> = outputs
+    .iter()
+    .map(|output| {
+      if output.is_ok() {
+        output.clone().unwrap()
+      } else {
+        panic!("Error in run")
+      }
+    })
+    .flatten()
+    .collect();
   let outputs: Vec<&ArrayD<Fr>> = outputs.iter().map(|x| x).collect();
   let model = convert_to_data(srs, model);
   let setup = basic_block.setup(srs, &model);
@@ -187,7 +188,20 @@ fn testBatchProve<BB: BasicBlock>(basic_block: BB, srs: &SRS, model: &ArrayD<Fr>
       cache.clone(),
     );
   }
+  for input in inputs.iter() {
+    basic_block.batch_prove_third(
+      srs,
+      setup,
+      &mut batch_prove_state,
+      &model,
+      &vec![input],
+      &outputs,
+      &mut rng,
+      cache.clone(),
+    );
+  }
   let guard = batch_prove_state.lock().unwrap();
+  println!("keys {:?}", guard.keys());
   let proofs: HashMap<_, (Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>)> = guard
     .keys()
     .map(|key| {
@@ -210,9 +224,10 @@ fn testBatchProve<BB: BasicBlock>(basic_block: BB, srs: &SRS, model: &ArrayD<Fr>
 
   let mut batch_verify_state = Arc::new(Mutex::new(HashMap::new()));
   for input in inputs.iter() {
-    basic_block.batch_verify_first(&mut batch_verify_state, &model, &vec![input], &outputs, &mut rng, cache.clone());
+    basic_block.batch_verify_first(&mut batch_verify_state, &model, &vec![input], &outputs, &mut rng2, cache.clone());
   }
   let guard = batch_verify_state.lock().unwrap();
+  println!("keys {:?}", guard.keys());
   let pairings: Vec<_> = guard
     .keys()
     .map(|key| {
@@ -223,7 +238,7 @@ fn testBatchProve<BB: BasicBlock>(basic_block: BB, srs: &SRS, model: &ArrayD<Fr>
         &proof.2.iter().map(|y| *y).collect(),
       );
       let (bb, values) = guard.get(key).unwrap();
-      bb.batch_verify(srs, proof, values, &mut rng)
+      bb.batch_verify(srs, proof, values, &mut rng2)
     })
     .flatten()
     .collect();
@@ -239,7 +254,7 @@ fn test_batch() {
   let N: usize = 1 << 6;
   let a = ArrayD::from_shape_fn(IxDyn(&[N]), |_| Fr::from(rng.gen_range(0..10)));
   let a_1 = ArrayD::from_shape_fn(IxDyn(&[N]), |_| Fr::from(rng.gen_range(0..10)));
-  testBasicBlock(
+  testBatchProve(
     CQBasicBlock {
       setup: util::CQArrayType::Custom(((0..N).map(|x| Fr::from(x as i32))).collect::<Vec<_>>()),
     },

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -38,6 +38,7 @@ pub struct ProverConfig {
   pub enc_input_path: String,
   pub enc_output_path: String,
   pub proof_path: String,
+  pub batch_proof_path: String,
   pub enable_layer_setup: bool,
 }
 

--- a/src/util/prover.rs
+++ b/src/util/prover.rs
@@ -169,6 +169,12 @@ pub fn prove(
   // Prove:
   let proofs = timed!(timing, "prove", graph.prove(srs, &setups, &models, &inputs, &outputs, &mut rng, timing));
   proofs.serialize_uncompressed(File::create(&CONFIG.prover.proof_path).unwrap()).unwrap();
+  let batch_proofs = timed!(
+    timing,
+    "prove",
+    graph.batch_prove(srs, &setups, &models, &inputs, &outputs, &mut rng, timing)
+  );
+  batch_proofs.serialize_uncompressed(File::create(&CONFIG.prover.batch_proof_path).unwrap()).unwrap();
 }
 
 #[cfg(not(feature = "mock_prove"))]


### PR DESCRIPTION
Batch CQ draft. Requires a total of three passes to avoid saving all input polynomials, one to commit all the inputs, one for non-opening commitments, one for opening commitments, but currently, these three passes are done in addition to the normal prove pass.

- [ ] Add serialization for commitments between rounds for Fiat-Shamir rng
- [ ] Fix rng correction factors (Cs) at proof
- [x] Add graph batch verify
- [x] Add batch prove/verify to main