### PR TITLE
Setup deduplication

### DIFF
--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -90,12 +90,15 @@ pub enum CacheValues {
   RLCRandom(Fr),
   Data(Data),
   G2(G2Affine),
+  G1Vec(Vec<G1Affine>),
 }
 
 // The cache is wrapped in Arc<Mutex<>> to allow multiple threads within the same role (either prover or verifier) to access it.
 // Arc (Atomic Reference Counting) enables safe sharing of the cache between threads,
 // while Mutex ensures that only one thread can write to the cache at a time, preventing race conditions.
 // Note: Each prover and verifier maintains its own separate cache. There is no cache sharing between the prover and verifier.
+pub type SetupCache = Arc<Mutex<HashMap<String, CacheValues>>>;
+
 pub type ProveVerifyCache = Arc<Mutex<HashMap<String, CacheValues>>>;
 
 pub type PairingCheck = Vec<(G1Affine, G2Affine)>;
@@ -166,7 +169,12 @@ pub trait BasicBlock: std::fmt::Debug + Send + Sync + downcast_rs::Downcast {
 
   // The subsequent setup/prove/verify functions run on encoded Data objects (vector commitments).
   // This reduces computation because the Data objects can be encoded once at the beginning and then reused for these functions.
-  fn setup(&self, _srs: &SRS, _model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
+  fn setup(
+    &self,
+    _srs: &SRS,
+    _model: &ArrayD<Data>,
+    _setup_cache: &mut SetupCache,
+  ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
     #[cfg(feature = "mock_prove")]
     eprintln!("\x1b[93mWARNING\x1b[0m: MockSetup is enabled. This is only for testing purposes.");
     (Vec::new(), Vec::new(), Vec::new())
@@ -180,6 +188,7 @@ pub trait BasicBlock: std::fmt::Debug + Send + Sync + downcast_rs::Downcast {
     _inputs: &Vec<&ArrayD<Data>>,
     _outputs: &Vec<&ArrayD<Data>>,
     _rng: &mut StdRng,
+    _setup_cache: &SetupCache,
     _cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     (Vec::new(), Vec::new(), Vec::new())

--- a/src/basic_block/bool_check.rs
+++ b/src/basic_block/bool_check.rs
@@ -1,4 +1,4 @@
-use super::BasicBlock;
+use super::{BasicBlock, SetupCache};
 use crate::{
   basic_block::{Data, DataEnc, PairingCheck, ProveVerifyCache, SRS},
   onnx, util,
@@ -40,6 +40,7 @@ impl BasicBlock for BooleanCheckBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     _outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    _setup_cache: &SetupCache,
     _cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let N = inputs[0].first().unwrap().raw.len();

--- a/src/basic_block/copy_constraint.rs
+++ b/src/basic_block/copy_constraint.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, Data, DataEnc, SRS};
+use super::{BasicBlock, Data, DataEnc, SetupCache, SRS};
 use crate::{
   basic_block::{PairingCheck, ProveVerifyCache},
   util::{self, calc_pow},
@@ -175,7 +175,12 @@ impl BasicBlock for CopyConstraintBasicBlock {
   }
 
   #[cfg(not(feature = "mock_prove"))]
-  fn setup(&self, srs: &SRS, _model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
+  fn setup(
+    &self,
+    srs: &SRS,
+    _model: &ArrayD<Data>,
+    _setup_cache: &mut SetupCache,
+  ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
     let output_dim = self.permutation.dim();
     let last_inp_dim = self.input_dim[self.input_dim.ndim() - 1];
     let last_outp_dim = output_dim[output_dim.ndim() - 1];
@@ -279,7 +284,12 @@ impl BasicBlock for CopyConstraintBasicBlock {
   }
 
   #[cfg(feature = "mock_prove")]
-  fn setup(&self, srs: &SRS, _model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
+  fn setup(
+    &self,
+    srs: &SRS,
+    _model: &ArrayD<Data>,
+    _setup_cache: &mut SetupCache,
+  ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
     eprintln!("\x1b[93mWARNING\x1b[0m: MockSetup is enabled. This is only for testing purposes.");
     let output_dim = self.permutation.dim().as_array_view().to_vec();
     let input_dim = self.input_dim.as_array_view().to_vec();
@@ -310,6 +320,7 @@ impl BasicBlock for CopyConstraintBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    _setup_cache: &SetupCache,
     _cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let input = inputs[0];

--- a/src/basic_block/cq.rs
+++ b/src/basic_block/cq.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SetupCache, SRS};
 use crate::util;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
@@ -39,52 +39,67 @@ impl BasicBlock for CQBasicBlock {
   }
 
   #[cfg(not(feature = "mock_prove"))]
-  fn setup(&self, srs: &SRS, model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
+  fn setup(&self, srs: &SRS, model: &ArrayD<Data>, setup_cache: &mut SetupCache) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
     assert!(model.len() == 1);
     let model = &model.first().unwrap();
     let N = model.raw.len();
     let domain_2N = GeneralEvaluationDomain::<Fr>::new(2 * N).unwrap();
     let domain_N = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
     let T_x_2 = util::msm::<G2Projective>(&srs.X2A, &model.poly.coeffs) + srs.Y2P * model.r;
-    let mut temp = model.poly.coeffs[1..].to_vec();
-    temp.resize(N * 2 - 1, Fr::zero());
-    let mut temp2 = srs.X1P[..N].to_vec();
-    temp2.reverse();
-    let mut Q_i_x_1 = util::toeplitz_mul(domain_2N, &temp, &temp2);
-    util::fft_in_place(domain_N, &mut Q_i_x_1);
-    let temp = Fr::from(N as u32).inverse().unwrap();
-    let temp2 = domain_N.group_gen_inv().pow(&[(N - 1) as u64]);
-    let scalars: Vec<_> = (0..N).into_par_iter().map(|i| temp * temp2.pow(&[i as u64])).collect();
-    util::ssm_g1_in_place(&mut Q_i_x_1, &scalars);
-    let mut L_i_x_1 = srs.X1P[..N].to_vec();
-    util::ifft_in_place(domain_N, &mut L_i_x_1);
-    let mut L_i_0_x_1 = L_i_x_1.clone();
-    let scalars = (0..N).into_par_iter().map(|i| domain_N.group_gen_inv().pow(&[i as u64])).collect();
-    util::ssm_g1_in_place(&mut L_i_0_x_1, &scalars);
 
-    let temp = srs.X1P[N - 1] * Fr::from(N as u64).inverse().unwrap();
-    L_i_0_x_1.par_iter_mut().for_each(|x| *x -= temp);
+    let mut cache = setup_cache.lock().unwrap();
+    if cache.get(&format!("cq_Q_i_x_1_{:p}_{}", self, N)).is_none() {
+      let mut temp = model.poly.coeffs[1..].to_vec();
+      temp.resize(N * 2 - 1, Fr::zero());
+      let mut temp2 = srs.X1P[..N].to_vec();
+      temp2.reverse();
+      let mut Q_i_x_1 = util::toeplitz_mul(domain_2N, &temp, &temp2);
+      util::fft_in_place(domain_N, &mut Q_i_x_1);
+      let temp = Fr::from(N as u32).inverse().unwrap();
+      let temp2 = domain_N.group_gen_inv().pow(&[(N - 1) as u64]);
+      let scalars: Vec<_> = (0..N).into_par_iter().map(|i| temp * temp2.pow(&[i as u64])).collect();
+      util::ssm_g1_in_place(&mut Q_i_x_1, &scalars);
+      let Q_i_x_1 = Q_i_x_1.into_iter().map(|x| x.into()).collect();
+      cache.insert(format!("cq_Q_i_x_1_{:p}_{}", self, N), CacheValues::G1Vec(Q_i_x_1));
+      let CacheValues::G1Vec(L_i_x_1) = cache.entry(format!("L_i_x_1_{}", N)).or_insert_with(|| {
+        let mut L_i_x_1 = srs.X1P[..N].to_vec();
+        util::ifft_in_place(domain_N, &mut L_i_x_1);
+        let L_i_x_1 = L_i_x_1.into_iter().map(|x| x.into()).collect();
+        CacheValues::G1Vec(L_i_x_1)
+      }) else {
+        panic!("Cache type error")
+      };
+      let mut L_i_0_x_1: Vec<G1Projective> = L_i_x_1.iter().map(|x| G1Projective::from(*x)).collect();
+      let scalars: Vec<Fr> = (0..N).into_par_iter().map(|i| domain_N.group_gen_inv().pow(&[i as u64])).collect();
+      util::ssm_g1_in_place(&mut L_i_0_x_1, &scalars);
 
-    let mut setup = Q_i_x_1;
-    setup.extend(L_i_x_1);
-    setup.extend(L_i_0_x_1);
-    return (setup, vec![T_x_2], Vec::new());
+      let temp = srs.X1P[N - 1] * Fr::from(N as u64).inverse().unwrap();
+      L_i_0_x_1.par_iter_mut().for_each(|x| *x -= temp);
+      let L_i_0_x_1 = L_i_0_x_1.into_iter().map(|x| x.into()).collect();
+      cache.insert(format!("cq_L_i_0_x_1_{}", N), CacheValues::G1Vec(L_i_0_x_1));
+    }
+
+    return (vec![], vec![T_x_2], Vec::new());
   }
 
   #[cfg(feature = "mock_prove")]
-  fn setup(&self, srs: &SRS, model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
+  fn setup(&self, srs: &SRS, model: &ArrayD<Data>, setup_cache: &mut SetupCache) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
     eprintln!("\x1b[93mWARNING\x1b[0m: MockSetup is enabled. This is only for testing purposes.");
     assert!(model.len() == 1);
     let model = &model.first().unwrap();
     let N = model.raw.len();
-    let L_i_x_1 = srs.X1P[..N].to_vec();
-    let L_i_0_x_1 = L_i_x_1.clone();
-    let Q_i_x_1 = L_i_x_1.clone();
+    let mut cache = setup_cache.lock().unwrap();
+    let _ = cache.entry(format!("L_i_x_1_{}", N)).or_insert_with(|| CacheValues::G1Vec(srs.X1A[..N].to_vec())) else {
+      panic!("Cache type error")
+    };
+    let _ = cache.entry(format!("cq_L_i_0_x_1_{}", N)).or_insert_with(|| CacheValues::G1Vec(srs.X1A[..N].to_vec())) else {
+      panic!("Cache type error")
+    };
+    let _ = cache.entry(format!("cq_Q_i_x_1_{:p}_{}", self, N)).or_insert_with(|| CacheValues::G1Vec(srs.X1A[..N].to_vec())) else {
+      panic!("Cache type error")
+    };
 
-    let mut setup = Q_i_x_1;
-    setup.extend(L_i_x_1);
-    setup.extend(L_i_0_x_1);
-    return (setup, vec![srs.X2P[0]], Vec::new());
+    return (vec![], vec![srs.X2P[0]], Vec::new());
   }
 
   fn prove(
@@ -95,6 +110,7 @@ impl BasicBlock for CQBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     _outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    setup_cache: &SetupCache,
     cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     assert!(inputs.len() == 1 && inputs[0].len() == 1);
@@ -106,9 +122,23 @@ impl BasicBlock for CQBasicBlock {
     let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
 
     // gen(N, t):
-    let Q_i_x_1 = &setup.0[..N];
-    let L_i_x_1 = &setup.0[N..2 * N];
-    let L_i_0_x_1 = &setup.0[2 * N..];
+    let setup_cache = setup_cache.lock().unwrap();
+    let L_i_x_1 = if let Some(CacheValues::G1Vec(vec)) = { setup_cache.get(&format!("L_i_x_1_{}", N)) } {
+      vec
+    } else {
+      panic!("Cache miss for L_i_x_1")
+    };
+    let L_i_0_x_1 = if let Some(CacheValues::G1Vec(vec)) = { setup_cache.get(&format!("cq_L_i_0_x_1_{}", N)) } {
+      vec
+    } else {
+      panic!("Cache miss for L_i_0_x_1")
+    };
+    let Q_i_x_1 = if let Some(CacheValues::G1Vec(vec)) = { setup_cache.get(&format!("cq_Q_i_x_1_{:p}_{}", self, N)) } {
+      vec
+    } else {
+      panic!("Cache miss for Q_i_x_1")
+    };
+
     let m_i = {
       let mut cache = cache.lock().unwrap();
       let CacheValues::CQTableDict(table_dict) =

--- a/src/basic_block/cq2.rs
+++ b/src/basic_block/cq2.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SetupCache, SRS};
 use crate::util;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
@@ -51,44 +51,60 @@ impl BasicBlock for CQ2BasicBlock {
   }
 
   #[cfg(not(feature = "mock_prove"))]
-  fn setup(&self, srs: &SRS, model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
+  fn setup(&self, srs: &SRS, model: &ArrayD<Data>, setup_cache: &mut SetupCache) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
     assert!(model.ndim() == 1 && model.len() == 2);
     let N = model[0].raw.len();
     let domain_2N = GeneralEvaluationDomain::<Fr>::new(2 * N).unwrap();
     let domain_N = GeneralEvaluationDomain::<Fr>::new(N).unwrap();
-    let mut setup = vec![];
     let mut setup2 = vec![];
     for i in 0..2 {
       setup2.push(util::msm::<G2Projective>(&srs.X2A, &model[i].poly.coeffs) + srs.Y2P * model[i].r);
-      let mut temp = model[i].poly.coeffs[1..].to_vec();
-      temp.resize(N * 2 - 1, Fr::zero());
-      let mut temp2 = srs.X1P[..N].to_vec();
-      temp2.reverse();
-      let mut Q_i_x_1 = util::toeplitz_mul(domain_2N, &temp, &temp2);
-      util::fft_in_place(domain_N, &mut Q_i_x_1);
-      let temp = Fr::from(N as u32).inverse().unwrap();
-      let temp2 = domain_N.group_gen_inv().pow(&[(N - 1) as u64]);
-      let scalars = (0..N).into_par_iter().map(|i| temp * temp2.pow(&[i as u64])).collect();
-      util::ssm_g1_in_place(&mut Q_i_x_1, &scalars);
-
-      setup.extend(Q_i_x_1);
+    }
+    let mut cache = setup_cache.lock().unwrap();
+    if cache.get(&format!("cq_Q_i_x_1_{:p}_{}", self, N)).is_none() {
+      for i in 0..2 {
+        let mut temp = model[i].poly.coeffs[1..].to_vec();
+        temp.resize(N * 2 - 1, Fr::zero());
+        let mut temp2 = srs.X1P[..N].to_vec();
+        temp2.reverse();
+        let mut Q_i_x_1 = util::toeplitz_mul(domain_2N, &temp, &temp2);
+        util::fft_in_place(domain_N, &mut Q_i_x_1);
+        let temp = Fr::from(N as u32).inverse().unwrap();
+        let temp2 = domain_N.group_gen_inv().pow(&[(N - 1) as u64]);
+        let scalars = (0..N).into_par_iter().map(|i| temp * temp2.pow(&[i as u64])).collect();
+        util::ssm_g1_in_place(&mut Q_i_x_1, &scalars);
+        let tag = if i == 0 { "A" } else { "B" };
+        let Q_i_x_1 = Q_i_x_1.into_iter().map(|x| x.into()).collect();
+        cache.insert(format!("cq_Q_i_x_1_{}_{:p}_{}", tag, self, N), CacheValues::G1Vec(Q_i_x_1));
+      }
     }
 
-    let mut L_i_x_1 = srs.X1P[..N].to_vec();
-    util::ifft_in_place(domain_N, &mut L_i_x_1);
-    let mut L_i_0_x_1 = L_i_x_1.clone();
-    let scalars = (0..N).into_par_iter().map(|i| domain_N.group_gen_inv().pow(&[i as u64])).collect();
-    util::ssm_g1_in_place(&mut L_i_0_x_1, &scalars);
-    let temp = srs.X1P[N - 1] * Fr::from(N as u64).inverse().unwrap();
-    L_i_0_x_1.par_iter_mut().for_each(|x| *x -= temp);
+    let CacheValues::G1Vec(L_i_x_1) = cache.entry(format!("L_i_x_1_{}", N)).or_insert_with(|| {
+      let mut L_i_x_1 = srs.X1P[..N].to_vec();
+      util::ifft_in_place(domain_N, &mut L_i_x_1);
+      let L_i_x_1 = L_i_x_1.into_iter().map(|x| x.into()).collect();
+      CacheValues::G1Vec(L_i_x_1)
+    }) else {
+      panic!("Cache type error")
+    };
 
-    setup.extend(L_i_x_1);
-    setup.extend(L_i_0_x_1);
-    return (setup, setup2, Vec::new());
+    let mut L_i_0_x_1 = L_i_x_1.iter().map(|x| G1Projective::from(*x)).collect();
+
+    let _ = cache.entry(format!("cq_L_i_0_x_1_{}", N)).or_insert_with(|| {
+      let scalars = (0..N).into_par_iter().map(|i| domain_N.group_gen_inv().pow(&[i as u64])).collect();
+      util::ssm_g1_in_place(&mut L_i_0_x_1, &scalars);
+
+      let temp = srs.X1P[N - 1] * Fr::from(N as u64).inverse().unwrap();
+      L_i_0_x_1.par_iter_mut().for_each(|x| *x -= temp);
+      let L_i_0_x_1 = L_i_0_x_1.into_iter().map(|x| x.into()).collect();
+      CacheValues::G1Vec(L_i_0_x_1)
+    });
+
+    return (vec![], setup2, Vec::new());
   }
 
   #[cfg(feature = "mock_prove")]
-  fn setup(&self, srs: &SRS, model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
+  fn setup(&self, srs: &SRS, model: &ArrayD<Data>, setup_cache: &mut SetupCache) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
     eprintln!("\x1b[93mWARNING\x1b[0m: MockSetup is enabled. This is only for testing purposes.");
     assert!(model.ndim() == 1 && model.len() == 2);
     let N = model[0].raw.len();
@@ -97,16 +113,21 @@ impl BasicBlock for CQ2BasicBlock {
     for i in 0..2 {
       setup2.push(srs.X2P[i]);
     }
-    let Q_i_x_1_A = srs.X1P[..N].to_vec();
-    let Q_i_x_1_B = srs.X1P[..N].to_vec();
-    let L_i_x_1 = srs.X1P[..N].to_vec();
-    let L_i_0_x_1 = srs.X1P[..N].to_vec();
 
-    setup.extend(Q_i_x_1_A);
-    setup.extend(Q_i_x_1_B);
-    setup.extend(L_i_x_1);
-    setup.extend(L_i_0_x_1);
-    return (setup, setup2, Vec::new());
+    let mut cache = setup_cache.lock().unwrap();
+    let _ = cache.entry(format!("cq_L_i_x_1_{}", N)).or_insert_with(|| CacheValues::G1Vec(srs.X1A[..N].to_vec())) else {
+      panic!("Cache type error")
+    };
+    let _ = cache.entry(format!("cq_L_i_0_x_1_{}", N)).or_insert_with(|| CacheValues::G1Vec(srs.X1A[..N].to_vec())) else {
+      panic!("Cache type error")
+    };
+    let _ = cache.entry(format!("cq_Q_i_x_1_A_{:p}_{}", self, N)).or_insert_with(|| CacheValues::G1Vec(srs.X1A[..N].to_vec())) else {
+      panic!("Cache type error")
+    };
+    let _ = cache.entry(format!("cq_Q_i_x_1_B_{:p}_{}", self, N)).or_insert_with(|| CacheValues::G1Vec(srs.X1A[..N].to_vec())) else {
+      panic!("Cache type error")
+    };
+    return (vec![], setup2, Vec::new());
   }
 
   fn prove(
@@ -117,6 +138,7 @@ impl BasicBlock for CQ2BasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     _outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    setup_cache: &SetupCache,
     cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     assert!(inputs.len() == 2 && inputs[0].len() == 1 && inputs[1].len() == 1);
@@ -133,10 +155,27 @@ impl BasicBlock for CQ2BasicBlock {
     let agg_model_r = model[0].r + model[1].r * alpha;
 
     // gen(N, t):
-    let Q_i_x_1_A = &setup.0[..N];
-    let Q_i_x_1_B = &setup.0[N..2 * N];
-    let L_i_x_1 = &setup.0[2 * N..3 * N];
-    let L_i_0_x_1 = &setup.0[3 * N..];
+    let setup_cache = setup_cache.lock().unwrap();
+    let L_i_x_1 = if let Some(CacheValues::G1Vec(vec)) = { setup_cache.get(&format!("L_i_x_1_{}", N)) } {
+      vec
+    } else {
+      panic!("Cache miss for L_i_x_1")
+    };
+    let L_i_0_x_1 = if let Some(CacheValues::G1Vec(vec)) = { setup_cache.get(&format!("cq_L_i_0_x_1_{}", N)) } {
+      vec
+    } else {
+      panic!("Cache miss for L_i_0_x_1")
+    };
+    let Q_i_x_1_A = if let Some(CacheValues::G1Vec(vec)) = { setup_cache.get(&format!("cq_Q_i_x_1_A_{:p}_{}", self, N)) } {
+      vec
+    } else {
+      panic!("Cache miss for Q_i_x_1_A")
+    };
+    let Q_i_x_1_B = if let Some(CacheValues::G1Vec(vec)) = { setup_cache.get(&format!("cq_Q_i_x_1_B_{:p}_{}", self, N)) } {
+      vec
+    } else {
+      panic!("Cache miss for Q_i_x_1_B")
+    };
 
     let m_i = {
       let mut cache = cache.lock().unwrap();

--- a/src/basic_block/cqlin.rs
+++ b/src/basic_block/cqlin.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SetupCache, SRS};
 use crate::util::{self, acc_to_acc_proof, calc_pow, AccHolder};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
@@ -105,7 +105,7 @@ impl BasicBlock for CQLinBasicBlock {
   }
 
   #[cfg(not(feature = "mock_prove"))]
-  fn setup(&self, srs: &SRS, model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
+  fn setup(&self, srs: &SRS, model: &ArrayD<Data>, setup_cache: &mut SetupCache) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
     let m = model.len();
     let n = model[0].raw.len();
     let N = srs.X2P.len() - 1;
@@ -114,101 +114,125 @@ impl BasicBlock for CQLinBasicBlock {
     let domain_n = GeneralEvaluationDomain::<Fr>::new(n).unwrap();
     let domain_2m = GeneralEvaluationDomain::<Fr>::new(2 * m).unwrap();
 
-    let mut L_H_i_x = srs.X1P[..n].to_vec();
-    util::ifft_in_place(domain_n, &mut L_H_i_x);
-    let mut L_V_i_x_n: Vec<_> = (0..m).into_par_iter().map(|i| srs.X1P[n * i]).collect();
-    util::ifft_in_place(domain_m, &mut L_V_i_x_n);
-    let mut L_V_i_x: Vec<G1Projective> = srs.X1P[..m].into_par_iter().map(|x| (*x).into()).collect();
-    util::ifft_in_place::<G1Projective>(domain_m, &mut L_V_i_x);
+    let mut cache = setup_cache.lock().unwrap();
+    if cache.get(&format!("cqlin_L_V_i_x_n_{}_{}", m, n)).is_none() {
+      let mut L_V_i_x_n: Vec<_> = (0..m).into_par_iter().map(|i| srs.X1P[n * i]).collect();
+      util::ifft_in_place(domain_m, &mut L_V_i_x_n);
+      let L_V_i_x_n = L_V_i_x_n.into_iter().map(|x| x.into()).collect();
+      cache.insert(format!("cqlin_L_V_i_x_n_{}_{}", m, n), CacheValues::G1Vec(L_V_i_x_n));
+    }
+
+    if cache.get(&format!("L_i_x_1_{}", m)).is_none() {
+      let mut L_V_i_x: Vec<G1Projective> = srs.X1P[..m].into_par_iter().map(|x| (*x).into()).collect();
+      util::ifft_in_place::<G1Projective>(domain_m, &mut L_V_i_x);
+      let L_V_i_x = L_V_i_x.into_iter().map(|x| x.into()).collect();
+      cache.insert(format!("L_i_x_1_{}", m), CacheValues::G1Vec(L_V_i_x));
+    }
 
     // Calculate G1 U for R and S
-    let mut temp: Vec<Vec<_>> = (0..n).into_par_iter().map(|i| (0..m).map(|j| srs.X1P[i + n * j]).collect()).collect();
-    temp.par_iter_mut().for_each(|x| util::ifft_in_place(domain_m, x));
-    let mut U: Vec<Vec<_>> = (0..m).into_par_iter().map(|i| (0..n).map(|j| temp[j][i]).collect()).collect();
-    U.par_iter_mut().for_each(|x| util::ifft_in_place(domain_n, x));
+    let M_x = if cache.get(&format!("cqlin_R_{:p}_{}", self, n)).is_none() {
+      let mut temp: Vec<Vec<_>> = (0..n).into_par_iter().map(|i| (0..m).map(|j| srs.X1P[i + n * j]).collect()).collect();
+      temp.par_iter_mut().for_each(|x| util::ifft_in_place(domain_m, x));
+      let mut U: Vec<Vec<_>> = (0..m).into_par_iter().map(|i| (0..n).map(|j| temp[j][i]).collect()).collect();
+      U.par_iter_mut().for_each(|x| util::ifft_in_place(domain_n, x));
 
-    // Calculate U for mn-degree check
-    let mut temp: Vec<Vec<_>> = (0..n).into_par_iter().map(|i| (0..m).map(|j| srs.X1P[N - m * n + i + n * j]).collect()).collect();
-    temp.par_iter_mut().for_each(|x| util::ifft_in_place(domain_m, x));
-    let mut U_P_R: Vec<Vec<_>> = (0..m).into_par_iter().map(|i| (0..n).map(|j| temp[j][i]).collect()).collect();
-    U_P_R.par_iter_mut().for_each(|x| util::ifft_in_place(domain_n, x));
+      // Calculate U for mn-degree check
+      let mut temp: Vec<Vec<_>> = (0..n).into_par_iter().map(|i| (0..m).map(|j| srs.X1P[N - m * n + i + n * j]).collect()).collect();
+      temp.par_iter_mut().for_each(|x| util::ifft_in_place(domain_m, x));
+      let mut U_P_R: Vec<Vec<_>> = (0..m).into_par_iter().map(|i| (0..n).map(|j| temp[j][i]).collect()).collect();
+      U_P_R.par_iter_mut().for_each(|x| util::ifft_in_place(domain_n, x));
 
-    // Calculate G2 U for M
-    let mut temp: Vec<Vec<G2Projective>> = (0..n).into_par_iter().map(|i| (0..m).map(|j| srs.X2P[i + n * j]).collect()).collect();
-    temp.par_iter_mut().for_each(|x| util::ifft_in_place(domain_m, x));
-    let mut U2: Vec<Vec<_>> = (0..m).into_par_iter().map(|i| (0..n).map(|j| temp[j][i]).collect()).collect();
-    U2.par_iter_mut().for_each(|x| util::ifft_in_place(domain_n, x));
-    let mut V = srs.X1P[m * n - n..m * n].to_vec();
-    util::ifft_in_place(domain_n, &mut V);
-    V.par_iter_mut().for_each(|x| *x *= m_inv);
+      // Calculate G2 U for M
+      let mut temp: Vec<Vec<G2Projective>> = (0..n).into_par_iter().map(|i| (0..m).map(|j| srs.X2P[i + n * j]).collect()).collect();
+      temp.par_iter_mut().for_each(|x| util::ifft_in_place(domain_m, x));
+      let mut U2: Vec<Vec<_>> = (0..m).into_par_iter().map(|i| (0..n).map(|j| temp[j][i]).collect()).collect();
+      U2.par_iter_mut().for_each(|x| util::ifft_in_place(domain_n, x));
+      let mut V = srs.X1P[m * n - n..m * n].to_vec();
+      util::ifft_in_place(domain_n, &mut V);
+      V.par_iter_mut().for_each(|x| *x *= m_inv);
 
-    let mut srs_star: Vec<Vec<_>> = (0..m).into_par_iter().map(|i| srs.X1P[n * i..n * i + n].to_vec()).collect();
-    srs_star.par_iter_mut().for_each(|x| util::ifft_in_place(domain_n, x));
-    srs_star = (0..n).into_par_iter().map(|i| (0..m).map(|j| srs_star[m - 1 - j][i]).collect()).collect();
-    srs_star.par_iter_mut().for_each(|x| x.append(&mut vec![G1Projective::zero(); m]));
-    srs_star.par_iter_mut().for_each(|x| util::fft_in_place(domain_2m, x));
+      let mut srs_star: Vec<Vec<_>> = (0..m).into_par_iter().map(|i| srs.X1P[n * i..n * i + n].to_vec()).collect();
+      srs_star.par_iter_mut().for_each(|x| util::ifft_in_place(domain_n, x));
+      srs_star = (0..n).into_par_iter().map(|i| (0..m).map(|j| srs_star[m - 1 - j][i]).collect()).collect();
+      srs_star.par_iter_mut().for_each(|x| x.append(&mut vec![G1Projective::zero(); m]));
+      srs_star.par_iter_mut().for_each(|x| util::fft_in_place(domain_2m, x));
 
-    let S: Vec<Vec<_>> = (0..m)
-      .into_par_iter()
-      .map(|i| (0..n).map(|j| (U[i][j] * domain_m.element(i).inverse().unwrap() - V[j]) * model[i].raw[j]).collect())
-      .collect();
-    let mut S: Vec<_> = S.par_iter().map(|x| x.iter().sum::<G1Projective>()).collect();
+      let S: Vec<Vec<_>> = (0..m)
+        .into_par_iter()
+        .map(|i| (0..n).map(|j| (U[i][j] * domain_m.element(i).inverse().unwrap() - V[j]) * model[i].raw[j]).collect())
+        .collect();
+      let S: Vec<_> = S.par_iter().map(|x| x.iter().sum::<G1Projective>()).collect();
 
-    let R: Vec<Vec<_>> = (0..m).into_par_iter().map(|i| (0..n).map(|j| U[i][j] * model[i].raw[j]).collect()).collect();
-    let R: Vec<_> = R.par_iter().map(|x| x.iter().sum::<G1Projective>()).collect();
+      let R: Vec<Vec<_>> = (0..m).into_par_iter().map(|i| (0..n).map(|j| U[i][j] * model[i].raw[j]).collect()).collect();
+      let R: Vec<_> = R.par_iter().map(|x| x.iter().sum::<G1Projective>()).collect();
 
-    let P_R: Vec<Vec<_>> = (0..m).into_par_iter().map(|i| (0..n).map(|j| U_P_R[i][j] * model[i].raw[j]).collect()).collect();
-    let mut P_R: Vec<_> = P_R.par_iter().map(|x| x.iter().sum::<G1Projective>()).collect();
+      let P_R: Vec<Vec<_>> = (0..m).into_par_iter().map(|i| (0..n).map(|j| U_P_R[i][j] * model[i].raw[j]).collect()).collect();
+      let P_R: Vec<_> = P_R.par_iter().map(|x| x.iter().sum::<G1Projective>()).collect();
 
-    // Calculate C for Q
-    let mut C: Vec<Vec<_>> = (0..n).into_par_iter().map(|i| (0..m).map(|j| model[j].raw[i]).collect()).collect();
-    C.par_iter_mut().for_each(|x| domain_m.ifft_in_place(x));
+      // Calculate C for Q
+      let mut C: Vec<Vec<_>> = (0..n).into_par_iter().map(|i| (0..m).map(|j| model[j].raw[i]).collect()).collect();
+      C.par_iter_mut().for_each(|x| domain_m.ifft_in_place(x));
 
-    // Calculate Q. The C above corresponds to the C in the cqlin paper
-    C.par_iter_mut().for_each(|x| x.append(&mut vec![Fr::zero(); m]));
-    C.par_iter_mut().for_each(|x| domain_2m.fft_in_place(x));
-    let temp: Vec<Vec<_>> = (0..2 * m).into_par_iter().map(|i| (0..n).map(|j| srs_star[j][i] * C[j][i]).collect()).collect();
-    let mut temp: Vec<_> = temp.par_iter().map(|x| x.iter().sum::<G1Projective>()).collect();
-    util::ifft_in_place(domain_2m, &mut temp);
-    let mut temp = temp[m..].to_vec();
-    util::fft_in_place(domain_m, &mut temp);
-    let mut Q: Vec<_> = (0..m).into_par_iter().map(|i| temp[i] * domain_m.element(i) * m_inv).collect();
-    let M_x = (0..m).into_par_iter().map(|i| (0..n).map(|j| U2[i][j] * model[i].raw[j]).sum::<G2Projective>()).sum::<G2Projective>(); // TODO: Change to msm
+      // Calculate Q. The C above corresponds to the C in the cqlin paper
+      C.par_iter_mut().for_each(|x| x.append(&mut vec![Fr::zero(); m]));
+      C.par_iter_mut().for_each(|x| domain_2m.fft_in_place(x));
+      let temp: Vec<Vec<_>> = (0..2 * m).into_par_iter().map(|i| (0..n).map(|j| srs_star[j][i] * C[j][i]).collect()).collect();
+      let mut temp: Vec<_> = temp.par_iter().map(|x| x.iter().sum::<G1Projective>()).collect();
+      util::ifft_in_place(domain_2m, &mut temp);
+      let mut temp = temp[m..].to_vec();
+      util::fft_in_place(domain_m, &mut temp);
+      let Q: Vec<_> = (0..m).into_par_iter().map(|i| temp[i] * domain_m.element(i) * m_inv).collect();
+      let M_x = (0..m).into_par_iter().map(|i| (0..n).map(|j| U2[i][j] * model[i].raw[j]).sum::<G2Projective>()).sum::<G2Projective>();
 
-    let mut setup = R;
-    setup.append(&mut Q);
-    setup.append(&mut S);
-    setup.append(&mut P_R);
-    setup.append(&mut L_V_i_x_n);
-    setup.append(&mut L_V_i_x);
-    setup.append(&mut L_H_i_x);
-    (setup, vec![M_x.into()], Vec::new())
+      let R = R.into_iter().map(|x| x.into()).collect();
+      let Q = Q.into_iter().map(|x| x.into()).collect();
+      let S = S.into_iter().map(|x| x.into()).collect();
+      let P_R = P_R.into_iter().map(|x| x.into()).collect();
+      cache.insert(format!("cqlin_R_{:p}_{}", self, n), CacheValues::G1Vec(R));
+      cache.insert(format!("cqlin_Q_{:p}_{}", self, n), CacheValues::G1Vec(Q));
+      cache.insert(format!("cqlin_S_{:p}_{}", self, n), CacheValues::G1Vec(S));
+      cache.insert(format!("cqlin_P_R_{:p}_{}", self, n), CacheValues::G1Vec(P_R));
+      cache.insert(format!("cqlin_M_x_{:p}", self), CacheValues::G2(M_x.into()));
+      M_x
+    } else {
+      let CacheValues::G2(M_x) = cache.get(&format!("cqlin_M_x_{:p}", self)).unwrap() else {
+        panic!("Cache type error")
+      };
+      G2Projective::from(*M_x)
+    };
+
+    (vec![], vec![M_x.into()], Vec::new())
   }
 
   #[cfg(feature = "mock_prove")]
-  fn setup(&self, srs: &SRS, model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
+  fn setup(&self, srs: &SRS, model: &ArrayD<Data>, setup_cache: &mut SetupCache) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
     eprintln!("\x1b[93mWARNING\x1b[0m: MockSetup is enabled. This is only for testing purposes.");
     let m = model.len();
     let n = model[0].raw.len();
 
-    let mut L_H_i_x = srs.X1P[..n].to_vec();
-    let mut L_V_i_x_n: Vec<_> = srs.X1P[..m].into_par_iter().map(|x| (*x).into()).collect();
-    let mut L_V_i_x: Vec<G1Projective> = srs.X1P[..m].into_par_iter().map(|x| (*x).into()).collect();
-    let R: Vec<_> = L_V_i_x.iter().map(|x| *x).collect();
-    let mut Q: Vec<_> = L_V_i_x.iter().map(|x| *x).collect();
-    let mut S: Vec<_> = L_V_i_x.iter().map(|x| *x).collect();
-    let mut P_R: Vec<_> = L_V_i_x.iter().map(|x| *x).collect();
-
     let M_x = srs.X2P[0].clone();
 
-    let mut setup = R;
-    setup.append(&mut Q);
-    setup.append(&mut S);
-    setup.append(&mut P_R);
-    setup.append(&mut L_V_i_x_n);
-    setup.append(&mut L_V_i_x);
-    setup.append(&mut L_H_i_x);
-    (setup, vec![M_x.into()], Vec::new())
+    let mut setup_cache = setup_cache.lock().unwrap();
+    let _ = setup_cache.entry(format!("cqlin_R_{:p}_{}", self, n)).or_insert_with(|| CacheValues::G1Vec(srs.X1A[..m].to_vec())) else {
+      panic!("Cache type error")
+    };
+    let _ = setup_cache.entry(format!("cqlin_Q_{:p}_{}", self, n)).or_insert_with(|| CacheValues::G1Vec(srs.X1A[..m].to_vec())) else {
+      panic!("Cache type error")
+    };
+    let _ = setup_cache.entry(format!("cqlin_S_{:p}_{}", self, n)).or_insert_with(|| CacheValues::G1Vec(srs.X1A[..m].to_vec())) else {
+      panic!("Cache type error")
+    };
+    let _ = setup_cache.entry(format!("cqlin_P_R_{:p}_{}", self, n)).or_insert_with(|| CacheValues::G1Vec(srs.X1A[..m].to_vec())) else {
+      panic!("Cache type error")
+    };
+    let _ = setup_cache.entry(format!("cqlin_L_V_i_x_n_{}_{}", m, n)).or_insert_with(|| CacheValues::G1Vec(srs.X1A[..m].to_vec())) else {
+      panic!("Cache type error")
+    };
+    let _ = setup_cache.entry(format!("cqlin_L_V_i_x_{}", m)).or_insert_with(|| CacheValues::G1Vec(srs.X1A[..m].to_vec())) else {
+      panic!("Cache type error")
+    };
+
+    (vec![], vec![M_x.into()], Vec::new())
   }
 
   fn prove(
@@ -219,6 +243,7 @@ impl BasicBlock for CQLinBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    setup_cache: &SetupCache,
     cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let l = inputs[0].len();
@@ -276,12 +301,37 @@ impl BasicBlock for CQLinBasicBlock {
     let mut flat_C = Data::new(srs, &flat_C);
     flat_C.r = flat_C_r;
 
-    let R = &setup.0[..m];
-    let Q = &setup.0[m..2 * m];
-    let S = &setup.0[2 * m..3 * m];
-    let P_R = &setup.0[3 * m..4 * m];
-    let L_V_i_x_n = &setup.0[4 * m..5 * m];
-    let L_V_i_x = &setup.0[5 * m..6 * m];
+    let setup_cache = setup_cache.lock().unwrap();
+    let R = if let Some(CacheValues::G1Vec(vec)) = { setup_cache.get(&format!("cqlin_R_{:p}_{}", self, n)) } {
+      vec
+    } else {
+      panic!("Cache miss for R")
+    };
+    let Q = if let Some(CacheValues::G1Vec(vec)) = { setup_cache.get(&format!("cqlin_Q_{:p}_{}", self, n)) } {
+      vec
+    } else {
+      panic!("Cache miss for Q")
+    };
+    let S = if let Some(CacheValues::G1Vec(vec)) = { setup_cache.get(&format!("cqlin_S_{:p}_{}", self, n)) } {
+      vec
+    } else {
+      panic!("Cache miss for S")
+    };
+    let P_R = if let Some(CacheValues::G1Vec(vec)) = { setup_cache.get(&format!("cqlin_P_R_{:p}_{}", self, n)) } {
+      vec
+    } else {
+      panic!("Cache miss for P_R")
+    };
+    let L_V_i_x_n = if let Some(CacheValues::G1Vec(vec)) = { setup_cache.get(&format!("cqlin_L_V_i_x_n_{}_{}", m, n)) } {
+      vec
+    } else {
+      panic!("Cache miss for L_V_i_x_n")
+    };
+    let L_V_i_x = if let Some(CacheValues::G1Vec(vec)) = { setup_cache.get(&format!("L_i_x_1_{}", m)) } {
+      vec
+    } else {
+      panic!("Cache miss for L_V_i_x")
+    };
 
     let R_x = util::msm::<G1Projective>(R, &flat_A.raw).into();
     let Q_x = util::msm::<G1Projective>(Q, &flat_A.raw).into();

--- a/src/basic_block/div.rs
+++ b/src/basic_block/div.rs
@@ -1,4 +1,4 @@
-use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SetupCache, SRS};
 use crate::{onnx, util};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::AffineRepr;
@@ -128,6 +128,7 @@ impl BasicBlock for DivConstProofBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    _setup_cache: &SetupCache,
     _cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     // rlc

--- a/src/basic_block/eq.rs
+++ b/src/basic_block/eq.rs
@@ -1,4 +1,4 @@
-use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SetupCache, SRS};
 use crate::util;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_poly::univariate::DensePolynomial;
@@ -16,6 +16,7 @@ impl BasicBlock for EqBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     _outputs: &Vec<&ArrayD<Data>>,
     _rng: &mut StdRng,
+    _setup_cache: &SetupCache,
     _cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     assert!(inputs.len() == 2 && inputs[0].ndim() <= 1 && inputs[1].ndim() <= 1);

--- a/src/basic_block/matmul.rs
+++ b/src/basic_block/matmul.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SetupCache, SRS};
 use crate::util::{self, calc_pow};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
@@ -60,6 +60,7 @@ impl BasicBlock for MatMulBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    _setup_cache: &SetupCache,
     cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let l = inputs[0].len();

--- a/src/basic_block/max.rs
+++ b/src/basic_block/max.rs
@@ -1,4 +1,4 @@
-use super::BasicBlock;
+use super::{BasicBlock, SetupCache};
 use crate::{
   basic_block::{Data, DataEnc, PairingCheck, ProveVerifyCache, SRS},
   onnx,
@@ -92,6 +92,7 @@ impl BasicBlock for MaxProofBasicBlock {
     _inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    _setup_cache: &SetupCache,
     _cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let N = outputs[1].first().unwrap().raw.len();

--- a/src/basic_block/mul.rs
+++ b/src/basic_block/mul.rs
@@ -1,4 +1,4 @@
-use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SetupCache, SRS};
 use crate::util::{self, acc_to_acc_proof, AccHolder};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_poly::{univariate::DensePolynomial, EvaluationDomain, GeneralEvaluationDomain};
@@ -104,6 +104,7 @@ impl BasicBlock for MulConstBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     _rng: &mut StdRng,
+    _setup_cache: &SetupCache,
     _cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let C = srs.X1P[0] * (Fr::from(self.c as u32) * inputs[0].first().unwrap().r - outputs[0].first().unwrap().r);
@@ -246,6 +247,7 @@ impl BasicBlock for MulScalarBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     _rng: &mut StdRng,
+    _setup_cache: &SetupCache,
     _cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let inp0 = &inputs[0].first().unwrap();
@@ -573,6 +575,7 @@ impl BasicBlock for MulBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     _rng: &mut StdRng,
+    _setup_cache: &SetupCache,
     _cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let inp0 = &inputs[0].first().unwrap();

--- a/src/basic_block/one_to_one.rs
+++ b/src/basic_block/one_to_one.rs
@@ -1,4 +1,4 @@
-use super::BasicBlock;
+use super::{BasicBlock, SetupCache};
 use crate::{
   basic_block::{Data, DataEnc, PairingCheck, ProveVerifyCache, SRS},
   onnx,
@@ -36,6 +36,7 @@ impl BasicBlock for OneToOneBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     _outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    _setup_cache: &SetupCache,
     _cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let N = inputs[0].first().unwrap().raw.len();

--- a/src/basic_block/ordered.rs
+++ b/src/basic_block/ordered.rs
@@ -1,4 +1,4 @@
-use super::BasicBlock;
+use super::{BasicBlock, SetupCache};
 use crate::{
   basic_block::{Data, DataEnc, PairingCheck, ProveVerifyCache, SRS},
   onnx,
@@ -43,6 +43,7 @@ impl BasicBlock for OrderedBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    _setup_cache: &SetupCache,
     _cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let N = inputs[0].first().unwrap().raw.len();

--- a/src/basic_block/permute.rs
+++ b/src/basic_block/permute.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SetupCache, SRS};
 use crate::util::{self, calc_pow};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
@@ -44,6 +44,7 @@ impl BasicBlock for PermuteBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    _setup_cache: &SetupCache,
     cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let alpha = {

--- a/src/basic_block/range.rs
+++ b/src/basic_block/range.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SetupCache, SRS};
 use crate::{
   onnx,
   util::{self, calc_pow},
@@ -50,7 +50,12 @@ impl BasicBlock for RangeConstBasicBlock {
   }
 
   #[cfg(not(feature = "mock_prove"))]
-  fn setup(&self, srs: &SRS, _model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
+  fn setup(
+    &self,
+    srs: &SRS,
+    _model: &ArrayD<Data>,
+    _setup_cache: &mut SetupCache,
+  ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
     let element_num = max(0, ((self.limit - self.start) + self.delta - 1) / self.delta);
     let element_num_pad = util::next_pow(element_num as u32) as usize;
     let domain = GeneralEvaluationDomain::<Fr>::new(element_num_pad.clone() as usize).unwrap();
@@ -70,7 +75,12 @@ impl BasicBlock for RangeConstBasicBlock {
   }
 
   #[cfg(feature = "mock_prove")]
-  fn setup(&self, srs: &SRS, _model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
+  fn setup(
+    &self,
+    srs: &SRS,
+    _model: &ArrayD<Data>,
+    _setup_cache: &mut SetupCache,
+  ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
     eprintln!("\x1b[93mWARNING\x1b[0m: MockSetup is enabled. This is only for testing purposes.");
     (vec![srs.X1P[0].clone()], vec![], vec![])
   }
@@ -83,6 +93,7 @@ impl BasicBlock for RangeConstBasicBlock {
     _inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     _rng: &mut StdRng,
+    _setup_cache: &SetupCache,
     _cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let C = srs.Y1P * outputs[0].first().unwrap().r;

--- a/src/basic_block/repeater.rs
+++ b/src/basic_block/repeater.rs
@@ -1,4 +1,4 @@
-use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SetupCache, SRS};
 use crate::{ndarr_azip, util};
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_poly::univariate::DensePolynomial;
@@ -131,8 +131,8 @@ impl BasicBlock for RepeaterBasicBlock {
     combineArr(&temp)
   }
 
-  fn setup(&self, srs: &SRS, model: &ArrayD<Data>) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
-    self.basic_block.setup(srs, model)
+  fn setup(&self, srs: &SRS, model: &ArrayD<Data>, setup_cache: &mut SetupCache) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>) {
+    self.basic_block.setup(srs, model, setup_cache)
   }
 
   fn prove(
@@ -143,6 +143,7 @@ impl BasicBlock for RepeaterBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     rng: &mut StdRng,
+    setup_cache: &SetupCache,
     cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let mut temp = broadcastN(inputs, Some(outputs), self.N - 1);
@@ -151,7 +152,7 @@ impl BasicBlock for RepeaterBasicBlock {
       let localInputs: Vec<_> = localInputs.iter().map(|y| y).collect();
       let localOutputs: Vec<_> = localOutputs.as_ref().unwrap().iter().map(|y| y).collect();
       let mut rng = rng.clone();
-      let tmp = self.basic_block.prove(srs, setup, model, &localInputs, &localOutputs, &mut rng, cache.clone());
+      let tmp = self.basic_block.prove(srs, setup, model, &localInputs, &localOutputs, &mut rng, setup_cache, cache.clone());
       *x = tmp;
     });
     let proof: (Vec<_>, Vec<_>, Vec<_>) = multiunzip(empty.into_iter());

--- a/src/basic_block/sum.rs
+++ b/src/basic_block/sum.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS};
+use super::{BasicBlock, Data, DataEnc, PairingCheck, ProveVerifyCache, SetupCache, SRS};
 use crate::util;
 use ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ff::Field;
@@ -28,6 +28,7 @@ impl BasicBlock for SumBasicBlock {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&ArrayD<Data>>,
     _rng: &mut StdRng,
+    _setup_cache: &SetupCache,
     _cache: ProveVerifyCache,
   ) -> (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>) {
     let input = inputs[0].first().unwrap();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -122,7 +122,12 @@ impl Graph {
     return outputsEnc;
   }
 
-  pub fn setup(&self, srs: &SRS, models: &Vec<&ArrayD<Data>>) -> Vec<(Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>)> {
+  pub fn setup(
+    &self,
+    srs: &SRS,
+    models: &Vec<&ArrayD<Data>>,
+    setup_cache: &mut SetupCache,
+  ) -> Vec<(Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>)> {
     assert!(self.basic_blocks.len() == self.precomputable.setup.len());
     self
       .basic_blocks
@@ -155,7 +160,7 @@ impl Graph {
             return setups.first().unwrap().clone();
           }
         }
-        let setup = b.setup(srs, *m);
+        let setup = b.setup(srs, *m, setup_cache);
         let setups = vec![setup];
         #[cfg(not(feature = "mock_prove"))]
         if save_cq_layer_setup {
@@ -177,6 +182,7 @@ impl Graph {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&Vec<&ArrayD<Data>>>,
     rng: &mut StdRng,
+    setup_cache: &SetupCache,
     timing: &mut TimingTree,
   ) -> Vec<(Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>)> {
     assert!(self.nodes.len() == self.precomputable.prove_and_verify.len());
@@ -220,6 +226,7 @@ impl Graph {
             &myInputs,
             outputs[i],
             rng,
+            setup_cache,
             cache.clone(),
           )
         );
@@ -245,6 +252,7 @@ impl Graph {
     inputs: &Vec<&ArrayD<Data>>,
     outputs: &Vec<&Vec<&ArrayD<Data>>>,
     rng: &mut StdRng,
+    setup_cache: &SetupCache,
     timing: &mut TimingTree,
   ) -> Vec<(Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>)> {
     assert!(self.nodes.len() == self.precomputable.prove_and_verify.len());
@@ -291,6 +299,7 @@ impl Graph {
           &myInputs,
           outputs[i],
           rng,
+          setup_cache,
           cache.clone(),
         )
       );

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -18,7 +18,8 @@ fn testBasicBlock<BB: BasicBlock>(basic_block: BB, srs: &SRS, model: &ArrayD<Fr>
   let outputs = if outputs.is_ok() { outputs.unwrap() } else { panic!("Error in run") };
   let outputs: Vec<&ArrayD<Fr>> = outputs.iter().map(|x| x).collect();
   let model = convert_to_data(srs, model);
-  let setup = basic_block.setup(srs, &model);
+  let mut setup_cache = Arc::new(Mutex::new(HashMap::new()));
+  let setup = basic_block.setup(srs, &model, &mut setup_cache);
   let setup: (Vec<G1Affine>, Vec<G2Affine>, Vec<DensePolynomial<Fr>>) = (
     setup.0.iter().map(|y| (*y).into()).collect(),
     setup.1.iter().map(|y| (*y).into()).collect(),
@@ -31,7 +32,7 @@ fn testBasicBlock<BB: BasicBlock>(basic_block: BB, srs: &SRS, model: &ArrayD<Fr>
   let outputs: Vec<&ArrayD<Data>> = outputs.iter().map(|output| output).collect();
   let mut rng2 = rng.clone();
   let cache = Arc::new(Mutex::new(HashMap::new()));
-  let proof = basic_block.prove(srs, setup, &model, &inputs, &outputs, &mut rng, cache.clone());
+  let proof = basic_block.prove(srs, setup, &model, &inputs, &outputs, &mut rng, &setup_cache, cache.clone());
   let proof: (Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>) = (
     proof.0.iter().map(|y| (*y).into()).collect(),
     proof.1.iter().map(|y| (*y).into()).collect(),
@@ -59,7 +60,8 @@ fn testBasicBlock<BB: BasicBlock>(basic_block: BB, srs: &SRS, model: &ArrayD<Fr>
   let outputs = if outputs.is_ok() { outputs.unwrap() } else { panic!("Error in run") };
   let outputs: Vec<&ArrayD<Fr>> = outputs.iter().map(|x| x).collect();
   let model = convert_to_data(srs, model);
-  let setup = basic_block.setup(srs, &model);
+  let mut setup_cache = Arc::new(Mutex::new(HashMap::new()));
+  let setup = basic_block.setup(srs, &model, &mut setup_cache);
   let setup: (Vec<G1Affine>, Vec<G2Affine>, Vec<DensePolynomial<Fr>>) = (
     setup.0.iter().map(|y| (*y).into()).collect(),
     setup.1.iter().map(|y| (*y).into()).collect(),
@@ -76,7 +78,7 @@ fn testBasicBlock<BB: BasicBlock>(basic_block: BB, srs: &SRS, model: &ArrayD<Fr>
   let mut proofs = vec![];
   let mut acc_proofs = vec![];
 
-  let proof_1 = basic_block.prove(srs, setup, &model, &inputs, &outputs, &mut rng, cache.clone());
+  let proof_1 = basic_block.prove(srs, setup, &model, &inputs, &outputs, &mut rng, &setup_cache, cache.clone());
   let acc_proof_1 = basic_block.acc_init(
     srs,
     &model,
@@ -93,7 +95,7 @@ fn testBasicBlock<BB: BasicBlock>(basic_block: BB, srs: &SRS, model: &ArrayD<Fr>
   );
   proofs.push(proof_1);
   acc_proofs.push(acc_proof_1_v);
-  let proof_2 = basic_block.prove(srs, setup, &model, &inputs, &outputs, &mut rng, cache.clone());
+  let proof_2 = basic_block.prove(srs, setup, &model, &inputs, &outputs, &mut rng, &setup_cache, cache.clone());
   let acc_proof_2 = basic_block.acc_prove(
     srs,
     &model,

--- a/src/util/prover.rs
+++ b/src/util/prover.rs
@@ -3,7 +3,7 @@
  * The functions are used for proving-related operations, such as
  * generating CQ tables and converting them to Data (generating commitment).
  */
-use crate::basic_block::{BasicBlock, Data, DataEnc, SRS};
+use crate::basic_block::{BasicBlock, Data, DataEnc, SetupCache, SRS};
 use crate::graph::Graph;
 use crate::util::{measure_file_size, verify};
 use crate::{onnx, ptau, util, CONFIG, LAYER_SETUP_DIR};
@@ -17,8 +17,10 @@ use rand::{rngs::StdRng, SeedableRng};
 use rayon::prelude::*;
 use rayon::range;
 use sha3::{Digest, Keccak256};
+use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::Read;
+use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum CQArrayType {
@@ -131,6 +133,7 @@ pub fn prove(
   models: Vec<&ArrayD<Data>>,
   graph: &mut Graph,
   timing: &mut TimingTree,
+  setup_cache: &mut SetupCache,
 ) {
   // Encode Data:
   let modelsEnc: Vec<ArrayD<DataEnc>> = util::vec_iter(&models).map(|model| (**model).map(|x| DataEnc::new(srs, x))).collect();
@@ -167,12 +170,16 @@ pub fn prove(
   let mut rng = StdRng::from_seed(buf);
 
   // Prove:
-  let proofs = timed!(timing, "prove", graph.prove(srs, &setups, &models, &inputs, &outputs, &mut rng, timing));
+  let proofs = timed!(
+    timing,
+    "prove",
+    graph.prove(srs, &setups, &models, &inputs, &outputs, &mut rng, &setup_cache, timing)
+  );
   proofs.serialize_uncompressed(File::create(&CONFIG.prover.proof_path).unwrap()).unwrap();
 }
 
 #[cfg(not(feature = "mock_prove"))]
-pub fn setup(srs: &SRS, graph: &Graph, models: &Vec<&ArrayD<Fr>>, timing: &mut TimingTree) {
+pub fn setup(srs: &SRS, graph: &Graph, models: &Vec<&ArrayD<Fr>>, setup_cache: &mut SetupCache, timing: &mut TimingTree) {
   // Setup:
   let models: Vec<ArrayD<Data>> = models
     .par_iter()
@@ -200,7 +207,7 @@ pub fn setup(srs: &SRS, graph: &Graph, models: &Vec<&ArrayD<Fr>>, timing: &mut T
     .collect();
 
   let models_ref: Vec<&ArrayD<Data>> = models.iter().map(|model| model).collect();
-  let setups = timed!(timing, "setup and encode models", graph.setup(srs, &models_ref));
+  let setups = timed!(timing, "setup and encode models", graph.setup(srs, &models_ref, setup_cache));
   // Save files:
   setups.serialize_uncompressed(File::create(&CONFIG.prover.setup_path).unwrap()).unwrap();
   let modelsBytes = bincode::serialize(&models).unwrap();
@@ -212,6 +219,7 @@ pub fn setup(
   srs: &SRS,
   graph: &Graph,
   models: &Vec<&ArrayD<Fr>>,
+  setup_cache: &mut SetupCache,
   timing: &mut TimingTree,
 ) -> (Vec<(Vec<G1Projective>, Vec<G2Projective>, Vec<DensePolynomial<Fr>>)>, Vec<ArrayD<Data>>) {
   // Setup:
@@ -224,7 +232,7 @@ pub fn setup(
     .collect();
 
   let models_ref: Vec<&ArrayD<Data>> = models.iter().map(|model| model).collect();
-  let setups = timed!(timing, "setup and encode models", graph.setup(srs, &models_ref));
+  let setups = timed!(timing, "setup and encode models", graph.setup(srs, &models_ref, setup_cache));
   (setups, models)
 }
 
@@ -257,10 +265,12 @@ pub fn zktorch_kernel() {
     return;
   }
 
+  let mut setup_cache = Arc::new(Mutex::new(HashMap::new()));
+
   #[cfg(not(feature = "mock_prove"))]
-  setup(&srs, &graph, &models, &mut timing);
+  setup(&srs, &graph, &models, &mut setup_cache, &mut timing);
   #[cfg(feature = "mock_prove")]
-  let (setups, models) = setup(&srs, &graph, &models, &mut timing);
+  let (setups, models) = setup(&srs, &graph, &models, &mut setup_cache, &mut timing);
 
   // Load model and setup:
   #[cfg(not(feature = "mock_prove"))]
@@ -277,13 +287,12 @@ pub fn zktorch_kernel() {
     })
     .collect();
   let setups = setups.iter().map(|x| (&x.0, &x.1, &x.2)).collect();
-
   #[cfg(not(feature = "mock_prove"))]
   let models = load_model();
   let models: Vec<&ArrayD<Data>> = models.iter().map(|model| model).collect();
 
   // Prove
-  prove(&srs, &inputs, outputs.unwrap(), setups, models, &mut graph, &mut timing);
+  prove(&srs, &inputs, outputs.unwrap(), setups, models, &mut graph, &mut timing, &mut setup_cache);
 
   // Verify
   #[cfg(not(feature = "mock_prove"))]


### PR DESCRIPTION
A lot of memory is wasted on duplicate setup vec elements. This enables storing these elements exactly once between cq, cq2, cqlin.

Note that when running tests going forward, we want to use the `--release` flag since the `SetupCache` `Arc<Mutex<..>>` is slow otherwise.