### PR TITLE
Mira matmul/permute readability

### DIFF
--- a/src/basic_block/matmul.rs
+++ b/src/basic_block/matmul.rs
@@ -13,10 +13,7 @@ use rayon::iter::ParallelIterator;
 
 struct MatMulAccProof<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize> {
   fiat_shamir: MatMulAccFiatShamir<P, Q>,
-  acc_corr1: P,
-  acc_corr2: P,
-  acc_corr3: P,
-  acc_corr4: P,
+  acc_corr: [P; 4],
   mu: Fr,
   prover_only: Option<MatMulAccProofProverOnly<P>>,
   errs: MatMulErrs<P, Q>,
@@ -114,10 +111,12 @@ fn accumulate(
       acc_flat_B_g2: matmul_acc.fiat_shamir.acc_flat_B_g2 + flat_B_g2 * acc_gamma,
       acc_beta_pow_g2: beta_pow_g2,
     },
-    acc_corr1: matmul_acc.acc_corr1 + corr1 * acc_gamma,
-    acc_corr2: matmul_acc.acc_corr2 + corr2 * acc_gamma,
-    acc_corr3: matmul_acc.acc_corr3 + corr3 * acc_gamma,
-    acc_corr4: matmul_acc.acc_corr4 + corr4 * acc_gamma,
+    acc_corr: [
+      matmul_acc.acc_corr[0] + corr1 * acc_gamma,
+      matmul_acc.acc_corr[1] + corr2 * acc_gamma,
+      matmul_acc.acc_corr[2] + corr3 * acc_gamma,
+      matmul_acc.acc_corr[3] + corr4 * acc_gamma,
+    ],
     mu: matmul_acc.mu + acc_gamma,
     prover_only: Some(MatMulAccProofProverOnly {
       acc_part_corr1: matmul_acc_prover_only.acc_part_corr1 + part_corr1 * acc_gamma,
@@ -205,10 +204,12 @@ fn matmul_acc_holder_to_acc<P: Clone + CanonicalSerialize, Q: Clone + CanonicalS
       acc_flat_B_g2: acc_holder.acc_g2[0].clone(),
       acc_beta_pow_g2: acc_holder.acc_g2[1].clone(),
     },
-    acc_corr1: acc_holder.acc_g1[7].clone(),
-    acc_corr2: acc_holder.acc_g1[8].clone(),
-    acc_corr3: acc_holder.acc_g1[9].clone(),
-    acc_corr4: acc_holder.acc_g1[10].clone(),
+    acc_corr: [
+      acc_holder.acc_g1[7].clone(),
+      acc_holder.acc_g1[8].clone(),
+      acc_holder.acc_g1[9].clone(),
+      acc_holder.acc_g1[10].clone(),
+    ],
     mu: acc_holder.mu,
     prover_only: if is_prover {
       Some(MatMulAccProofProverOnly {
@@ -281,10 +282,10 @@ fn matmul_acc_to_acc_holder<P: Clone + CanonicalSerialize, Q: Clone + CanonicalS
       acc.fiat_shamir.acc_right_x,
       acc.fiat_shamir.acc_right_Q_x,
       acc.fiat_shamir.acc_right_zero_div,
-      acc.acc_corr1,
-      acc.acc_corr2,
-      acc.acc_corr3,
-      acc.acc_corr4,
+      acc.acc_corr[0].clone(),
+      acc.acc_corr[1].clone(),
+      acc.acc_corr[2].clone(),
+      acc.acc_corr[3].clone(),
       acc.fiat_shamir.acc_flat_A,
       acc.fiat_shamir.acc_flat_B,
       acc.fiat_shamir.acc_flat_C,
@@ -310,10 +311,10 @@ fn matmul_acc_to_acc_holder<P: Clone + CanonicalSerialize, Q: Clone + CanonicalS
       acc.fiat_shamir.acc_right_x,
       acc.fiat_shamir.acc_right_Q_x,
       acc.fiat_shamir.acc_right_zero_div,
-      acc.acc_corr1,
-      acc.acc_corr2,
-      acc.acc_corr3,
-      acc.acc_corr4,
+      acc.acc_corr[0].clone(),
+      acc.acc_corr[1].clone(),
+      acc.acc_corr[2].clone(),
+      acc.acc_corr[3].clone(),
       acc.fiat_shamir.acc_flat_A,
       acc.fiat_shamir.acc_flat_B,
       acc.fiat_shamir.acc_flat_C,
@@ -733,7 +734,7 @@ impl BasicBlock for MatMulBasicBlock {
     let mut matmul_acc = acc_proof_to_matmul_acc(acc_proof, true).unwrap();
 
     let po = matmul_acc.prover_only.as_ref().unwrap();
-    matmul_acc.acc_corr1 = po.acc_part_corr1 * matmul_acc.mu
+    matmul_acc.acc_corr[0] = po.acc_part_corr1 * matmul_acc.mu
       + po.acc_flat_A_no_blind * po.acc_flat_B_r
       + po.acc_flat_B_no_blind * po.acc_flat_A_r
       + srs.Y1P * po.acc_flat_A_r * po.acc_flat_B_r;
@@ -883,10 +884,7 @@ impl BasicBlock for MatMulBasicBlock {
     let acc_flat_B = acc.fiat_shamir.acc_flat_B;
     let acc_flat_C = acc.fiat_shamir.acc_flat_C;
     let beta_pow_g2 = acc.fiat_shamir.acc_beta_pow_g2;
-    let acc_corr1 = acc.acc_corr1;
-    let acc_corr2 = acc.acc_corr2;
-    let acc_corr3 = acc.acc_corr3;
-    let acc_corr4 = acc.acc_corr4;
+    let acc_corr = acc.acc_corr;
     let acc_mu = acc.mu;
     let errs = &acc.acc_errs;
 
@@ -902,7 +900,7 @@ impl BasicBlock for MatMulBasicBlock {
       (acc_flat_A, acc_flat_B_g2),
       ((-acc_left_x * acc_mu).into(), srs.X2A[0]),
       ((-acc_left_Q_x * acc_mu).into(), (srs.X2A[self.m] - srs.X2A[0]).into()),
-      (-acc_corr1, srs.Y2A),
+      (-acc_corr[0], srs.Y2A),
     ];
     acc_1.extend(err_1);
 
@@ -911,21 +909,21 @@ impl BasicBlock for MatMulBasicBlock {
     let acc_3: PairingCheck = vec![
       ((acc_left_x - acc_left_zero).into(), srs.X2A[0]),
       (-acc_left_zero_div, srs.X2A[1]),
-      (-acc_corr2, srs.Y2A),
+      (-acc_corr[1], srs.Y2A),
     ];
 
     let acc_4: PairingCheck = vec![
       (acc_flat_C, beta_pow_g2),
       (-acc_right_x, srs.X2A[0]),
       (-acc_right_Q_x, (srs.X2A[self.n] - srs.X2A[0]).into()),
-      (-acc_corr3, srs.Y2A),
+      (-acc_corr[2], srs.Y2A),
     ];
 
     let acc_right_zero: G1Projective = acc_left_zero * (Fr::from(self.m as u32) * Fr::from(self.n as u32).inverse().unwrap());
     let acc_5 = vec![
       ((-acc_right_zero + acc_right_x).into(), srs.X2A[0]),
       (-acc_right_zero_div, srs.X2A[1]),
-      (-acc_corr4, srs.Y2A),
+      (-acc_corr[3], srs.Y2A),
     ];
 
     vec![acc_1, acc_2, acc_3, acc_4, acc_5]

--- a/src/basic_block/matmul.rs
+++ b/src/basic_block/matmul.rs
@@ -181,8 +181,6 @@ fn acc_proof_to_matmul_acc_holder<P: Clone, Q: Clone>(acc_proof: (&Vec<P>, &Vec<
     vec![],
   );
 
-  // println!("acc_err1: {:?}, {:?}", acc_err1.0.len(), acc_err1.1.len());
-
   let acc_errs = vec![acc_err1];
 
   AccHolder {

--- a/src/basic_block/matmul.rs
+++ b/src/basic_block/matmul.rs
@@ -11,7 +11,129 @@ use ndarray::{arr1, arr2, ArrayD, Ix1, Ix2, IxDyn};
 use rand::{rngs::StdRng, SeedableRng};
 use rayon::iter::ParallelIterator;
 
-fn acc_proof_to_matmul_acc<P: Clone, Q: Clone>(acc_proof: (&Vec<P>, &Vec<Q>, &Vec<Fr>), is_prover: bool) -> AccHolder<P, Q> {
+struct MatMulAccProof<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize> {
+  fiat_shamir: MatMulAccFiatShamir<P, Q>,
+  acc_corr1: P,
+  acc_corr2: P,
+  acc_corr3: P,
+  acc_corr4: P,
+  mu: Fr,
+  prover_only: Option<MatMulAccProofProverOnly<P>>,
+  errs: MatMulErrs<P, Q>,
+  acc_errs: MatMulErrs<P, Q>,
+}
+
+#[derive(CanonicalSerialize)]
+struct MatMulAccFiatShamir<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize> {
+  acc_left_x: P,
+  acc_left_Q_x: P,
+  acc_left_zero: P,
+  acc_left_zero_div: P,
+  acc_right_x: P,
+  acc_right_Q_x: P,
+  acc_right_zero_div: P,
+  acc_flat_A: P,
+  acc_flat_B: P,
+  acc_flat_C: P,
+  acc_flat_B_g2: Q,
+  acc_beta_pow_g2: Q,
+}
+
+struct MatMulAccProofProverOnly<P: Clone + CanonicalSerialize> {
+  acc_part_corr1: P,
+  acc_flat_A_no_blind: P,
+  acc_flat_B_no_blind: P,
+  acc_flat_A_r: Fr,
+  acc_flat_B_r: Fr,
+}
+
+#[derive(CanonicalSerialize, Clone)]
+struct MatMulErrs<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize> {
+  flat_A: P,
+  acc_flat_A: P,
+  acc_left_Q_x: P,
+  acc_left_x: P,
+  acc_part_corr1: P,
+  acc_flat_B_g2: Q,
+  flat_B_g2: Q,
+}
+
+fn accumulate(
+  matmul_acc: &MatMulAccProof<G1Projective, G2Projective>,
+  errs: &MatMulErrs<G1Projective, G2Projective>,
+  proof: &(&Vec<G1Projective>, &Vec<G2Projective>, &Vec<Fr>),
+  acc_gamma: Fr,
+) -> MatMulAccProof<G1Projective, G2Projective> {
+  let [left_x, left_Q_x, left_zero, left_zero_div, right_x, right_Q_x, right_zero_div, corr1, corr2, corr3, corr4, flat_A, flat_B, flat_C, part_corr1, flat_A_no_blind, flat_B_no_blind] =
+    proof.0[..]
+  else {
+    panic!("Wrong proof format")
+  };
+
+  let [flat_B_g2, beta_pow_g2] = proof.1[..] else {
+    panic!("Wrong proof format")
+  };
+  let [flat_A_r, flat_B_r] = proof.2[..] else {
+    panic!("Wrong proof format")
+  };
+
+  let new_errs = MatMulErrs {
+    flat_A: errs.flat_A * acc_gamma,
+    acc_flat_A: errs.acc_flat_A * acc_gamma,
+    acc_left_Q_x: errs.acc_left_Q_x * acc_gamma,
+    acc_left_x: errs.acc_left_x * acc_gamma,
+    acc_part_corr1: errs.acc_part_corr1 * acc_gamma,
+    acc_flat_B_g2: errs.acc_flat_B_g2,
+    flat_B_g2: errs.flat_B_g2,
+  };
+
+  let acc_errs = MatMulErrs {
+    flat_A: new_errs.flat_A,
+    acc_flat_A: new_errs.acc_flat_A,
+    acc_left_Q_x: matmul_acc.acc_errs.acc_left_Q_x + new_errs.acc_left_Q_x,
+    acc_left_x: matmul_acc.acc_errs.acc_left_x + new_errs.acc_left_x,
+    acc_part_corr1: matmul_acc.acc_errs.acc_part_corr1 + new_errs.acc_part_corr1,
+    acc_flat_B_g2: new_errs.acc_flat_B_g2,
+    flat_B_g2: new_errs.flat_B_g2,
+  };
+
+  // Compute the error
+  let matmul_acc_prover_only = matmul_acc.prover_only.as_ref().unwrap();
+  let new_matmul_acc = MatMulAccProof {
+    fiat_shamir: MatMulAccFiatShamir {
+      acc_left_x: matmul_acc.fiat_shamir.acc_left_x + left_x * acc_gamma,
+      acc_left_Q_x: matmul_acc.fiat_shamir.acc_left_Q_x + left_Q_x * acc_gamma,
+      acc_left_zero: matmul_acc.fiat_shamir.acc_left_zero + left_zero * acc_gamma,
+      acc_left_zero_div: matmul_acc.fiat_shamir.acc_left_zero_div + left_zero_div * acc_gamma,
+      acc_right_x: matmul_acc.fiat_shamir.acc_right_x + right_x * acc_gamma,
+      acc_right_Q_x: matmul_acc.fiat_shamir.acc_right_Q_x + right_Q_x * acc_gamma,
+      acc_right_zero_div: matmul_acc.fiat_shamir.acc_right_zero_div + right_zero_div * acc_gamma,
+      acc_flat_A: matmul_acc.fiat_shamir.acc_flat_A + flat_A * acc_gamma,
+      acc_flat_B: matmul_acc.fiat_shamir.acc_flat_B + flat_B * acc_gamma,
+      acc_flat_C: matmul_acc.fiat_shamir.acc_flat_C + flat_C * acc_gamma,
+      acc_flat_B_g2: matmul_acc.fiat_shamir.acc_flat_B_g2 + flat_B_g2 * acc_gamma,
+      acc_beta_pow_g2: beta_pow_g2,
+    },
+    acc_corr1: matmul_acc.acc_corr1 + corr1 * acc_gamma,
+    acc_corr2: matmul_acc.acc_corr2 + corr2 * acc_gamma,
+    acc_corr3: matmul_acc.acc_corr3 + corr3 * acc_gamma,
+    acc_corr4: matmul_acc.acc_corr4 + corr4 * acc_gamma,
+    mu: matmul_acc.mu + acc_gamma,
+    prover_only: Some(MatMulAccProofProverOnly {
+      acc_part_corr1: matmul_acc_prover_only.acc_part_corr1 + part_corr1 * acc_gamma,
+      acc_flat_A_no_blind: matmul_acc_prover_only.acc_flat_A_no_blind + flat_A_no_blind * acc_gamma,
+      acc_flat_B_no_blind: matmul_acc_prover_only.acc_flat_B_no_blind + flat_B_no_blind * acc_gamma,
+      acc_flat_A_r: matmul_acc_prover_only.acc_flat_A_r + flat_A_r * acc_gamma,
+      acc_flat_B_r: matmul_acc_prover_only.acc_flat_B_r + flat_B_r * acc_gamma,
+    }),
+    errs: errs.clone(),
+    acc_errs,
+  };
+
+  new_matmul_acc
+}
+
+fn acc_proof_to_matmul_acc_holder<P: Clone, Q: Clone>(acc_proof: (&Vec<P>, &Vec<Q>, &Vec<Fr>), is_prover: bool) -> AccHolder<P, Q> {
   if acc_proof.0.len() == 0 && acc_proof.1.len() == 0 && acc_proof.2.len() == 0 {
     return AccHolder {
       acc_g1: vec![],
@@ -51,6 +173,168 @@ fn acc_proof_to_matmul_acc<P: Clone, Q: Clone>(acc_proof: (&Vec<P>, &Vec<Q>, &Ve
     errs,
     acc_errs,
   }
+}
+
+fn acc_proof_to_matmul_acc<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize>(
+  acc_proof: (&Vec<P>, &Vec<Q>, &Vec<Fr>),
+  is_prover: bool,
+) -> Option<MatMulAccProof<P, Q>> {
+  if acc_proof.0.len() == 0 && acc_proof.1.len() == 0 && acc_proof.2.len() == 0 {
+    return None;
+  }
+  let acc_holder = acc_proof_to_matmul_acc_holder(acc_proof, is_prover);
+  Some(matmul_acc_holder_to_acc(acc_holder, is_prover))
+}
+
+fn matmul_acc_holder_to_acc<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize>(
+  acc_holder: AccHolder<P, Q>,
+  is_prover: bool,
+) -> MatMulAccProof<P, Q> {
+  let acc_proof = MatMulAccProof {
+    fiat_shamir: MatMulAccFiatShamir {
+      acc_left_x: acc_holder.acc_g1[0].clone(),
+      acc_left_Q_x: acc_holder.acc_g1[1].clone(),
+      acc_left_zero: acc_holder.acc_g1[2].clone(),
+      acc_left_zero_div: acc_holder.acc_g1[3].clone(),
+      acc_right_x: acc_holder.acc_g1[4].clone(),
+      acc_right_Q_x: acc_holder.acc_g1[5].clone(),
+      acc_right_zero_div: acc_holder.acc_g1[6].clone(),
+      acc_flat_A: acc_holder.acc_g1[11].clone(),
+      acc_flat_B: acc_holder.acc_g1[12].clone(),
+      acc_flat_C: acc_holder.acc_g1[13].clone(),
+      acc_flat_B_g2: acc_holder.acc_g2[0].clone(),
+      acc_beta_pow_g2: acc_holder.acc_g2[1].clone(),
+    },
+    acc_corr1: acc_holder.acc_g1[7].clone(),
+    acc_corr2: acc_holder.acc_g1[8].clone(),
+    acc_corr3: acc_holder.acc_g1[9].clone(),
+    acc_corr4: acc_holder.acc_g1[10].clone(),
+    mu: acc_holder.mu,
+    prover_only: if is_prover {
+      Some(MatMulAccProofProverOnly {
+        acc_part_corr1: acc_holder.acc_g1[14].clone(),
+        acc_flat_A_no_blind: acc_holder.acc_g1[15].clone(),
+        acc_flat_B_no_blind: acc_holder.acc_g1[16].clone(),
+        acc_flat_A_r: acc_holder.acc_fr[0],
+        acc_flat_B_r: acc_holder.acc_fr[1],
+      })
+    } else {
+      None
+    },
+    errs: MatMulErrs {
+      flat_A: acc_holder.errs[0].0[0].clone(),
+      acc_flat_A: acc_holder.errs[0].0[1].clone(),
+      acc_left_Q_x: acc_holder.errs[0].0[2].clone(),
+      acc_left_x: acc_holder.errs[0].0[3].clone(),
+      acc_part_corr1: acc_holder.errs[0].0[4].clone(),
+      acc_flat_B_g2: acc_holder.errs[0].1[0].clone(),
+      flat_B_g2: acc_holder.errs[0].1[1].clone(),
+    },
+    acc_errs: MatMulErrs {
+      flat_A: acc_holder.acc_errs[0].0[0].clone(),
+      acc_flat_A: acc_holder.acc_errs[0].0[1].clone(),
+      acc_left_Q_x: acc_holder.acc_errs[0].0[2].clone(),
+      acc_left_x: acc_holder.acc_errs[0].0[3].clone(),
+      acc_part_corr1: acc_holder.acc_errs[0].0[4].clone(),
+      acc_flat_B_g2: acc_holder.acc_errs[0].1[0].clone(),
+      flat_B_g2: acc_holder.acc_errs[0].1[1].clone(),
+    },
+  };
+  acc_proof
+}
+
+fn matmul_acc_to_acc_holder<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize>(
+  acc: MatMulAccProof<P, Q>,
+  is_prover: bool,
+) -> AccHolder<P, Q> {
+  let acc_g2 = vec![acc.fiat_shamir.acc_flat_B_g2, acc.fiat_shamir.acc_beta_pow_g2];
+  let mu = acc.mu;
+  let errs = vec![(
+    vec![
+      acc.errs.flat_A,
+      acc.errs.acc_flat_A,
+      acc.errs.acc_left_Q_x,
+      acc.errs.acc_left_x,
+      acc.errs.acc_part_corr1,
+    ],
+    vec![acc.errs.acc_flat_B_g2, acc.errs.flat_B_g2],
+    vec![],
+  )];
+  let acc_errs = vec![(
+    vec![
+      acc.acc_errs.flat_A,
+      acc.acc_errs.acc_flat_A,
+      acc.acc_errs.acc_left_Q_x,
+      acc.acc_errs.acc_left_x,
+      acc.acc_errs.acc_part_corr1,
+    ],
+    vec![acc.acc_errs.acc_flat_B_g2, acc.acc_errs.flat_B_g2],
+    vec![],
+  )];
+  if is_prover {
+    let prover_only = acc.prover_only.unwrap();
+    let acc_g1 = vec![
+      acc.fiat_shamir.acc_left_x,
+      acc.fiat_shamir.acc_left_Q_x,
+      acc.fiat_shamir.acc_left_zero,
+      acc.fiat_shamir.acc_left_zero_div,
+      acc.fiat_shamir.acc_right_x,
+      acc.fiat_shamir.acc_right_Q_x,
+      acc.fiat_shamir.acc_right_zero_div,
+      acc.acc_corr1,
+      acc.acc_corr2,
+      acc.acc_corr3,
+      acc.acc_corr4,
+      acc.fiat_shamir.acc_flat_A,
+      acc.fiat_shamir.acc_flat_B,
+      acc.fiat_shamir.acc_flat_C,
+      prover_only.acc_part_corr1,
+      prover_only.acc_flat_A_no_blind,
+      prover_only.acc_flat_B_no_blind,
+    ];
+    let acc_fr = vec![prover_only.acc_flat_A_r, prover_only.acc_flat_B_r];
+    AccHolder {
+      acc_g1,
+      acc_g2,
+      acc_fr,
+      mu,
+      errs,
+      acc_errs,
+    }
+  } else {
+    let acc_g1 = vec![
+      acc.fiat_shamir.acc_left_x,
+      acc.fiat_shamir.acc_left_Q_x,
+      acc.fiat_shamir.acc_left_zero,
+      acc.fiat_shamir.acc_left_zero_div,
+      acc.fiat_shamir.acc_right_x,
+      acc.fiat_shamir.acc_right_Q_x,
+      acc.fiat_shamir.acc_right_zero_div,
+      acc.acc_corr1,
+      acc.acc_corr2,
+      acc.acc_corr3,
+      acc.acc_corr4,
+      acc.fiat_shamir.acc_flat_A,
+      acc.fiat_shamir.acc_flat_B,
+      acc.fiat_shamir.acc_flat_C,
+    ];
+    AccHolder {
+      acc_g1,
+      acc_g2,
+      acc_fr: vec![],
+      mu,
+      errs,
+      acc_errs,
+    }
+  }
+}
+
+fn matmul_acc_to_acc_proof<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize>(
+  acc: MatMulAccProof<P, Q>,
+  is_prover: bool,
+) -> (Vec<P>, Vec<Q>, Vec<Fr>) {
+  let acc_holder = matmul_acc_to_acc_holder(acc, is_prover);
+  acc_to_acc_proof(acc_holder)
 }
 
 fn index<'a, T>(A: &'a ArrayD<T>, i: usize) -> &'a T {
@@ -395,90 +679,49 @@ impl BasicBlock for MatMulBasicBlock {
       panic!("Wrong proof format")
     };
 
-    let acc_holder = acc_proof_to_matmul_acc(acc_proof, true);
-    let mut new_acc_holder = AccHolder {
-      acc_g1: Vec::new(),
-      acc_g2: Vec::new(),
-      acc_fr: Vec::new(),
-      mu: Fr::zero(),
-      errs: Vec::new(),
-      acc_errs: Vec::new(),
-    };
+    let matmul_acc = acc_proof_to_matmul_acc(acc_proof, true).unwrap();
 
-    let [acc_left_x, acc_left_Q_x, _acc_left_zero, _acc_left_zero_div, _acc_right_x, _acc_right_Q_x, _acc_right_zero_div, _acc_corr1, _acc_corr2, _acc_corr3, _acc_corr4, acc_flat_A, _acc_flat_B, _acc_flat_C, acc_part_corr1, acc_flat_A_no_blind, acc_flat_B_no_blind] =
-      acc_holder.acc_g1[..]
-    else {
-      panic!("Wrong acc proof format")
-    };
-    let [acc_flat_B_g2, acc_beta_pow_g2] = acc_holder.acc_g2[..] else {
-      panic!("Wrong acc proof format")
-    };
-    assert!(beta_pow_g2 == acc_beta_pow_g2);
-    let acc_mu = acc_holder.mu;
-    let [acc_flat_A_r, acc_flat_B_r] = acc_holder.acc_fr[..] else {
-      panic!("Wrong acc proof format")
-    };
+    let acc_flat_A = matmul_acc.fiat_shamir.acc_flat_A;
+    let acc_left_x = matmul_acc.fiat_shamir.acc_left_x;
+    let acc_left_Q_x = matmul_acc.fiat_shamir.acc_left_Q_x;
+    let acc_mu = matmul_acc.mu;
+    let acc_part_corr1 = matmul_acc.prover_only.as_ref().unwrap().acc_part_corr1;
+    let po = matmul_acc.prover_only.as_ref().unwrap();
+    let acc_flat_A_no_blind = po.acc_flat_A_no_blind;
+    let acc_flat_B_no_blind = po.acc_flat_B_no_blind;
+    let acc_flat_A_r = po.acc_flat_A_r;
+    let acc_flat_B_r = po.acc_flat_B_r;
+    let acc_flat_B_g2 = matmul_acc.fiat_shamir.acc_flat_B_g2;
 
-    // Compute the error
-    let err: (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) = (
-      vec![
-        flat_A,
-        acc_flat_A,
-        acc_left_Q_x + left_Q_x * acc_mu,
-        acc_left_x + left_x * acc_mu,
-        acc_part_corr1
-          + part_corr1 * acc_mu
-          + acc_flat_A_no_blind * flat_B_r
-          + flat_A_no_blind * acc_flat_B_r
-          + acc_flat_B_no_blind * flat_A_r
-          + flat_B_no_blind * acc_flat_A_r
-          + srs.Y1P * (flat_A_r * acc_flat_B_r + flat_B_r * acc_flat_A_r),
-      ],
-      vec![acc_flat_B_g2, flat_B_g2],
-      vec![],
-    );
-    let mut errs = vec![err];
+    let errs = MatMulErrs {
+      flat_A,
+      acc_flat_A,
+      acc_left_Q_x: acc_left_Q_x + left_Q_x * acc_mu,
+      acc_left_x: acc_left_x + left_x * acc_mu,
+      acc_part_corr1: acc_part_corr1
+        + part_corr1 * acc_mu
+        + acc_flat_A_no_blind * flat_B_r
+        + flat_A_no_blind * acc_flat_B_r
+        + acc_flat_B_no_blind * flat_A_r
+        + flat_B_no_blind * acc_flat_A_r
+        + srs.Y1P * (flat_A_r * acc_flat_B_r + flat_B_r * acc_flat_A_r),
+      acc_flat_B_g2,
+      flat_B_g2,
+    };
 
     // Fiat-Shamir
     let mut bytes = Vec::new();
-    acc_holder.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
-    acc_holder.acc_g1[11..14].serialize_uncompressed(&mut bytes).unwrap();
-    acc_holder.acc_g2.serialize_uncompressed(&mut bytes).unwrap();
+    matmul_acc.fiat_shamir.serialize_uncompressed(&mut bytes).unwrap();
     proof.0[..7].serialize_uncompressed(&mut bytes).unwrap();
     proof.0[11..14].serialize_uncompressed(&mut bytes).unwrap();
     proof.1.serialize_uncompressed(&mut bytes).unwrap();
-    errs.iter().for_each(|(g1, g2, f)| {
-      g1.serialize_uncompressed(&mut bytes).unwrap();
-      g2.serialize_uncompressed(&mut bytes).unwrap();
-      f.serialize_uncompressed(&mut bytes).unwrap();
-    });
+    errs.serialize_uncompressed(&mut bytes).unwrap();
     util::add_randomness(rng, bytes);
     let acc_gamma = Fr::rand(rng);
 
-    new_acc_holder.acc_g1 = proof.0.iter().zip(acc_holder.acc_g1.iter()).map(|(x, y)| *x * acc_gamma + y).collect();
-    new_acc_holder.acc_g2 = vec![flat_B_g2 * acc_gamma + acc_flat_B_g2, beta_pow_g2];
-    new_acc_holder.acc_fr = proof.2.iter().zip(acc_holder.acc_fr.iter()).map(|(x, y)| *x * acc_gamma + y).collect();
-    new_acc_holder.mu = acc_mu + acc_gamma;
-    new_acc_holder.errs = errs.clone();
-    new_acc_holder.acc_errs = acc_holder.acc_errs;
+    let new_matmul_acc = accumulate(&matmul_acc, &errs, &proof, acc_gamma);
 
-    errs[0].0 = errs[0].0.iter().map(|x| (*x * acc_gamma).into()).collect();
-
-    // Append error terms
-    let err1_g1_len = new_acc_holder.acc_errs[0].0.len();
-    let q_term_g1 = new_acc_holder.acc_errs[0].0[err1_g1_len - 3].clone() + errs[0].0[2];
-    let l_term_g1 = new_acc_holder.acc_errs[0].0[err1_g1_len - 2].clone() + errs[0].0[3];
-    let c_term_g1 = new_acc_holder.acc_errs[0].0[err1_g1_len - 1].clone() + errs[0].0[4];
-    let mut errs_0_g1 = errs[0].0[..2].to_vec();
-    let mut errs_0_g2 = errs[0].1[..2].to_vec();
-
-    new_acc_holder.acc_errs[0].0 = new_acc_holder.acc_errs[0].0[..err1_g1_len - 3].to_vec();
-    new_acc_holder.acc_errs[0].0.append(&mut errs_0_g1);
-    new_acc_holder.acc_errs[0].0.push(q_term_g1);
-    new_acc_holder.acc_errs[0].0.push(l_term_g1);
-    new_acc_holder.acc_errs[0].0.push(c_term_g1);
-    new_acc_holder.acc_errs[0].1.append(&mut errs_0_g2);
-    acc_to_acc_proof(new_acc_holder)
+    matmul_acc_to_acc_proof(new_matmul_acc, true)
   }
 
   fn acc_clean(
@@ -487,16 +730,16 @@ impl BasicBlock for MatMulBasicBlock {
     proof: (&Vec<G1Projective>, &Vec<G2Projective>, &Vec<Fr>),
     acc_proof: (&Vec<G1Projective>, &Vec<G2Projective>, &Vec<Fr>),
   ) -> ((Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>), (Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>)) {
-    let mut acc_holder = acc_proof_to_matmul_acc(acc_proof, true);
-    // acc_corr1 = acc_part_corr1 * mu + acc_flat_A_no_blind * acc_flat_B_r + acc_flat_B_no_blind * acc_flat_A_r + srs.Y1P * acc_flat_A_r * acc_flat_B_r
-    acc_holder.acc_g1[7] = acc_holder.acc_g1[14] * acc_holder.mu
-      + acc_holder.acc_g1[15] * acc_holder.acc_fr[1]
-      + acc_holder.acc_g1[16] * acc_holder.acc_fr[0]
-      + srs.Y1P * acc_holder.acc_fr[0] * acc_holder.acc_fr[1];
-    // remove blinding terms from acc proof for the verifier
-    acc_holder.acc_g1 = acc_holder.acc_g1[..acc_holder.acc_g1.len() - 3].to_vec();
-    acc_holder.acc_fr = vec![];
-    let acc_proof = acc_to_acc_proof(acc_holder);
+    let mut matmul_acc = acc_proof_to_matmul_acc(acc_proof, true).unwrap();
+
+    let po = matmul_acc.prover_only.as_ref().unwrap();
+    matmul_acc.acc_corr1 = po.acc_part_corr1 * matmul_acc.mu
+      + po.acc_flat_A_no_blind * po.acc_flat_B_r
+      + po.acc_flat_B_no_blind * po.acc_flat_A_r
+      + srs.Y1P * po.acc_flat_A_r * po.acc_flat_B_r;
+
+    matmul_acc.prover_only = None;
+    let acc_proof = matmul_acc_to_acc_proof(matmul_acc, false);
 
     // remove blinding terms from bb proof for the verifier
     let cqlin_proof = (proof.0[..11].to_vec(), proof.1.to_vec(), vec![]);
@@ -574,10 +817,10 @@ impl BasicBlock for MatMulBasicBlock {
 
     let proof0_11_14 = vec![flat_A, flat_B, flat_C];
 
-    let prev_acc_holder = acc_proof_to_matmul_acc(prev_acc_proof, false);
-    let acc_holder = acc_proof_to_matmul_acc(acc_proof, false);
+    let prev_acc = acc_proof_to_matmul_acc(prev_acc_proof, false);
+    let acc = acc_proof_to_matmul_acc(acc_proof, false).unwrap();
 
-    if prev_acc_holder.mu.is_zero() && acc_holder.mu.is_one() {
+    if prev_acc.is_none() || (prev_acc.as_ref().unwrap().mu.is_zero() && acc.mu.is_one()) {
       // skip verifying RLC because no RLC was done in acc_init.
       // Fiat-shamir
       let mut bytes = Vec::new();
@@ -591,65 +834,68 @@ impl BasicBlock for MatMulBasicBlock {
 
     // Fiat-Shamir
     let mut bytes = Vec::new();
-    prev_acc_holder.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
-    prev_acc_holder.acc_g1[11..14].serialize_uncompressed(&mut bytes).unwrap();
-    prev_acc_holder.acc_g2.serialize_uncompressed(&mut bytes).unwrap();
+    let prev_acc = prev_acc.unwrap();
+    prev_acc.fiat_shamir.serialize_uncompressed(&mut bytes).unwrap();
     proof.0[..7].serialize_uncompressed(&mut bytes).unwrap();
     proof0_11_14.serialize_uncompressed(&mut bytes).unwrap();
     proof.1.serialize_uncompressed(&mut bytes).unwrap();
-    acc_holder.errs.iter().for_each(|(g1, g2, f)| {
-      g1.serialize_uncompressed(&mut bytes).unwrap();
-      g2.serialize_uncompressed(&mut bytes).unwrap();
-      f.serialize_uncompressed(&mut bytes).unwrap();
-    });
+    acc.errs.serialize_uncompressed(&mut bytes).unwrap();
     util::add_randomness(rng, bytes);
     let acc_gamma = Fr::rand(rng);
 
-    proof.0.iter().enumerate().for_each(|(i, x)| {
-      if i < 7 {
-        // i==7 is corr1
-        let z = *x * acc_gamma + prev_acc_holder.acc_g1[i];
-        result &= acc_holder.acc_g1[i] == z;
-      }
-    });
-    proof0_11_14.iter().enumerate().for_each(|(i, x)| {
-      let z = *x * acc_gamma + prev_acc_holder.acc_g1[i + 11];
-      result &= acc_holder.acc_g1[i + 11] == z;
-    });
-    result &= acc_holder.acc_g2[0] == prev_acc_holder.acc_g2[0] + proof.1[0] * acc_gamma;
-    result &= acc_holder.acc_g2[1] == prev_acc_holder.acc_g2[1] && proof.1[1] == beta_pow_g2 && beta_pow_g2 == acc_holder.acc_g2[1];
-    result &= acc_holder.mu == prev_acc_holder.mu + acc_gamma;
-    acc_holder.errs[0].0[acc_holder.errs[0].0.len() - 3..]
-      .iter()
-      .zip(prev_acc_holder.acc_errs[0].0[prev_acc_holder.acc_errs[0].0.len() - 3..].iter())
-      .enumerate()
-      .for_each(|(j, (x, y))| {
-        let z = *y + *x * acc_gamma;
-        result &= z == acc_holder.acc_errs[0].0[acc_holder.acc_errs[0].0.len() - 3 + j];
-      });
+    result &= (proof.0[0] * acc_gamma + prev_acc.fiat_shamir.acc_left_x) == acc.fiat_shamir.acc_left_x;
+    result &= (proof.0[1] * acc_gamma + prev_acc.fiat_shamir.acc_left_Q_x) == acc.fiat_shamir.acc_left_Q_x;
+    result &= (proof.0[2] * acc_gamma + prev_acc.fiat_shamir.acc_left_zero) == acc.fiat_shamir.acc_left_zero;
+    result &= (proof.0[3] * acc_gamma + prev_acc.fiat_shamir.acc_left_zero_div) == acc.fiat_shamir.acc_left_zero_div;
+    result &= (proof.0[4] * acc_gamma + prev_acc.fiat_shamir.acc_right_x) == acc.fiat_shamir.acc_right_x;
+    result &= (proof.0[5] * acc_gamma + prev_acc.fiat_shamir.acc_right_Q_x) == acc.fiat_shamir.acc_right_Q_x;
+    result &= (proof.0[6] * acc_gamma + prev_acc.fiat_shamir.acc_right_zero_div) == acc.fiat_shamir.acc_right_zero_div;
+
+    result &= (flat_A * acc_gamma + prev_acc.fiat_shamir.acc_flat_A) == acc.fiat_shamir.acc_flat_A;
+    result &= (flat_B * acc_gamma + prev_acc.fiat_shamir.acc_flat_B) == acc.fiat_shamir.acc_flat_B;
+    result &= (flat_C * acc_gamma + prev_acc.fiat_shamir.acc_flat_C) == acc.fiat_shamir.acc_flat_C;
+
+    result &= acc.fiat_shamir.acc_flat_B_g2 == prev_acc.fiat_shamir.acc_flat_B_g2 + proof.1[0] * acc_gamma;
+    result &= acc.fiat_shamir.acc_beta_pow_g2 == prev_acc.fiat_shamir.acc_beta_pow_g2
+      && proof.1[1] == beta_pow_g2
+      && beta_pow_g2 == acc.fiat_shamir.acc_beta_pow_g2;
+    result &= acc.mu == prev_acc.mu + acc_gamma;
+
+    result &= prev_acc.acc_errs.acc_left_Q_x + acc.errs.acc_left_Q_x * acc_gamma == acc.acc_errs.acc_left_Q_x;
+    result &= prev_acc.acc_errs.acc_left_x + acc.errs.acc_left_x * acc_gamma == acc.acc_errs.acc_left_x;
+    result &= prev_acc.acc_errs.acc_part_corr1 + acc.errs.acc_part_corr1 * acc_gamma == acc.acc_errs.acc_part_corr1;
+
     Some(result)
   }
 
   fn acc_decide(&self, srs: &SRS, acc_proof: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>)) -> Vec<PairingCheck> {
-    let acc_holder = acc_proof_to_matmul_acc(acc_proof, false);
-    let [acc_left_x, acc_left_Q_x, acc_left_zero, acc_left_zero_div, acc_right_x, acc_right_Q_x, acc_right_zero_div, acc_corr1, acc_corr2, acc_corr3, acc_corr4, acc_flat_A, acc_flat_B, acc_flat_C] =
-      acc_holder.acc_g1[..]
-    else {
-      panic!("Wrong acc proof format")
-    };
-    let [acc_flat_B_g2, beta_pow_g2] = acc_holder.acc_g2[..] else {
-      panic!("Wrong acc proof format")
-    };
-    let acc_mu = acc_holder.mu;
-    let err_1 = &acc_holder.acc_errs[0];
+    let acc = acc_proof_to_matmul_acc(acc_proof, false).unwrap();
+
+    let acc_flat_A = acc.fiat_shamir.acc_flat_A;
+    let acc_flat_B_g2 = acc.fiat_shamir.acc_flat_B_g2;
+    let acc_left_x = acc.fiat_shamir.acc_left_x;
+    let acc_left_Q_x = acc.fiat_shamir.acc_left_Q_x;
+    let acc_left_zero = acc.fiat_shamir.acc_left_zero;
+    let acc_left_zero_div = acc.fiat_shamir.acc_left_zero_div;
+    let acc_right_x = acc.fiat_shamir.acc_right_x;
+    let acc_right_Q_x = acc.fiat_shamir.acc_right_Q_x;
+    let acc_right_zero_div = acc.fiat_shamir.acc_right_zero_div;
+    let acc_flat_B = acc.fiat_shamir.acc_flat_B;
+    let acc_flat_C = acc.fiat_shamir.acc_flat_C;
+    let beta_pow_g2 = acc.fiat_shamir.acc_beta_pow_g2;
+    let acc_corr1 = acc.acc_corr1;
+    let acc_corr2 = acc.acc_corr2;
+    let acc_corr3 = acc.acc_corr3;
+    let acc_corr4 = acc.acc_corr4;
+    let acc_mu = acc.mu;
+    let errs = &acc.acc_errs;
 
     let mut temp: PairingCheck = vec![];
-    for i in 0..err_1.1.len() {
-      temp.push((-err_1.0[i], err_1.1[i]));
-    }
-    temp.push((err_1.0[err_1.1.len()], (srs.X2A[self.m] - srs.X2A[0]).into()));
-    temp.push((err_1.0[err_1.1.len() + 1], srs.X2A[0]));
-    temp.push((err_1.0[err_1.1.len() + 2], srs.Y2A));
+    temp.push((-errs.flat_A, errs.acc_flat_B_g2));
+    temp.push((-errs.acc_flat_A, errs.flat_B_g2));
+    temp.push((errs.acc_left_Q_x, (srs.X2A[self.m] - srs.X2A[0]).into()));
+    temp.push((errs.acc_left_x, srs.X2A[0]));
+    temp.push((errs.acc_part_corr1, srs.Y2A));
 
     let err_1 = temp;
     let mut acc_1: PairingCheck = vec![
@@ -686,7 +932,7 @@ impl BasicBlock for MatMulBasicBlock {
   }
 
   fn acc_clean_errs(&self, acc_proof: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>)) -> (Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>) {
-    let mut acc_holder = acc_proof_to_matmul_acc(acc_proof, false);
+    let mut acc_holder = acc_proof_to_matmul_acc_holder(acc_proof, false);
     acc_holder.errs = vec![];
     acc_to_acc_proof(acc_holder)
   }

--- a/src/basic_block/matmul.rs
+++ b/src/basic_block/matmul.rs
@@ -17,7 +17,7 @@ struct MatMulAccProof<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSeriali
   mu: Fr,
   prover_only: Option<MatMulAccProofProverOnly<P>>,
   errs: MatMulErrs<P, Q>,
-  acc_errs: MatMulErrs<P, Q>,
+  acc_errs: MatMulAccErrs<P, Q>,
 }
 
 #[derive(CanonicalSerialize)]
@@ -55,6 +55,19 @@ struct MatMulErrs<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize> 
   flat_B_g2: Q,
 }
 
+#[derive(Clone)]
+struct MatMulAccErrs<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize> {
+  prev_g1s: Vec<P>,
+  flat_A: P,
+  acc_flat_A: P,
+  acc_left_Q_x: P,
+  acc_left_x: P,
+  acc_part_corr1: P,
+  prev_g2s: Vec<Q>,
+  acc_flat_B_g2: Q,
+  flat_B_g2: Q,
+}
+
 fn accumulate(
   matmul_acc: &MatMulAccProof<G1Projective, G2Projective>,
   errs: &MatMulErrs<G1Projective, G2Projective>,
@@ -84,15 +97,21 @@ fn accumulate(
     flat_B_g2: errs.flat_B_g2,
   };
 
-  let acc_errs = MatMulErrs {
+  let mut acc_errs = MatMulAccErrs {
+    prev_g1s: matmul_acc.acc_errs.prev_g1s.clone(),
     flat_A: new_errs.flat_A,
     acc_flat_A: new_errs.acc_flat_A,
     acc_left_Q_x: matmul_acc.acc_errs.acc_left_Q_x + new_errs.acc_left_Q_x,
     acc_left_x: matmul_acc.acc_errs.acc_left_x + new_errs.acc_left_x,
     acc_part_corr1: matmul_acc.acc_errs.acc_part_corr1 + new_errs.acc_part_corr1,
+    prev_g2s: matmul_acc.acc_errs.prev_g2s.clone(),
     acc_flat_B_g2: new_errs.acc_flat_B_g2,
     flat_B_g2: new_errs.flat_B_g2,
   };
+  acc_errs.prev_g1s.push(matmul_acc.acc_errs.flat_A);
+  acc_errs.prev_g1s.push(matmul_acc.acc_errs.acc_flat_A);
+  acc_errs.prev_g2s.push(matmul_acc.acc_errs.acc_flat_B_g2);
+  acc_errs.prev_g2s.push(matmul_acc.acc_errs.flat_B_g2);
 
   // Compute the error
   let matmul_acc_prover_only = matmul_acc.prover_only.as_ref().unwrap();
@@ -162,6 +181,8 @@ fn acc_proof_to_matmul_acc_holder<P: Clone, Q: Clone>(acc_proof: (&Vec<P>, &Vec<
     vec![],
   );
 
+  // println!("acc_err1: {:?}, {:?}", acc_err1.0.len(), acc_err1.1.len());
+
   let acc_errs = vec![acc_err1];
 
   AccHolder {
@@ -189,6 +210,8 @@ fn matmul_acc_holder_to_acc<P: Clone + CanonicalSerialize, Q: Clone + CanonicalS
   acc_holder: AccHolder<P, Q>,
   is_prover: bool,
 ) -> MatMulAccProof<P, Q> {
+  let g1_len = acc_holder.acc_errs[0].0.len();
+  let g2_len = acc_holder.acc_errs[0].1.len();
   let acc_proof = MatMulAccProof {
     fiat_shamir: MatMulAccFiatShamir {
       acc_left_x: acc_holder.acc_g1[0].clone(),
@@ -231,14 +254,16 @@ fn matmul_acc_holder_to_acc<P: Clone + CanonicalSerialize, Q: Clone + CanonicalS
       acc_flat_B_g2: acc_holder.errs[0].1[0].clone(),
       flat_B_g2: acc_holder.errs[0].1[1].clone(),
     },
-    acc_errs: MatMulErrs {
-      flat_A: acc_holder.acc_errs[0].0[0].clone(),
-      acc_flat_A: acc_holder.acc_errs[0].0[1].clone(),
-      acc_left_Q_x: acc_holder.acc_errs[0].0[2].clone(),
-      acc_left_x: acc_holder.acc_errs[0].0[3].clone(),
-      acc_part_corr1: acc_holder.acc_errs[0].0[4].clone(),
-      acc_flat_B_g2: acc_holder.acc_errs[0].1[0].clone(),
-      flat_B_g2: acc_holder.acc_errs[0].1[1].clone(),
+    acc_errs: MatMulAccErrs {
+      prev_g1s: acc_holder.acc_errs[0].0[..g1_len - 5].to_vec(),
+      flat_A: acc_holder.acc_errs[0].0[g1_len - 5].clone(),
+      acc_flat_A: acc_holder.acc_errs[0].0[g1_len - 4].clone(),
+      acc_left_Q_x: acc_holder.acc_errs[0].0[g1_len - 3].clone(),
+      acc_left_x: acc_holder.acc_errs[0].0[g1_len - 2].clone(),
+      acc_part_corr1: acc_holder.acc_errs[0].0[g1_len - 1].clone(),
+      prev_g2s: acc_holder.acc_errs[0].1[..g2_len - 2].to_vec(),
+      acc_flat_B_g2: acc_holder.acc_errs[0].1[g2_len - 2].clone(),
+      flat_B_g2: acc_holder.acc_errs[0].1[g2_len - 1].clone(),
     },
   };
   acc_proof
@@ -889,6 +914,9 @@ impl BasicBlock for MatMulBasicBlock {
     let errs = &acc.acc_errs;
 
     let mut temp: PairingCheck = vec![];
+    for i in 0..errs.prev_g2s.len() {
+      temp.push((-errs.prev_g1s[i], errs.prev_g2s[i]));
+    }
     temp.push((-errs.flat_A, errs.acc_flat_B_g2));
     temp.push((-errs.acc_flat_A, errs.flat_B_g2));
     temp.push((errs.acc_left_Q_x, (srs.X2A[self.m] - srs.X2A[0]).into()));

--- a/src/basic_block/matmul.rs
+++ b/src/basic_block/matmul.rs
@@ -11,7 +11,7 @@ use ndarray::{arr1, arr2, ArrayD, Ix1, Ix2, IxDyn};
 use rand::{rngs::StdRng, SeedableRng};
 use rayon::iter::ParallelIterator;
 
-struct MatMulAccProof<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize> {
+struct MatMulAccProof<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize> {
   fiat_shamir: MatMulAccFiatShamir<P, Q>,
   acc_corr: [P; 4],
   mu: Fr,
@@ -21,7 +21,7 @@ struct MatMulAccProof<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSeriali
 }
 
 #[derive(CanonicalSerialize)]
-struct MatMulAccFiatShamir<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize> {
+struct MatMulAccFiatShamir<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize> {
   acc_left_x: P,
   acc_left_Q_x: P,
   acc_left_zero: P,
@@ -36,7 +36,7 @@ struct MatMulAccFiatShamir<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSe
   acc_beta_pow_g2: Q,
 }
 
-struct MatMulAccProofProverOnly<P: Clone + CanonicalSerialize> {
+struct MatMulAccProofProverOnly<P: Copy + CanonicalSerialize> {
   acc_part_corr1: P,
   acc_flat_A_no_blind: P,
   acc_flat_B_no_blind: P,
@@ -45,7 +45,7 @@ struct MatMulAccProofProverOnly<P: Clone + CanonicalSerialize> {
 }
 
 #[derive(CanonicalSerialize, Clone)]
-struct MatMulErrs<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize> {
+struct MatMulErrs<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize> {
   flat_A: P,
   acc_flat_A: P,
   acc_left_Q_x: P,
@@ -56,7 +56,7 @@ struct MatMulErrs<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize> 
 }
 
 #[derive(Clone)]
-struct MatMulAccErrs<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize> {
+struct MatMulAccErrs<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize> {
   prev_g1s: Vec<P>,
   flat_A: P,
   acc_flat_A: P,
@@ -151,7 +151,7 @@ fn accumulate(
   new_matmul_acc
 }
 
-fn acc_proof_to_matmul_acc_holder<P: Clone, Q: Clone>(acc_proof: (&Vec<P>, &Vec<Q>, &Vec<Fr>), is_prover: bool) -> AccHolder<P, Q> {
+fn acc_proof_to_matmul_acc_holder<P: Copy, Q: Copy>(acc_proof: (&Vec<P>, &Vec<Q>, &Vec<Fr>), is_prover: bool) -> AccHolder<P, Q> {
   if acc_proof.0.len() == 0 && acc_proof.1.len() == 0 && acc_proof.2.len() == 0 {
     return AccHolder {
       acc_g1: vec![],
@@ -193,7 +193,7 @@ fn acc_proof_to_matmul_acc_holder<P: Clone, Q: Clone>(acc_proof: (&Vec<P>, &Vec<
   }
 }
 
-fn acc_proof_to_matmul_acc<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize>(
+fn acc_proof_to_matmul_acc<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(
   acc_proof: (&Vec<P>, &Vec<Q>, &Vec<Fr>),
   is_prover: bool,
 ) -> Option<MatMulAccProof<P, Q>> {
@@ -204,7 +204,7 @@ fn acc_proof_to_matmul_acc<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSe
   Some(matmul_acc_holder_to_acc(acc_holder, is_prover))
 }
 
-fn matmul_acc_holder_to_acc<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize>(
+fn matmul_acc_holder_to_acc<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(
   acc_holder: AccHolder<P, Q>,
   is_prover: bool,
 ) -> MatMulAccProof<P, Q> {
@@ -212,31 +212,26 @@ fn matmul_acc_holder_to_acc<P: Clone + CanonicalSerialize, Q: Clone + CanonicalS
   let g2_len = acc_holder.acc_errs[0].1.len();
   let acc_proof = MatMulAccProof {
     fiat_shamir: MatMulAccFiatShamir {
-      acc_left_x: acc_holder.acc_g1[0].clone(),
-      acc_left_Q_x: acc_holder.acc_g1[1].clone(),
-      acc_left_zero: acc_holder.acc_g1[2].clone(),
-      acc_left_zero_div: acc_holder.acc_g1[3].clone(),
-      acc_right_x: acc_holder.acc_g1[4].clone(),
-      acc_right_Q_x: acc_holder.acc_g1[5].clone(),
-      acc_right_zero_div: acc_holder.acc_g1[6].clone(),
-      acc_flat_A: acc_holder.acc_g1[11].clone(),
-      acc_flat_B: acc_holder.acc_g1[12].clone(),
-      acc_flat_C: acc_holder.acc_g1[13].clone(),
-      acc_flat_B_g2: acc_holder.acc_g2[0].clone(),
-      acc_beta_pow_g2: acc_holder.acc_g2[1].clone(),
+      acc_left_x: acc_holder.acc_g1[0],
+      acc_left_Q_x: acc_holder.acc_g1[1],
+      acc_left_zero: acc_holder.acc_g1[2],
+      acc_left_zero_div: acc_holder.acc_g1[3],
+      acc_right_x: acc_holder.acc_g1[4],
+      acc_right_Q_x: acc_holder.acc_g1[5],
+      acc_right_zero_div: acc_holder.acc_g1[6],
+      acc_flat_A: acc_holder.acc_g1[11],
+      acc_flat_B: acc_holder.acc_g1[12],
+      acc_flat_C: acc_holder.acc_g1[13],
+      acc_flat_B_g2: acc_holder.acc_g2[0],
+      acc_beta_pow_g2: acc_holder.acc_g2[1],
     },
-    acc_corr: [
-      acc_holder.acc_g1[7].clone(),
-      acc_holder.acc_g1[8].clone(),
-      acc_holder.acc_g1[9].clone(),
-      acc_holder.acc_g1[10].clone(),
-    ],
+    acc_corr: [acc_holder.acc_g1[7], acc_holder.acc_g1[8], acc_holder.acc_g1[9], acc_holder.acc_g1[10]],
     mu: acc_holder.mu,
     prover_only: if is_prover {
       Some(MatMulAccProofProverOnly {
-        acc_part_corr1: acc_holder.acc_g1[14].clone(),
-        acc_flat_A_no_blind: acc_holder.acc_g1[15].clone(),
-        acc_flat_B_no_blind: acc_holder.acc_g1[16].clone(),
+        acc_part_corr1: acc_holder.acc_g1[14],
+        acc_flat_A_no_blind: acc_holder.acc_g1[15],
+        acc_flat_B_no_blind: acc_holder.acc_g1[16],
         acc_flat_A_r: acc_holder.acc_fr[0],
         acc_flat_B_r: acc_holder.acc_fr[1],
       })
@@ -244,30 +239,30 @@ fn matmul_acc_holder_to_acc<P: Clone + CanonicalSerialize, Q: Clone + CanonicalS
       None
     },
     errs: MatMulErrs {
-      flat_A: acc_holder.errs[0].0[0].clone(),
-      acc_flat_A: acc_holder.errs[0].0[1].clone(),
-      acc_left_Q_x: acc_holder.errs[0].0[2].clone(),
-      acc_left_x: acc_holder.errs[0].0[3].clone(),
-      acc_part_corr1: acc_holder.errs[0].0[4].clone(),
-      acc_flat_B_g2: acc_holder.errs[0].1[0].clone(),
-      flat_B_g2: acc_holder.errs[0].1[1].clone(),
+      flat_A: acc_holder.errs[0].0[0],
+      acc_flat_A: acc_holder.errs[0].0[1],
+      acc_left_Q_x: acc_holder.errs[0].0[2],
+      acc_left_x: acc_holder.errs[0].0[3],
+      acc_part_corr1: acc_holder.errs[0].0[4],
+      acc_flat_B_g2: acc_holder.errs[0].1[0],
+      flat_B_g2: acc_holder.errs[0].1[1],
     },
     acc_errs: MatMulAccErrs {
       prev_g1s: acc_holder.acc_errs[0].0[..g1_len - 5].to_vec(),
-      flat_A: acc_holder.acc_errs[0].0[g1_len - 5].clone(),
-      acc_flat_A: acc_holder.acc_errs[0].0[g1_len - 4].clone(),
-      acc_left_Q_x: acc_holder.acc_errs[0].0[g1_len - 3].clone(),
-      acc_left_x: acc_holder.acc_errs[0].0[g1_len - 2].clone(),
-      acc_part_corr1: acc_holder.acc_errs[0].0[g1_len - 1].clone(),
+      flat_A: acc_holder.acc_errs[0].0[g1_len - 5],
+      acc_flat_A: acc_holder.acc_errs[0].0[g1_len - 4],
+      acc_left_Q_x: acc_holder.acc_errs[0].0[g1_len - 3],
+      acc_left_x: acc_holder.acc_errs[0].0[g1_len - 2],
+      acc_part_corr1: acc_holder.acc_errs[0].0[g1_len - 1],
       prev_g2s: acc_holder.acc_errs[0].1[..g2_len - 2].to_vec(),
-      acc_flat_B_g2: acc_holder.acc_errs[0].1[g2_len - 2].clone(),
-      flat_B_g2: acc_holder.acc_errs[0].1[g2_len - 1].clone(),
+      acc_flat_B_g2: acc_holder.acc_errs[0].1[g2_len - 2],
+      flat_B_g2: acc_holder.acc_errs[0].1[g2_len - 1],
     },
   };
   acc_proof
 }
 
-fn matmul_acc_to_acc_holder<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize>(
+fn matmul_acc_to_acc_holder<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(
   acc: MatMulAccProof<P, Q>,
   is_prover: bool,
 ) -> AccHolder<P, Q> {
@@ -305,10 +300,10 @@ fn matmul_acc_to_acc_holder<P: Clone + CanonicalSerialize, Q: Clone + CanonicalS
       acc.fiat_shamir.acc_right_x,
       acc.fiat_shamir.acc_right_Q_x,
       acc.fiat_shamir.acc_right_zero_div,
-      acc.acc_corr[0].clone(),
-      acc.acc_corr[1].clone(),
-      acc.acc_corr[2].clone(),
-      acc.acc_corr[3].clone(),
+      acc.acc_corr[0],
+      acc.acc_corr[1],
+      acc.acc_corr[2],
+      acc.acc_corr[3],
       acc.fiat_shamir.acc_flat_A,
       acc.fiat_shamir.acc_flat_B,
       acc.fiat_shamir.acc_flat_C,
@@ -334,10 +329,10 @@ fn matmul_acc_to_acc_holder<P: Clone + CanonicalSerialize, Q: Clone + CanonicalS
       acc.fiat_shamir.acc_right_x,
       acc.fiat_shamir.acc_right_Q_x,
       acc.fiat_shamir.acc_right_zero_div,
-      acc.acc_corr[0].clone(),
-      acc.acc_corr[1].clone(),
-      acc.acc_corr[2].clone(),
-      acc.acc_corr[3].clone(),
+      acc.acc_corr[0],
+      acc.acc_corr[1],
+      acc.acc_corr[2],
+      acc.acc_corr[3],
       acc.fiat_shamir.acc_flat_A,
       acc.fiat_shamir.acc_flat_B,
       acc.fiat_shamir.acc_flat_C,
@@ -353,7 +348,7 @@ fn matmul_acc_to_acc_holder<P: Clone + CanonicalSerialize, Q: Clone + CanonicalS
   }
 }
 
-fn matmul_acc_to_acc_proof<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize>(
+fn matmul_acc_to_acc_proof<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(
   acc: MatMulAccProof<P, Q>,
   is_prover: bool,
 ) -> (Vec<P>, Vec<Q>, Vec<Fr>) {

--- a/src/basic_block/permute.rs
+++ b/src/basic_block/permute.rs
@@ -10,7 +10,68 @@ use ark_std::{ops::Mul, ops::Sub, One, UniformRand, Zero};
 use ndarray::{Array, ArrayD, Axis};
 use rand::{rngs::StdRng, SeedableRng};
 
-fn acc_proof_to_permute_acc<P: Clone, Q: Clone>(acc_proof: (&Vec<P>, &Vec<Q>, &Vec<Fr>)) -> AccHolder<P, Q> {
+// [acc_left_x, acc_left_Q_x, acc_left_zero, acc_left_zero_div, acc_right_x, acc_right_Q_x, acc_right_zero_div, acc_corr1, acc_corr2, acc_corr3, acc_corr4, acc_flat_L, acc_flat_R]
+//acc_b_g2, acc_d_g2
+
+struct PermuteAccProof<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize> {
+  fiat_shamir: PermuteAccFiatShamir<P, Q>,
+  acc_corr: [P; 4],
+  mu: Fr,
+}
+
+#[derive(CanonicalSerialize)]
+struct PermuteAccFiatShamir<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize> {
+  acc_left_x: P,
+  acc_left_Q_x: P,
+  acc_left_zero: P,
+  acc_left_zero_div: P,
+  acc_right_x: P,
+  acc_right_Q_x: P,
+  acc_right_zero_div: P,
+  acc_flat_L: P,
+  acc_flat_R: P,
+  acc_b_g2: Q,
+  acc_d_g2: Q,
+}
+
+fn accumulate(
+  permute_acc: &PermuteAccProof<G1Projective, G2Projective>,
+  proof: &(&Vec<G1Projective>, &Vec<G2Projective>, &Vec<Fr>),
+  acc_gamma: Fr,
+) -> PermuteAccProof<G1Projective, G2Projective> {
+  let [left_x, left_Q_x, left_zero, left_zero_div, right_x, right_Q_x, right_zero_div, corr1, corr2, corr3, corr4, flat_L, flat_R] = proof.0[..]
+  else {
+    panic!("Wrong proof format")
+  };
+
+  // Compute the error
+  let new_matmul_acc = PermuteAccProof {
+    fiat_shamir: PermuteAccFiatShamir {
+      acc_left_x: permute_acc.fiat_shamir.acc_left_x + left_x * acc_gamma,
+      acc_left_Q_x: permute_acc.fiat_shamir.acc_left_Q_x + left_Q_x * acc_gamma,
+      acc_left_zero: permute_acc.fiat_shamir.acc_left_zero + left_zero * acc_gamma,
+      acc_left_zero_div: permute_acc.fiat_shamir.acc_left_zero_div + left_zero_div * acc_gamma,
+      acc_right_x: permute_acc.fiat_shamir.acc_right_x + right_x * acc_gamma,
+      acc_right_Q_x: permute_acc.fiat_shamir.acc_right_Q_x + right_Q_x * acc_gamma,
+      acc_right_zero_div: permute_acc.fiat_shamir.acc_right_zero_div + right_zero_div * acc_gamma,
+      acc_flat_L: permute_acc.fiat_shamir.acc_flat_L + flat_L * acc_gamma,
+      acc_flat_R: permute_acc.fiat_shamir.acc_flat_R + flat_R * acc_gamma,
+      acc_b_g2: permute_acc.fiat_shamir.acc_b_g2,
+      acc_d_g2: permute_acc.fiat_shamir.acc_d_g2,
+    },
+    acc_corr: [
+      permute_acc.acc_corr[0] + corr1 * acc_gamma,
+      permute_acc.acc_corr[1] + corr2 * acc_gamma,
+      permute_acc.acc_corr[2] + corr3 * acc_gamma,
+      permute_acc.acc_corr[3] + corr4 * acc_gamma,
+    ],
+    mu: permute_acc.mu + acc_gamma,
+  };
+
+  new_matmul_acc
+}
+
+fn acc_proof_to_permute_acc_holder<P: Clone, Q: Clone>(acc_proof: (&Vec<P>, &Vec<Q>, &Vec<Fr>)) -> AccHolder<P, Q> {
   if acc_proof.0.len() == 0 && acc_proof.1.len() == 0 && acc_proof.2.len() == 0 {
     return AccHolder {
       acc_g1: vec![],
@@ -32,6 +93,71 @@ fn acc_proof_to_permute_acc<P: Clone, Q: Clone>(acc_proof: (&Vec<P>, &Vec<Q>, &V
     errs: vec![],
     acc_errs: vec![],
   }
+}
+
+fn permute_acc_holder_to_acc<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize>(acc_holder: AccHolder<P, Q>) -> PermuteAccProof<P, Q> {
+  PermuteAccProof {
+    fiat_shamir: PermuteAccFiatShamir {
+      acc_left_x: acc_holder.acc_g1[0].clone(),
+      acc_left_Q_x: acc_holder.acc_g1[1].clone(),
+      acc_left_zero: acc_holder.acc_g1[2].clone(),
+      acc_left_zero_div: acc_holder.acc_g1[3].clone(),
+      acc_right_x: acc_holder.acc_g1[4].clone(),
+      acc_right_Q_x: acc_holder.acc_g1[5].clone(),
+      acc_right_zero_div: acc_holder.acc_g1[6].clone(),
+      acc_flat_L: acc_holder.acc_g1[11].clone(),
+      acc_flat_R: acc_holder.acc_g1[12].clone(),
+      acc_b_g2: acc_holder.acc_g2[0].clone(),
+      acc_d_g2: acc_holder.acc_g2[1].clone(),
+    },
+    acc_corr: [
+      acc_holder.acc_g1[7].clone(),
+      acc_holder.acc_g1[8].clone(),
+      acc_holder.acc_g1[9].clone(),
+      acc_holder.acc_g1[10].clone(),
+    ],
+    mu: acc_holder.mu,
+  }
+}
+
+fn permute_acc_to_acc_holder<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize>(acc: PermuteAccProof<P, Q>) -> AccHolder<P, Q> {
+  AccHolder {
+    acc_g1: vec![
+      acc.fiat_shamir.acc_left_x,
+      acc.fiat_shamir.acc_left_Q_x,
+      acc.fiat_shamir.acc_left_zero,
+      acc.fiat_shamir.acc_left_zero_div,
+      acc.fiat_shamir.acc_right_x,
+      acc.fiat_shamir.acc_right_Q_x,
+      acc.fiat_shamir.acc_right_zero_div,
+      acc.acc_corr[0].clone(),
+      acc.acc_corr[1].clone(),
+      acc.acc_corr[2].clone(),
+      acc.acc_corr[3].clone(),
+      acc.fiat_shamir.acc_flat_L,
+      acc.fiat_shamir.acc_flat_R,
+    ],
+    acc_g2: vec![acc.fiat_shamir.acc_b_g2, acc.fiat_shamir.acc_d_g2],
+    acc_fr: vec![],
+    mu: acc.mu,
+    errs: vec![],
+    acc_errs: vec![],
+  }
+}
+
+fn acc_proof_to_permute_acc<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize>(
+  acc_proof: (&Vec<P>, &Vec<Q>, &Vec<Fr>),
+) -> Option<PermuteAccProof<P, Q>> {
+  if acc_proof.0.len() == 0 && acc_proof.1.len() == 0 && acc_proof.2.len() == 0 {
+    return None;
+  }
+  let acc_holder = acc_proof_to_permute_acc_holder(acc_proof);
+  Some(permute_acc_holder_to_acc(acc_holder))
+}
+
+fn permute_acc_to_acc_proof<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize>(acc: PermuteAccProof<P, Q>) -> (Vec<P>, Vec<Q>, Vec<Fr>) {
+  let acc_holder = permute_acc_to_acc_holder(acc);
+  acc_to_acc_proof(acc_holder)
 }
 
 #[derive(Debug)]
@@ -352,37 +478,23 @@ impl BasicBlock for PermuteBasicBlock {
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let [b_g2, d_g2] = proof.1[..] else { panic!("Wrong proof format") };
 
-    let acc_holder = acc_proof_to_permute_acc(acc_proof);
-    let mut new_acc_holder = AccHolder {
-      acc_g1: Vec::new(),
-      acc_g2: Vec::new(),
-      acc_fr: Vec::new(),
-      mu: Fr::zero(),
-      errs: Vec::new(),
-      acc_errs: Vec::new(),
-    };
+    let permute_acc = acc_proof_to_permute_acc(acc_proof).unwrap();
 
-    let [acc_b_g2, acc_d_g2] = acc_holder.acc_g2[..] else {
-      panic!("Wrong acc proof format")
-    };
+    let [acc_b_g2, acc_d_g2] = [permute_acc.fiat_shamir.acc_b_g2.clone(), permute_acc.fiat_shamir.acc_d_g2.clone()];
     assert!(b_g2 == acc_b_g2 && d_g2 == acc_d_g2);
-    let acc_mu = acc_holder.mu;
 
     // Compute the error (but we skip it because permuteBB has no error)
 
     // Fiat-Shamir
     let mut bytes = Vec::new();
-    acc_holder.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
-    acc_holder.acc_g1[11..13].serialize_uncompressed(&mut bytes).unwrap();
+    permute_acc.fiat_shamir.serialize_uncompressed(&mut bytes).unwrap();
     proof.0[..7].serialize_uncompressed(&mut bytes).unwrap();
     proof.0[11..13].serialize_uncompressed(&mut bytes).unwrap();
     util::add_randomness(rng, bytes);
     let acc_gamma = Fr::rand(rng);
 
-    new_acc_holder.acc_g1 = proof.0.iter().zip(acc_holder.acc_g1.iter()).map(|(x, y)| *x * acc_gamma + y).collect();
-    new_acc_holder.acc_g2 = acc_holder.acc_g2.clone();
-    new_acc_holder.mu = acc_mu + acc_gamma;
-    acc_to_acc_proof(new_acc_holder)
+    let new_permute_acc = accumulate(&permute_acc, &proof, acc_gamma);
+    permute_acc_to_acc_proof(new_permute_acc)
   }
 
   fn acc_clean(
@@ -473,10 +585,10 @@ impl BasicBlock for PermuteBasicBlock {
 
     let proof0_11_13 = vec![flat_L, flat_R];
 
-    let prev_acc_holder = acc_proof_to_permute_acc(prev_acc_proof);
-    let acc_holder = acc_proof_to_permute_acc(acc_proof);
+    let prev_acc = acc_proof_to_permute_acc(prev_acc_proof);
+    let acc = acc_proof_to_permute_acc(acc_proof).unwrap();
 
-    if prev_acc_holder.mu.is_zero() && acc_holder.mu.is_one() {
+    if prev_acc.is_none() || (prev_acc.as_ref().unwrap().mu.is_zero() && acc.mu.is_one()) {
       // skip verifying RLC because no RLC was done in acc_init.
       // Fiat-shamir
       let mut bytes = Vec::new();
@@ -489,41 +601,49 @@ impl BasicBlock for PermuteBasicBlock {
 
     // Fiat-Shamir
     let mut bytes = Vec::new();
-    prev_acc_holder.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
-    prev_acc_holder.acc_g1[11..13].serialize_uncompressed(&mut bytes).unwrap();
+    let prev_acc = prev_acc.unwrap();
+    prev_acc.fiat_shamir.serialize_uncompressed(&mut bytes).unwrap();
     proof.0[..7].serialize_uncompressed(&mut bytes).unwrap();
     proof0_11_13.serialize_uncompressed(&mut bytes).unwrap();
     util::add_randomness(rng, bytes);
     let acc_gamma = Fr::rand(rng);
 
-    proof.0.iter().enumerate().for_each(|(i, x)| {
-      if i < 7 {
-        // i==7 is corr1
-        let z = *x * acc_gamma + prev_acc_holder.acc_g1[i];
-        result &= acc_holder.acc_g1[i] == z;
-      }
-    });
-    proof0_11_13.iter().enumerate().for_each(|(i, x)| {
-      let z = *x * acc_gamma + prev_acc_holder.acc_g1[i + 11];
-      result &= acc_holder.acc_g1[i + 11] == z;
-    });
-    result &= acc_holder.acc_g2[0] == prev_acc_holder.acc_g2[0] && b_g2 == acc_holder.acc_g2[0];
-    result &= acc_holder.acc_g2[1] == prev_acc_holder.acc_g2[1] && d_g2 == acc_holder.acc_g2[1];
-    result &= acc_holder.mu == prev_acc_holder.mu + acc_gamma;
+    result &= acc.fiat_shamir.acc_left_x == proof.0[0] * acc_gamma + prev_acc.fiat_shamir.acc_left_x;
+    result &= acc.fiat_shamir.acc_left_Q_x == proof.0[1] * acc_gamma + prev_acc.fiat_shamir.acc_left_Q_x;
+    result &= acc.fiat_shamir.acc_left_zero == proof.0[2] * acc_gamma + prev_acc.fiat_shamir.acc_left_zero;
+    result &= acc.fiat_shamir.acc_left_zero_div == proof.0[3] * acc_gamma + prev_acc.fiat_shamir.acc_left_zero_div;
+    result &= acc.fiat_shamir.acc_right_x == proof.0[4] * acc_gamma + prev_acc.fiat_shamir.acc_right_x;
+    result &= acc.fiat_shamir.acc_right_Q_x == proof.0[5] * acc_gamma + prev_acc.fiat_shamir.acc_right_Q_x;
+    result &= acc.fiat_shamir.acc_right_zero_div == proof.0[6] * acc_gamma + prev_acc.fiat_shamir.acc_right_zero_div;
+
+    result &= acc.fiat_shamir.acc_flat_L == flat_L * acc_gamma + prev_acc.fiat_shamir.acc_flat_L;
+    result &= acc.fiat_shamir.acc_flat_R == flat_R * acc_gamma + prev_acc.fiat_shamir.acc_flat_R;
+
+    result &= acc.fiat_shamir.acc_b_g2 == prev_acc.fiat_shamir.acc_b_g2 && b_g2 == acc.fiat_shamir.acc_b_g2;
+    result &= acc.fiat_shamir.acc_d_g2 == prev_acc.fiat_shamir.acc_d_g2 && d_g2 == acc.fiat_shamir.acc_d_g2;
+    result &= acc.mu == prev_acc.mu + acc_gamma;
     Some(result)
   }
 
   fn acc_decide(&self, srs: &SRS, acc_proof: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>)) -> Vec<PairingCheck> {
     let m2 = self.permutation.1.len();
-    let acc_holder = acc_proof_to_permute_acc(acc_proof);
-    let [acc_left_x, acc_left_Q_x, acc_left_zero, acc_left_zero_div, acc_right_x, acc_right_Q_x, acc_right_zero_div, acc_corr1, acc_corr2, acc_corr3, acc_corr4, acc_flat_L, acc_flat_R] =
-      acc_holder.acc_g1[..]
-    else {
-      panic!("Wrong acc proof format")
-    };
-    let [acc_b_g2, acc_d_g2] = acc_holder.acc_g2[..] else {
-      panic!("Wrong acc proof format")
-    };
+    let acc_holder = acc_proof_to_permute_acc(acc_proof).unwrap();
+
+    let acc_left_x = acc_holder.fiat_shamir.acc_left_x;
+    let acc_left_Q_x = acc_holder.fiat_shamir.acc_left_Q_x;
+    let acc_left_zero = acc_holder.fiat_shamir.acc_left_zero;
+    let acc_left_zero_div = acc_holder.fiat_shamir.acc_left_zero_div;
+    let acc_right_x = acc_holder.fiat_shamir.acc_right_x;
+    let acc_right_Q_x = acc_holder.fiat_shamir.acc_right_Q_x;
+    let acc_right_zero_div = acc_holder.fiat_shamir.acc_right_zero_div;
+    let acc_corr1 = acc_holder.acc_corr[0];
+    let acc_corr2 = acc_holder.acc_corr[1];
+    let acc_corr3 = acc_holder.acc_corr[2];
+    let acc_corr4 = acc_holder.acc_corr[3];
+    let acc_flat_L = acc_holder.fiat_shamir.acc_flat_L;
+    let acc_flat_R = acc_holder.fiat_shamir.acc_flat_R;
+    let acc_b_g2 = acc_holder.fiat_shamir.acc_b_g2;
+    let acc_d_g2 = acc_holder.fiat_shamir.acc_d_g2;
 
     let acc_1: PairingCheck = vec![
       (acc_flat_L, acc_b_g2),

--- a/src/basic_block/permute.rs
+++ b/src/basic_block/permute.rs
@@ -13,14 +13,14 @@ use rand::{rngs::StdRng, SeedableRng};
 // [acc_left_x, acc_left_Q_x, acc_left_zero, acc_left_zero_div, acc_right_x, acc_right_Q_x, acc_right_zero_div, acc_corr1, acc_corr2, acc_corr3, acc_corr4, acc_flat_L, acc_flat_R]
 //acc_b_g2, acc_d_g2
 
-struct PermuteAccProof<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize> {
+struct PermuteAccProof<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize> {
   fiat_shamir: PermuteAccFiatShamir<P, Q>,
   acc_corr: [P; 4],
   mu: Fr,
 }
 
 #[derive(CanonicalSerialize)]
-struct PermuteAccFiatShamir<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize> {
+struct PermuteAccFiatShamir<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize> {
   acc_left_x: P,
   acc_left_Q_x: P,
   acc_left_zero: P,
@@ -71,7 +71,7 @@ fn accumulate(
   new_matmul_acc
 }
 
-fn acc_proof_to_permute_acc_holder<P: Clone, Q: Clone>(acc_proof: (&Vec<P>, &Vec<Q>, &Vec<Fr>)) -> AccHolder<P, Q> {
+fn acc_proof_to_permute_acc_holder<P: Copy, Q: Copy>(acc_proof: (&Vec<P>, &Vec<Q>, &Vec<Fr>)) -> AccHolder<P, Q> {
   if acc_proof.0.len() == 0 && acc_proof.1.len() == 0 && acc_proof.2.len() == 0 {
     return AccHolder {
       acc_g1: vec![],
@@ -95,32 +95,27 @@ fn acc_proof_to_permute_acc_holder<P: Clone, Q: Clone>(acc_proof: (&Vec<P>, &Vec
   }
 }
 
-fn permute_acc_holder_to_acc<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize>(acc_holder: AccHolder<P, Q>) -> PermuteAccProof<P, Q> {
+fn permute_acc_holder_to_acc<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(acc_holder: AccHolder<P, Q>) -> PermuteAccProof<P, Q> {
   PermuteAccProof {
     fiat_shamir: PermuteAccFiatShamir {
-      acc_left_x: acc_holder.acc_g1[0].clone(),
-      acc_left_Q_x: acc_holder.acc_g1[1].clone(),
-      acc_left_zero: acc_holder.acc_g1[2].clone(),
-      acc_left_zero_div: acc_holder.acc_g1[3].clone(),
-      acc_right_x: acc_holder.acc_g1[4].clone(),
-      acc_right_Q_x: acc_holder.acc_g1[5].clone(),
-      acc_right_zero_div: acc_holder.acc_g1[6].clone(),
-      acc_flat_L: acc_holder.acc_g1[11].clone(),
-      acc_flat_R: acc_holder.acc_g1[12].clone(),
-      acc_b_g2: acc_holder.acc_g2[0].clone(),
-      acc_d_g2: acc_holder.acc_g2[1].clone(),
+      acc_left_x: acc_holder.acc_g1[0],
+      acc_left_Q_x: acc_holder.acc_g1[1],
+      acc_left_zero: acc_holder.acc_g1[2],
+      acc_left_zero_div: acc_holder.acc_g1[3],
+      acc_right_x: acc_holder.acc_g1[4],
+      acc_right_Q_x: acc_holder.acc_g1[5],
+      acc_right_zero_div: acc_holder.acc_g1[6],
+      acc_flat_L: acc_holder.acc_g1[11],
+      acc_flat_R: acc_holder.acc_g1[12],
+      acc_b_g2: acc_holder.acc_g2[0],
+      acc_d_g2: acc_holder.acc_g2[1],
     },
-    acc_corr: [
-      acc_holder.acc_g1[7].clone(),
-      acc_holder.acc_g1[8].clone(),
-      acc_holder.acc_g1[9].clone(),
-      acc_holder.acc_g1[10].clone(),
-    ],
+    acc_corr: [acc_holder.acc_g1[7], acc_holder.acc_g1[8], acc_holder.acc_g1[9], acc_holder.acc_g1[10]],
     mu: acc_holder.mu,
   }
 }
 
-fn permute_acc_to_acc_holder<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize>(acc: PermuteAccProof<P, Q>) -> AccHolder<P, Q> {
+fn permute_acc_to_acc_holder<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(acc: PermuteAccProof<P, Q>) -> AccHolder<P, Q> {
   AccHolder {
     acc_g1: vec![
       acc.fiat_shamir.acc_left_x,
@@ -130,10 +125,10 @@ fn permute_acc_to_acc_holder<P: Clone + CanonicalSerialize, Q: Clone + Canonical
       acc.fiat_shamir.acc_right_x,
       acc.fiat_shamir.acc_right_Q_x,
       acc.fiat_shamir.acc_right_zero_div,
-      acc.acc_corr[0].clone(),
-      acc.acc_corr[1].clone(),
-      acc.acc_corr[2].clone(),
-      acc.acc_corr[3].clone(),
+      acc.acc_corr[0],
+      acc.acc_corr[1],
+      acc.acc_corr[2],
+      acc.acc_corr[3],
       acc.fiat_shamir.acc_flat_L,
       acc.fiat_shamir.acc_flat_R,
     ],
@@ -145,7 +140,7 @@ fn permute_acc_to_acc_holder<P: Clone + CanonicalSerialize, Q: Clone + Canonical
   }
 }
 
-fn acc_proof_to_permute_acc<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize>(
+fn acc_proof_to_permute_acc<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(
   acc_proof: (&Vec<P>, &Vec<Q>, &Vec<Fr>),
 ) -> Option<PermuteAccProof<P, Q>> {
   if acc_proof.0.len() == 0 && acc_proof.1.len() == 0 && acc_proof.2.len() == 0 {
@@ -155,7 +150,7 @@ fn acc_proof_to_permute_acc<P: Clone + CanonicalSerialize, Q: Clone + CanonicalS
   Some(permute_acc_holder_to_acc(acc_holder))
 }
 
-fn permute_acc_to_acc_proof<P: Clone + CanonicalSerialize, Q: Clone + CanonicalSerialize>(acc: PermuteAccProof<P, Q>) -> (Vec<P>, Vec<Q>, Vec<Fr>) {
+fn permute_acc_to_acc_proof<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(acc: PermuteAccProof<P, Q>) -> (Vec<P>, Vec<Q>, Vec<Fr>) {
   let acc_holder = permute_acc_to_acc_holder(acc);
   acc_to_acc_proof(acc_holder)
 }
@@ -480,7 +475,7 @@ impl BasicBlock for PermuteBasicBlock {
 
     let permute_acc = acc_proof_to_permute_acc(acc_proof).unwrap();
 
-    let [acc_b_g2, acc_d_g2] = [permute_acc.fiat_shamir.acc_b_g2.clone(), permute_acc.fiat_shamir.acc_d_g2.clone()];
+    let [acc_b_g2, acc_d_g2] = [permute_acc.fiat_shamir.acc_b_g2, permute_acc.fiat_shamir.acc_d_g2];
     assert!(b_g2 == acc_b_g2 && d_g2 == acc_d_g2);
 
     // Compute the error (but we skip it because permuteBB has no error)


### PR DESCRIPTION
Sample readability for matmul and permute to include named structs that also simplify logic for what is included in fiat-shamir and prover vs. verifier.

Bing-Jyue says that the parallelization features will change the API, so the design may change again based on that.