### PR TITLE
Add generalized Mira for MatMul and Permute

### DIFF
--- a/src/basic_block/matmul.rs
+++ b/src/basic_block/matmul.rs
@@ -188,11 +188,15 @@ impl AccProofLayout for MatMulBasicBlock {
 
     // Fiat-Shamir
     let mut bytes = Vec::new();
-    acc_1.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
-    acc_1.acc_g1[11..14].serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g1[..MatMulG1Terms::idx(MatMulG1Terms::Corr1)].serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A)..MatMulG1Terms::idx(MatMulG1Terms::Part_corr1)]
+      .serialize_uncompressed(&mut bytes)
+      .unwrap();
     acc_1.acc_g2.serialize_uncompressed(&mut bytes).unwrap();
-    acc_2.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
-    acc_2.acc_g1[11..14].serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.acc_g1[..MatMulG1Terms::idx(MatMulG1Terms::Corr1)].serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A)..MatMulG1Terms::idx(MatMulG1Terms::Part_corr1)]
+      .serialize_uncompressed(&mut bytes)
+      .unwrap();
     acc_2.acc_g2.serialize_uncompressed(&mut bytes).unwrap();
     errs.iter().for_each(|(g1, g2, f, gt)| {
       g1.serialize_uncompressed(&mut bytes).unwrap();
@@ -239,11 +243,15 @@ impl AccProofLayout for MatMulBasicBlock {
 
     // Fiat-Shamir
     let mut bytes = Vec::new();
-    acc_1.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
-    acc_1.acc_g1[11..14].serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g1[..MatMulG1Terms::idx(MatMulG1Terms::Corr1)].serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A)..MatMulG1Terms::idx(MatMulG1Terms::Part_corr1)]
+      .serialize_uncompressed(&mut bytes)
+      .unwrap();
     acc_1.acc_g2.serialize_uncompressed(&mut bytes).unwrap();
-    acc_2.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
-    acc_2.acc_g1[11..14].serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.acc_g1[..MatMulG1Terms::idx(MatMulG1Terms::Corr1)].serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A)..MatMulG1Terms::idx(MatMulG1Terms::Part_corr1)]
+      .serialize_uncompressed(&mut bytes)
+      .unwrap();
     acc_2.acc_g2.serialize_uncompressed(&mut bytes).unwrap();
     new_acc.errs.iter().for_each(|(g1, g2, f, gt)| {
       g1.serialize_uncompressed(&mut bytes).unwrap();
@@ -255,14 +263,17 @@ impl AccProofLayout for MatMulBasicBlock {
     let acc_gamma = Fr::rand(rng);
     let acc_gamma_sq = acc_gamma * acc_gamma;
 
-    acc_2.acc_g1[..7].iter().enumerate().for_each(|(i, x)| {
+    acc_2.acc_g1[..MatMulG1Terms::idx(MatMulG1Terms::Corr1)].iter().enumerate().for_each(|(i, x)| {
       let z = *x * acc_gamma + acc_1.acc_g1[i];
       result &= new_acc.acc_g1[i] == z;
     });
-    acc_2.acc_g1[11..14].iter().enumerate().for_each(|(i, x)| {
-      let z = *x * acc_gamma + acc_1.acc_g1[i + 11];
-      result &= new_acc.acc_g1[i + 11] == z;
-    });
+    acc_2.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A)..MatMulG1Terms::idx(MatMulG1Terms::Part_corr1)]
+      .iter()
+      .enumerate()
+      .for_each(|(i, x)| {
+        let z = *x * acc_gamma + acc_1.acc_g1[i + MatMulG1Terms::idx(MatMulG1Terms::Flat_A)];
+        result &= new_acc.acc_g1[i + MatMulG1Terms::idx(MatMulG1Terms::Flat_A)] == z;
+      });
     result &= new_acc.acc_g2[0] == acc_1.acc_g2[0] + acc_2.acc_g2[0] * acc_gamma;
     result &= new_acc.acc_g2[1] == acc_1.acc_g2[1];
     result &= new_acc.mu == acc_1.mu + acc_gamma * acc_2.mu;
@@ -699,8 +710,8 @@ impl BasicBlock for MatMulBasicBlock {
     let temp: Vec<_> = (0..l).map(|i| index(outputs[0], i).g1).collect();
     let flat_C = util::msm::<G1Projective>(&temp, &alpha_pow);
 
-    result &= flat_A == proof.0[11] && flat_B == proof.0[12];
-    result &= flat_C == proof.0[13];
+    result &= flat_A == proof.0[MatMulG1Terms::idx(MatMulG1Terms::Flat_A)] && flat_B == proof.0[MatMulG1Terms::idx(MatMulG1Terms::Flat_B)];
+    result &= flat_C == proof.0[MatMulG1Terms::idx(MatMulG1Terms::Flat_C)];
     if prev_acc_proof.2.len() == 0 && acc_proof.2[0].is_one() {
       return Some(result);
     }

--- a/src/basic_block/matmul.rs
+++ b/src/basic_block/matmul.rs
@@ -3,7 +3,7 @@
 use super::{
   AccProofAff, AccProofAffRef, AccProofProj, AccProofProjRef, BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS,
 };
-use crate::util::{self, acc_to_acc_proof, calc_pow, AccHolder};
+use crate::util::{self, acc_proof_to_acc, acc_to_acc_proof, calc_pow, AccHolder, AccProofLayout};
 use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::bn::Bn;
 use ark_ec::pairing::{Pairing, PairingOutput};
@@ -16,13 +16,201 @@ use ndarray::{arr1, arr2, ArrayD, Ix1, Ix2, IxDyn};
 use rand::{rngs::StdRng, SeedableRng};
 use rayon::iter::ParallelIterator;
 
+impl AccProofLayout for MatMulBasicBlock {
+  fn acc_g1_num(&self, is_prover: bool) -> usize {
+    if is_prover {
+      17
+    } else {
+      14
+    }
+  }
+
+  fn acc_g2_num(&self, _is_prover: bool) -> usize {
+    2
+  }
+
+  fn acc_fr_num(&self, is_prover: bool) -> usize {
+    if is_prover {
+      2
+    } else {
+      0
+    }
+  }
+
+  fn err_g1_nums(&self) -> Vec<usize> {
+    vec![3]
+  }
+
+  fn err_g2_nums(&self) -> Vec<usize> {
+    vec![0]
+  }
+
+  fn err_fr_nums(&self) -> Vec<usize> {
+    vec![0]
+  }
+
+  fn err_gt_nums(&self) -> Vec<usize> {
+    vec![1]
+  }
+
+  fn prover_proof_to_acc(&self, proof: (&Vec<G1Projective>, &Vec<G2Projective>, &Vec<Fr>)) -> AccHolder<G1Projective, G2Projective> {
+    AccHolder {
+      acc_g1: proof.0.clone(),
+      acc_g2: proof.1.clone(),
+      acc_fr: proof.2.clone(),
+      mu: Fr::one(),
+      errs: vec![(
+        vec![G1Projective::zero(); 3],
+        vec![],
+        vec![],
+        vec![PairingOutput::<Bn<ark_bn254::Config>>::zero()],
+      )],
+      acc_errs: vec![(
+        vec![G1Projective::zero(); 3],
+        vec![],
+        vec![],
+        vec![PairingOutput::<Bn<ark_bn254::Config>>::zero()],
+      )],
+    }
+  }
+
+  fn verifier_proof_to_acc(&self, proof: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>)) -> AccHolder<G1Affine, G2Affine> {
+    AccHolder {
+      acc_g1: proof.0.clone(),
+      acc_g2: proof.1.clone(),
+      acc_fr: proof.2.clone(),
+      mu: Fr::one(),
+      errs: vec![(
+        vec![G1Affine::zero(); 3],
+        vec![],
+        vec![],
+        vec![PairingOutput::<Bn<ark_bn254::Config>>::zero()],
+      )],
+      acc_errs: vec![(
+        vec![G1Affine::zero(); 3],
+        vec![],
+        vec![],
+        vec![PairingOutput::<Bn<ark_bn254::Config>>::zero()],
+      )],
+    }
+  }
+
+  fn mira_prove(
+    &self,
+    srs: &SRS,
+    acc_1: AccHolder<G1Projective, G2Projective>,
+    acc_2: AccHolder<G1Projective, G2Projective>,
+    rng: &mut StdRng,
+  ) -> AccHolder<G1Projective, G2Projective> {
+    let acc_1 = matmul_acc_holder_to_acc(acc_1, true);
+    let acc_2 = matmul_acc_holder_to_acc(acc_2, true);
+
+    let acc_flat_A = acc_1.fiat_shamir.acc_flat_A;
+    let acc_left_x = acc_1.fiat_shamir.acc_left_x;
+    let acc_left_Q_x = acc_1.fiat_shamir.acc_left_Q_x;
+    let acc_mu = acc_1.mu;
+    let acc_part_corr1 = acc_1.prover_only.as_ref().unwrap().acc_part_corr1;
+    let po = acc_1.prover_only.as_ref().unwrap();
+    let acc_flat_A_no_blind = po.acc_flat_A_no_blind;
+    let acc_flat_B_no_blind = po.acc_flat_B_no_blind;
+    let acc_flat_A_r = po.acc_flat_A_r;
+    let acc_flat_B_r = po.acc_flat_B_r;
+    let acc_flat_B_g2 = acc_1.fiat_shamir.acc_flat_B_g2;
+
+    let flat_A = acc_2.fiat_shamir.acc_flat_A;
+    let left_x = acc_2.fiat_shamir.acc_left_x;
+    let left_Q_x = acc_2.fiat_shamir.acc_left_Q_x;
+    let part_corr1 = acc_2.prover_only.as_ref().unwrap().acc_part_corr1;
+    let po = acc_2.prover_only.as_ref().unwrap();
+    let flat_A_no_blind = po.acc_flat_A_no_blind;
+    let flat_B_no_blind = po.acc_flat_B_no_blind;
+    let flat_A_r = po.acc_flat_A_r;
+    let flat_B_r = po.acc_flat_B_r;
+    let flat_B_g2 = acc_2.fiat_shamir.acc_flat_B_g2;
+
+    // Compute the error
+    let err = MatMulErrs {
+      acc_left_Q_x: acc_left_Q_x * acc_2.mu + left_Q_x * acc_mu,
+      acc_left_x: acc_left_x * acc_2.mu + left_x * acc_mu,
+      acc_part_corr1: acc_part_corr1 * acc_2.mu
+        + part_corr1 * acc_mu
+        + acc_flat_A_no_blind * flat_B_r
+        + flat_A_no_blind * acc_flat_B_r
+        + acc_flat_B_no_blind * flat_A_r
+        + flat_B_no_blind * acc_flat_A_r
+        + srs.Y1P * (flat_A_r * acc_flat_B_r + flat_B_r * acc_flat_A_r),
+      acc_gt: Bn254::multi_pairing(vec![flat_A, acc_flat_A], vec![acc_flat_B_g2, flat_B_g2]),
+    };
+
+    // Fiat-Shamir
+    let mut bytes = Vec::new();
+    acc_1.fiat_shamir.serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.fiat_shamir.serialize_uncompressed(&mut bytes).unwrap();
+    err.serialize_uncompressed(&mut bytes).unwrap();
+    util::add_randomness(rng, bytes);
+    let acc_gamma = Fr::rand(rng);
+
+    // Accumulate
+    let new_acc = accumulate(&acc_1, &acc_2, &err, acc_gamma);
+
+    matmul_acc_to_acc_holder(new_acc, true)
+  }
+
+  fn mira_verify(
+    &self,
+    acc_1: AccHolder<G1Affine, G2Affine>,
+    acc_2: AccHolder<G1Affine, G2Affine>,
+    new_acc: AccHolder<G1Affine, G2Affine>,
+    rng: &mut StdRng,
+  ) -> Option<bool> {
+    let acc_1 = matmul_acc_holder_to_acc(acc_1, false);
+    let acc_2 = matmul_acc_holder_to_acc(acc_2, false);
+    let new_acc = matmul_acc_holder_to_acc(new_acc, false);
+
+    let mut result = true;
+
+    // Fiat-Shamir
+    let mut bytes = Vec::new();
+    acc_1.fiat_shamir.serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.fiat_shamir.serialize_uncompressed(&mut bytes).unwrap();
+    new_acc.errs.serialize_uncompressed(&mut bytes).unwrap();
+    util::add_randomness(rng, bytes);
+    let acc_gamma = Fr::rand(rng);
+    let acc_gamma_sq = acc_gamma * acc_gamma;
+
+    result &= (acc_2.fiat_shamir.acc_left_x * acc_gamma + acc_1.fiat_shamir.acc_left_x) == new_acc.fiat_shamir.acc_left_x;
+    result &= (acc_2.fiat_shamir.acc_left_Q_x * acc_gamma + acc_1.fiat_shamir.acc_left_Q_x) == new_acc.fiat_shamir.acc_left_Q_x;
+    result &= (acc_2.fiat_shamir.acc_left_zero * acc_gamma + acc_1.fiat_shamir.acc_left_zero) == new_acc.fiat_shamir.acc_left_zero;
+    result &= (acc_2.fiat_shamir.acc_left_zero_div * acc_gamma + acc_1.fiat_shamir.acc_left_zero_div) == new_acc.fiat_shamir.acc_left_zero_div;
+    result &= (acc_2.fiat_shamir.acc_right_x * acc_gamma + acc_1.fiat_shamir.acc_right_x) == new_acc.fiat_shamir.acc_right_x;
+    result &= (acc_2.fiat_shamir.acc_right_Q_x * acc_gamma + acc_1.fiat_shamir.acc_right_Q_x) == new_acc.fiat_shamir.acc_right_Q_x;
+    result &= (acc_2.fiat_shamir.acc_right_zero_div * acc_gamma + acc_1.fiat_shamir.acc_right_zero_div) == new_acc.fiat_shamir.acc_right_zero_div;
+
+    result &= (acc_2.fiat_shamir.acc_flat_A * acc_gamma + acc_1.fiat_shamir.acc_flat_A) == new_acc.fiat_shamir.acc_flat_A;
+    result &= (acc_2.fiat_shamir.acc_flat_B * acc_gamma + acc_1.fiat_shamir.acc_flat_B) == new_acc.fiat_shamir.acc_flat_B;
+    result &= (acc_2.fiat_shamir.acc_flat_C * acc_gamma + acc_1.fiat_shamir.acc_flat_C) == new_acc.fiat_shamir.acc_flat_C;
+    result &= new_acc.fiat_shamir.acc_flat_B_g2 == acc_1.fiat_shamir.acc_flat_B_g2 + acc_2.fiat_shamir.acc_flat_B_g2 * acc_gamma;
+    result &= new_acc.fiat_shamir.acc_beta_pow_g2 == acc_2.fiat_shamir.acc_beta_pow_g2;
+    result &= new_acc.mu == acc_1.mu + acc_gamma * acc_2.mu;
+
+    result &= acc_1.acc_errs.acc_left_Q_x + new_acc.errs.acc_left_Q_x * acc_gamma + acc_2.acc_errs.acc_left_Q_x * acc_gamma_sq
+      == new_acc.acc_errs.acc_left_Q_x;
+    result &=
+      acc_1.acc_errs.acc_left_x + new_acc.errs.acc_left_x * acc_gamma + acc_2.acc_errs.acc_left_x * acc_gamma_sq == new_acc.acc_errs.acc_left_x;
+    result &= acc_1.acc_errs.acc_part_corr1 + new_acc.errs.acc_part_corr1 * acc_gamma + acc_2.acc_errs.acc_part_corr1 * acc_gamma_sq
+      == new_acc.acc_errs.acc_part_corr1;
+    result &= acc_1.acc_errs.acc_gt + new_acc.errs.acc_gt * acc_gamma + acc_2.acc_errs.acc_gt * acc_gamma_sq == new_acc.acc_errs.acc_gt;
+    Some(result)
+  }
+}
+
 struct MatMulAccProof<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize> {
   fiat_shamir: MatMulAccFiatShamir<P, Q>,
   acc_corr: [P; 4],
   mu: Fr,
   prover_only: Option<MatMulAccProofProverOnly<P>>,
-  errs: MatMulErrs<P, Q>,
-  acc_errs: MatMulAccErrs<P, Q>,
+  errs: MatMulErrs<P>,
+  acc_errs: MatMulAccErrs<P>,
 }
 
 #[derive(CanonicalSerialize)]
@@ -50,104 +238,73 @@ struct MatMulAccProofProverOnly<P: Copy + CanonicalSerialize> {
 }
 
 #[derive(CanonicalSerialize, Clone)]
-struct MatMulErrs<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize> {
-  flat_A: P,
-  acc_flat_A: P,
+struct MatMulErrs<P: Copy + CanonicalSerialize> {
   acc_left_Q_x: P,
   acc_left_x: P,
   acc_part_corr1: P,
-  acc_flat_B_g2: Q,
-  flat_B_g2: Q,
+  acc_gt: PairingOutput<Bn<ark_bn254::Config>>,
 }
 
 #[derive(Clone)]
-struct MatMulAccErrs<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize> {
-  prev_g1s: Vec<P>,
-  flat_A: P,
-  acc_flat_A: P,
+struct MatMulAccErrs<P: Copy + CanonicalSerialize> {
   acc_left_Q_x: P,
   acc_left_x: P,
   acc_part_corr1: P,
-  prev_g2s: Vec<Q>,
-  acc_flat_B_g2: Q,
-  flat_B_g2: Q,
+  acc_gt: PairingOutput<Bn<ark_bn254::Config>>,
 }
 
 fn accumulate(
-  matmul_acc: &MatMulAccProof<G1Projective, G2Projective>,
-  errs: &MatMulErrs<G1Projective, G2Projective>,
-  proof: &(&Vec<G1Projective>, &Vec<G2Projective>, &Vec<Fr>),
+  matmul_acc_1: &MatMulAccProof<G1Projective, G2Projective>,
+  matmul_acc_2: &MatMulAccProof<G1Projective, G2Projective>,
+  errs: &MatMulErrs<G1Projective>,
   acc_gamma: Fr,
 ) -> MatMulAccProof<G1Projective, G2Projective> {
-  let [left_x, left_Q_x, left_zero, left_zero_div, right_x, right_Q_x, right_zero_div, corr1, corr2, corr3, corr4, flat_A, flat_B, flat_C, part_corr1, flat_A_no_blind, flat_B_no_blind] =
-    proof.0[..]
-  else {
-    panic!("Wrong proof format")
-  };
-
-  let [flat_B_g2, beta_pow_g2] = proof.1[..] else {
-    panic!("Wrong proof format")
-  };
-  let [flat_A_r, flat_B_r] = proof.2[..] else {
-    panic!("Wrong proof format")
-  };
-
   let new_errs = MatMulErrs {
-    flat_A: errs.flat_A * acc_gamma,
-    acc_flat_A: errs.acc_flat_A * acc_gamma,
     acc_left_Q_x: errs.acc_left_Q_x * acc_gamma,
     acc_left_x: errs.acc_left_x * acc_gamma,
     acc_part_corr1: errs.acc_part_corr1 * acc_gamma,
-    acc_flat_B_g2: errs.acc_flat_B_g2,
-    flat_B_g2: errs.flat_B_g2,
+    acc_gt: errs.acc_gt * acc_gamma,
   };
 
-  let mut acc_errs = MatMulAccErrs {
-    prev_g1s: matmul_acc.acc_errs.prev_g1s.clone(),
-    flat_A: new_errs.flat_A,
-    acc_flat_A: new_errs.acc_flat_A,
-    acc_left_Q_x: matmul_acc.acc_errs.acc_left_Q_x + new_errs.acc_left_Q_x,
-    acc_left_x: matmul_acc.acc_errs.acc_left_x + new_errs.acc_left_x,
-    acc_part_corr1: matmul_acc.acc_errs.acc_part_corr1 + new_errs.acc_part_corr1,
-    prev_g2s: matmul_acc.acc_errs.prev_g2s.clone(),
-    acc_flat_B_g2: new_errs.acc_flat_B_g2,
-    flat_B_g2: new_errs.flat_B_g2,
+  let acc_gamma_sq = acc_gamma * acc_gamma;
+  let acc_errs = MatMulAccErrs {
+    acc_left_Q_x: matmul_acc_1.acc_errs.acc_left_Q_x + new_errs.acc_left_Q_x + matmul_acc_2.acc_errs.acc_left_Q_x * acc_gamma_sq,
+    acc_left_x: matmul_acc_1.acc_errs.acc_left_x + new_errs.acc_left_x + matmul_acc_2.acc_errs.acc_left_x * acc_gamma_sq,
+    acc_part_corr1: matmul_acc_1.acc_errs.acc_part_corr1 + new_errs.acc_part_corr1 + matmul_acc_2.acc_errs.acc_part_corr1 * acc_gamma_sq,
+    acc_gt: matmul_acc_1.acc_errs.acc_gt + new_errs.acc_gt + matmul_acc_2.acc_errs.acc_gt * acc_gamma_sq,
   };
-  acc_errs.prev_g1s.push(matmul_acc.acc_errs.flat_A);
-  acc_errs.prev_g1s.push(matmul_acc.acc_errs.acc_flat_A);
-  acc_errs.prev_g2s.push(matmul_acc.acc_errs.acc_flat_B_g2);
-  acc_errs.prev_g2s.push(matmul_acc.acc_errs.flat_B_g2);
 
   // Compute the error
-  let matmul_acc_prover_only = matmul_acc.prover_only.as_ref().unwrap();
+  let matmul_acc_prover_only_1 = matmul_acc_1.prover_only.as_ref().unwrap();
+  let matmul_acc_prover_only_2 = matmul_acc_2.prover_only.as_ref().unwrap();
   let new_matmul_acc = MatMulAccProof {
     fiat_shamir: MatMulAccFiatShamir {
-      acc_left_x: matmul_acc.fiat_shamir.acc_left_x + left_x * acc_gamma,
-      acc_left_Q_x: matmul_acc.fiat_shamir.acc_left_Q_x + left_Q_x * acc_gamma,
-      acc_left_zero: matmul_acc.fiat_shamir.acc_left_zero + left_zero * acc_gamma,
-      acc_left_zero_div: matmul_acc.fiat_shamir.acc_left_zero_div + left_zero_div * acc_gamma,
-      acc_right_x: matmul_acc.fiat_shamir.acc_right_x + right_x * acc_gamma,
-      acc_right_Q_x: matmul_acc.fiat_shamir.acc_right_Q_x + right_Q_x * acc_gamma,
-      acc_right_zero_div: matmul_acc.fiat_shamir.acc_right_zero_div + right_zero_div * acc_gamma,
-      acc_flat_A: matmul_acc.fiat_shamir.acc_flat_A + flat_A * acc_gamma,
-      acc_flat_B: matmul_acc.fiat_shamir.acc_flat_B + flat_B * acc_gamma,
-      acc_flat_C: matmul_acc.fiat_shamir.acc_flat_C + flat_C * acc_gamma,
-      acc_flat_B_g2: matmul_acc.fiat_shamir.acc_flat_B_g2 + flat_B_g2 * acc_gamma,
-      acc_beta_pow_g2: beta_pow_g2,
+      acc_left_x: matmul_acc_1.fiat_shamir.acc_left_x + matmul_acc_2.fiat_shamir.acc_left_x * acc_gamma,
+      acc_left_Q_x: matmul_acc_1.fiat_shamir.acc_left_Q_x + matmul_acc_2.fiat_shamir.acc_left_Q_x * acc_gamma,
+      acc_left_zero: matmul_acc_1.fiat_shamir.acc_left_zero + matmul_acc_2.fiat_shamir.acc_left_zero * acc_gamma,
+      acc_left_zero_div: matmul_acc_1.fiat_shamir.acc_left_zero_div + matmul_acc_2.fiat_shamir.acc_left_zero_div * acc_gamma,
+      acc_right_x: matmul_acc_1.fiat_shamir.acc_right_x + matmul_acc_2.fiat_shamir.acc_right_x * acc_gamma,
+      acc_right_Q_x: matmul_acc_1.fiat_shamir.acc_right_Q_x + matmul_acc_2.fiat_shamir.acc_right_Q_x * acc_gamma,
+      acc_right_zero_div: matmul_acc_1.fiat_shamir.acc_right_zero_div + matmul_acc_2.fiat_shamir.acc_right_zero_div * acc_gamma,
+      acc_flat_A: matmul_acc_1.fiat_shamir.acc_flat_A + matmul_acc_2.fiat_shamir.acc_flat_A * acc_gamma,
+      acc_flat_B: matmul_acc_1.fiat_shamir.acc_flat_B + matmul_acc_2.fiat_shamir.acc_flat_B * acc_gamma,
+      acc_flat_C: matmul_acc_1.fiat_shamir.acc_flat_C + matmul_acc_2.fiat_shamir.acc_flat_C * acc_gamma,
+      acc_flat_B_g2: matmul_acc_1.fiat_shamir.acc_flat_B_g2 + matmul_acc_2.fiat_shamir.acc_flat_B_g2 * acc_gamma,
+      acc_beta_pow_g2: matmul_acc_2.fiat_shamir.acc_beta_pow_g2,
     },
     acc_corr: [
-      matmul_acc.acc_corr[0] + corr1 * acc_gamma,
-      matmul_acc.acc_corr[1] + corr2 * acc_gamma,
-      matmul_acc.acc_corr[2] + corr3 * acc_gamma,
-      matmul_acc.acc_corr[3] + corr4 * acc_gamma,
+      matmul_acc_1.acc_corr[0] + matmul_acc_2.acc_corr[0] * acc_gamma,
+      matmul_acc_1.acc_corr[1] + matmul_acc_2.acc_corr[1] * acc_gamma,
+      matmul_acc_1.acc_corr[2] + matmul_acc_2.acc_corr[2] * acc_gamma,
+      matmul_acc_1.acc_corr[3] + matmul_acc_2.acc_corr[3] * acc_gamma,
     ],
-    mu: matmul_acc.mu + acc_gamma,
+    mu: matmul_acc_1.mu + acc_gamma * matmul_acc_2.mu,
     prover_only: Some(MatMulAccProofProverOnly {
-      acc_part_corr1: matmul_acc_prover_only.acc_part_corr1 + part_corr1 * acc_gamma,
-      acc_flat_A_no_blind: matmul_acc_prover_only.acc_flat_A_no_blind + flat_A_no_blind * acc_gamma,
-      acc_flat_B_no_blind: matmul_acc_prover_only.acc_flat_B_no_blind + flat_B_no_blind * acc_gamma,
-      acc_flat_A_r: matmul_acc_prover_only.acc_flat_A_r + flat_A_r * acc_gamma,
-      acc_flat_B_r: matmul_acc_prover_only.acc_flat_B_r + flat_B_r * acc_gamma,
+      acc_part_corr1: matmul_acc_prover_only_1.acc_part_corr1 + matmul_acc_prover_only_2.acc_part_corr1 * acc_gamma,
+      acc_flat_A_no_blind: matmul_acc_prover_only_1.acc_flat_A_no_blind + matmul_acc_prover_only_2.acc_flat_A_no_blind * acc_gamma,
+      acc_flat_B_no_blind: matmul_acc_prover_only_1.acc_flat_B_no_blind + matmul_acc_prover_only_2.acc_flat_B_no_blind * acc_gamma,
+      acc_flat_A_r: matmul_acc_prover_only_1.acc_flat_A_r + matmul_acc_prover_only_2.acc_flat_A_r * acc_gamma,
+      acc_flat_B_r: matmul_acc_prover_only_1.acc_flat_B_r + matmul_acc_prover_only_2.acc_flat_B_r * acc_gamma,
     }),
     errs: errs.clone(),
     acc_errs,
@@ -156,74 +313,10 @@ fn accumulate(
   new_matmul_acc
 }
 
-fn acc_proof_to_matmul_acc_holder<P: Copy, Q: Copy>(
-  acc_proof: (&Vec<P>, &Vec<Q>, &Vec<Fr>, &Vec<PairingOutput<Bn<ark_bn254::Config>>>),
-  is_prover: bool,
-) -> AccHolder<P, Q> {
-  if acc_proof.0.len() == 0 && acc_proof.1.len() == 0 && acc_proof.2.len() == 0 {
-    return AccHolder {
-      acc_g1: vec![],
-      acc_g2: vec![],
-      acc_fr: vec![],
-      mu: Fr::zero(),
-      errs: vec![],
-      acc_errs: vec![],
-    };
-  }
-
-  // [acc_left_x, acc_left_Q_x, acc_left_zero, acc_left_zero_div, acc_right_x,
-  // acc_right_Q_x, acc_right_zero_div, acc_corr1, acc_corr2, acc_corr3,
-  // acc_corr4, acc_flat_A, acc_flat_B, acc_flat_C, acc_part_corr1,
-  // acc_flat_A_no_blind, acc_flat_B_no_blind]
-  let acc_g1_num = if is_prover { 17 } else { 14 };
-  let acc_fr_num = if is_prover { 2 } else { 0 };
-  let acc_err_g2_num = acc_proof.1.len() - 4;
-
-  let err1: (Vec<P>, Vec<Q>, Vec<Fr>, Vec<PairingOutput<Bn<ark_bn254::Config>>>) = (
-    acc_proof.0[acc_g1_num..(acc_g1_num + 5)].to_vec(),
-    acc_proof.1[2..4].to_vec(),
-    vec![],
-    vec![],
-  );
-
-  let errs = vec![err1];
-
-  let acc_err1: (Vec<P>, Vec<Q>, Vec<Fr>, Vec<PairingOutput<Bn<ark_bn254::Config>>>) = (
-    acc_proof.0[(acc_g1_num + 5)..(acc_g1_num + 8 + acc_err_g2_num)].to_vec(),
-    acc_proof.1[4..(4 + acc_err_g2_num)].to_vec(),
-    vec![],
-    vec![],
-  );
-
-  let acc_errs = vec![acc_err1];
-
-  AccHolder {
-    acc_g1: acc_proof.0[..acc_g1_num].to_vec(),
-    acc_g2: acc_proof.1[..2].to_vec(),
-    acc_fr: acc_proof.2[..acc_fr_num].to_vec(),
-    mu: acc_proof.2[acc_proof.2.len() - 1],
-    errs,
-    acc_errs,
-  }
-}
-
-fn acc_proof_to_matmul_acc<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(
-  acc_proof: (&Vec<P>, &Vec<Q>, &Vec<Fr>, &Vec<PairingOutput<Bn<ark_bn254::Config>>>),
-  is_prover: bool,
-) -> Option<MatMulAccProof<P, Q>> {
-  if acc_proof.0.len() == 0 && acc_proof.1.len() == 0 && acc_proof.2.len() == 0 {
-    return None;
-  }
-  let acc_holder = acc_proof_to_matmul_acc_holder(acc_proof, is_prover);
-  Some(matmul_acc_holder_to_acc(acc_holder, is_prover))
-}
-
 fn matmul_acc_holder_to_acc<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(
   acc_holder: AccHolder<P, Q>,
   is_prover: bool,
 ) -> MatMulAccProof<P, Q> {
-  let g1_len = acc_holder.acc_errs[0].0.len();
-  let g2_len = acc_holder.acc_errs[0].1.len();
   let acc_proof = MatMulAccProof {
     fiat_shamir: MatMulAccFiatShamir {
       acc_left_x: acc_holder.acc_g1[0],
@@ -253,24 +346,16 @@ fn matmul_acc_holder_to_acc<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSer
       None
     },
     errs: MatMulErrs {
-      flat_A: acc_holder.errs[0].0[0],
-      acc_flat_A: acc_holder.errs[0].0[1],
-      acc_left_Q_x: acc_holder.errs[0].0[2],
-      acc_left_x: acc_holder.errs[0].0[3],
-      acc_part_corr1: acc_holder.errs[0].0[4],
-      acc_flat_B_g2: acc_holder.errs[0].1[0],
-      flat_B_g2: acc_holder.errs[0].1[1],
+      acc_left_Q_x: acc_holder.errs[0].0[0],
+      acc_left_x: acc_holder.errs[0].0[1],
+      acc_part_corr1: acc_holder.errs[0].0[2],
+      acc_gt: acc_holder.errs[0].3[0],
     },
     acc_errs: MatMulAccErrs {
-      prev_g1s: acc_holder.acc_errs[0].0[..g1_len - 5].to_vec(),
-      flat_A: acc_holder.acc_errs[0].0[g1_len - 5],
-      acc_flat_A: acc_holder.acc_errs[0].0[g1_len - 4],
-      acc_left_Q_x: acc_holder.acc_errs[0].0[g1_len - 3],
-      acc_left_x: acc_holder.acc_errs[0].0[g1_len - 2],
-      acc_part_corr1: acc_holder.acc_errs[0].0[g1_len - 1],
-      prev_g2s: acc_holder.acc_errs[0].1[..g2_len - 2].to_vec(),
-      acc_flat_B_g2: acc_holder.acc_errs[0].1[g2_len - 2],
-      flat_B_g2: acc_holder.acc_errs[0].1[g2_len - 1],
+      acc_left_Q_x: acc_holder.acc_errs[0].0[0],
+      acc_left_x: acc_holder.acc_errs[0].0[1],
+      acc_part_corr1: acc_holder.acc_errs[0].0[2],
+      acc_gt: acc_holder.acc_errs[0].3[0],
     },
   };
   acc_proof
@@ -283,28 +368,16 @@ fn matmul_acc_to_acc_holder<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSer
   let acc_g2 = vec![acc.fiat_shamir.acc_flat_B_g2, acc.fiat_shamir.acc_beta_pow_g2];
   let mu = acc.mu;
   let errs = vec![(
-    vec![
-      acc.errs.flat_A,
-      acc.errs.acc_flat_A,
-      acc.errs.acc_left_Q_x,
-      acc.errs.acc_left_x,
-      acc.errs.acc_part_corr1,
-    ],
-    vec![acc.errs.acc_flat_B_g2, acc.errs.flat_B_g2],
+    vec![acc.errs.acc_left_Q_x, acc.errs.acc_left_x, acc.errs.acc_part_corr1],
     vec![],
     vec![],
+    vec![acc.errs.acc_gt],
   )];
   let acc_errs = vec![(
-    vec![
-      acc.acc_errs.flat_A,
-      acc.acc_errs.acc_flat_A,
-      acc.acc_errs.acc_left_Q_x,
-      acc.acc_errs.acc_left_x,
-      acc.acc_errs.acc_part_corr1,
-    ],
-    vec![acc.acc_errs.acc_flat_B_g2, acc.acc_errs.flat_B_g2],
+    vec![acc.acc_errs.acc_left_Q_x, acc.acc_errs.acc_left_x, acc.acc_errs.acc_part_corr1],
     vec![],
     vec![],
+    vec![acc.acc_errs.acc_gt],
   )];
   if is_prover {
     let prover_only = acc.prover_only.unwrap();
@@ -362,14 +435,6 @@ fn matmul_acc_to_acc_holder<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSer
       acc_errs,
     }
   }
-}
-
-fn matmul_acc_to_acc_proof<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(
-  acc: MatMulAccProof<P, Q>,
-  is_prover: bool,
-) -> (Vec<P>, Vec<Q>, Vec<Fr>, Vec<PairingOutput<Bn<ark_bn254::Config>>>) {
-  let acc_holder = matmul_acc_to_acc_holder(acc, is_prover);
-  acc_to_acc_proof(acc_holder)
 }
 
 fn index<'a, T>(A: &'a ArrayD<T>, i: usize) -> &'a T {
@@ -563,6 +628,7 @@ impl BasicBlock for MatMulBasicBlock {
     return (proof, proof2, fr);
   }
 
+  #[cfg(not(feature = "fold"))]
   fn verify(
     &self,
     srs: &SRS,
@@ -659,6 +725,31 @@ impl BasicBlock for MatMulBasicBlock {
     checks
   }
 
+  #[cfg(feature = "fold")]
+  fn verify(
+    &self,
+    _srs: &SRS,
+    _model: &ArrayD<DataEnc>,
+    _inputs: &Vec<&ArrayD<DataEnc>>,
+    _outputs: &Vec<&ArrayD<DataEnc>>,
+    _proof: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>),
+    rng: &mut StdRng,
+    cache: ProveVerifyCache,
+  ) -> Vec<PairingCheck> {
+    let (_alpha, _beta) = {
+      let mut cache = cache.lock().unwrap();
+      let CacheValues::RLCRandom(alpha) = cache.entry("matmul_alpha".to_owned()).or_insert_with(|| CacheValues::RLCRandom(Fr::rand(rng))) else {
+        panic!("Cache type error")
+      };
+      let alpha = alpha.clone();
+      let CacheValues::RLCRandom(beta) = cache.entry("matmul_beta".to_owned()).or_insert_with(|| CacheValues::RLCRandom(Fr::rand(rng))) else {
+        panic!("Cache type error")
+      };
+      (alpha, beta.clone())
+    };
+    vec![]
+  }
+
   fn acc_prove(
     &self,
     srs: &SRS,
@@ -670,62 +761,12 @@ impl BasicBlock for MatMulBasicBlock {
     rng: &mut StdRng,
     _cache: ProveVerifyCache,
   ) -> AccProofProj {
-    let [left_x, left_Q_x, _left_zero, _left_zero_div, _right_x, _right_Q_x, _right_zero_div, _corr1, _corr2, _corr3, _corr4, flat_A, _flat_B, _flat_C, part_corr1, flat_A_no_blind, flat_B_no_blind] =
-      proof.0[..]
-    else {
-      panic!("Wrong proof format")
-    };
-
-    let [flat_B_g2, beta_pow_g2] = proof.1[..] else {
-      panic!("Wrong proof format")
-    };
-    let [flat_A_r, flat_B_r] = proof.2[..] else {
-      panic!("Wrong proof format")
-    };
-
-    let matmul_acc = acc_proof_to_matmul_acc(acc_proof, true).unwrap();
-
-    let acc_flat_A = matmul_acc.fiat_shamir.acc_flat_A;
-    let acc_left_x = matmul_acc.fiat_shamir.acc_left_x;
-    let acc_left_Q_x = matmul_acc.fiat_shamir.acc_left_Q_x;
-    let acc_mu = matmul_acc.mu;
-    let acc_part_corr1 = matmul_acc.prover_only.as_ref().unwrap().acc_part_corr1;
-    let po = matmul_acc.prover_only.as_ref().unwrap();
-    let acc_flat_A_no_blind = po.acc_flat_A_no_blind;
-    let acc_flat_B_no_blind = po.acc_flat_B_no_blind;
-    let acc_flat_A_r = po.acc_flat_A_r;
-    let acc_flat_B_r = po.acc_flat_B_r;
-    let acc_flat_B_g2 = matmul_acc.fiat_shamir.acc_flat_B_g2;
-
-    let errs = MatMulErrs {
-      flat_A,
-      acc_flat_A,
-      acc_left_Q_x: acc_left_Q_x + left_Q_x * acc_mu,
-      acc_left_x: acc_left_x + left_x * acc_mu,
-      acc_part_corr1: acc_part_corr1
-        + part_corr1 * acc_mu
-        + acc_flat_A_no_blind * flat_B_r
-        + flat_A_no_blind * acc_flat_B_r
-        + acc_flat_B_no_blind * flat_A_r
-        + flat_B_no_blind * acc_flat_A_r
-        + srs.Y1P * (flat_A_r * acc_flat_B_r + flat_B_r * acc_flat_A_r),
-      acc_flat_B_g2,
-      flat_B_g2,
-    };
-
-    // Fiat-Shamir
-    let mut bytes = Vec::new();
-    matmul_acc.fiat_shamir.serialize_uncompressed(&mut bytes).unwrap();
-    proof.0[..7].serialize_uncompressed(&mut bytes).unwrap();
-    proof.0[11..14].serialize_uncompressed(&mut bytes).unwrap();
-    proof.1.serialize_uncompressed(&mut bytes).unwrap();
-    errs.serialize_uncompressed(&mut bytes).unwrap();
-    util::add_randomness(rng, bytes);
-    let acc_gamma = Fr::rand(rng);
-
-    let new_matmul_acc = accumulate(&matmul_acc, &errs, &proof, acc_gamma);
-
-    matmul_acc_to_acc_proof(new_matmul_acc, true)
+    let proof = self.prover_proof_to_acc(proof);
+    if acc_proof.0.len() == 0 && acc_proof.1.len() == 0 && acc_proof.2.len() == 0 {
+      return acc_to_acc_proof(proof);
+    }
+    let acc_proof = acc_proof_to_acc(self, acc_proof, true);
+    acc_to_acc_proof(self.mira_prove(srs, acc_proof, proof, rng))
   }
 
   fn acc_clean(
@@ -734,19 +775,19 @@ impl BasicBlock for MatMulBasicBlock {
     proof: (&Vec<G1Projective>, &Vec<G2Projective>, &Vec<Fr>),
     acc_proof: AccProofProjRef,
   ) -> ((Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>), AccProofAff) {
-    let mut matmul_acc = acc_proof_to_matmul_acc(acc_proof, true).unwrap();
-
-    let po = matmul_acc.prover_only.as_ref().unwrap();
-    matmul_acc.acc_corr[0] = po.acc_part_corr1 * matmul_acc.mu
-      + po.acc_flat_A_no_blind * po.acc_flat_B_r
-      + po.acc_flat_B_no_blind * po.acc_flat_A_r
-      + srs.Y1P * po.acc_flat_A_r * po.acc_flat_B_r;
-
-    matmul_acc.prover_only = None;
-    let acc_proof = matmul_acc_to_acc_proof(matmul_acc, false);
+    let mut acc_holder = acc_proof_to_acc(self, acc_proof, true);
+    // acc_corr1 = acc_part_corr1 * mu + acc_flat_A_no_blind * acc_flat_B_r + acc_flat_B_no_blind * acc_flat_A_r + srs.Y1P * acc_flat_A_r * acc_flat_B_r
+    acc_holder.acc_g1[7] = acc_holder.acc_g1[14] * acc_holder.mu
+      + acc_holder.acc_g1[15] * acc_holder.acc_fr[1]
+      + acc_holder.acc_g1[16] * acc_holder.acc_fr[0]
+      + srs.Y1P * acc_holder.acc_fr[0] * acc_holder.acc_fr[1];
+    // remove blinding terms from acc proof for the verifier
+    acc_holder.acc_g1 = acc_holder.acc_g1[..acc_holder.acc_g1.len() - 3].to_vec();
+    acc_holder.acc_fr = vec![];
+    let acc_proof = acc_to_acc_proof(acc_holder);
 
     // remove blinding terms from bb proof for the verifier
-    let cqlin_proof = (proof.0[..11].to_vec(), proof.1.to_vec(), vec![]);
+    let cqlin_proof = (proof.0[..proof.0.len() - 3].to_vec(), proof.1.to_vec(), vec![]);
 
     (
       (
@@ -758,7 +799,7 @@ impl BasicBlock for MatMulBasicBlock {
         acc_proof.0.iter().map(|x| (*x).into()).collect(),
         acc_proof.1.iter().map(|x| (*x).into()).collect(),
         acc_proof.2,
-        vec![],
+        acc_proof.3.iter().map(|x| *x).collect(),
       ),
     )
   }
@@ -820,122 +861,69 @@ impl BasicBlock for MatMulBasicBlock {
     let temp: Vec<_> = (0..l).map(|i| index(outputs[0], i).g1).collect();
     let flat_C = util::msm::<G1Projective>(&temp, &alpha_pow);
 
-    let proof0_11_14 = vec![flat_A, flat_B, flat_C];
-
-    let prev_acc = acc_proof_to_matmul_acc(prev_acc_proof, false);
-    let acc = acc_proof_to_matmul_acc(acc_proof, false).unwrap();
-
-    if prev_acc.is_none() || (prev_acc.as_ref().unwrap().mu.is_zero() && acc.mu.is_one()) {
-      // skip verifying RLC because no RLC was done in acc_init.
-      // Fiat-shamir
-      let mut bytes = Vec::new();
-      proof.0[..7].serialize_uncompressed(&mut bytes).unwrap();
-      proof0_11_14.serialize_uncompressed(&mut bytes).unwrap();
-      proof.1.serialize_uncompressed(&mut bytes).unwrap();
-      util::add_randomness(rng, bytes);
-      let _acc_gamma = Fr::rand(rng);
+    result &= flat_A == proof.0[11] && flat_B == proof.0[12];
+    result &= flat_C == proof.0[13];
+    if prev_acc_proof.2.len() == 0 && acc_proof.2[0].is_one() {
       return Some(result);
     }
-
-    // Fiat-Shamir
-    let mut bytes = Vec::new();
-    let prev_acc = prev_acc.unwrap();
-    prev_acc.fiat_shamir.serialize_uncompressed(&mut bytes).unwrap();
-    proof.0[..7].serialize_uncompressed(&mut bytes).unwrap();
-    proof0_11_14.serialize_uncompressed(&mut bytes).unwrap();
-    proof.1.serialize_uncompressed(&mut bytes).unwrap();
-    acc.errs.serialize_uncompressed(&mut bytes).unwrap();
-    util::add_randomness(rng, bytes);
-    let acc_gamma = Fr::rand(rng);
-
-    result &= (proof.0[0] * acc_gamma + prev_acc.fiat_shamir.acc_left_x) == acc.fiat_shamir.acc_left_x;
-    result &= (proof.0[1] * acc_gamma + prev_acc.fiat_shamir.acc_left_Q_x) == acc.fiat_shamir.acc_left_Q_x;
-    result &= (proof.0[2] * acc_gamma + prev_acc.fiat_shamir.acc_left_zero) == acc.fiat_shamir.acc_left_zero;
-    result &= (proof.0[3] * acc_gamma + prev_acc.fiat_shamir.acc_left_zero_div) == acc.fiat_shamir.acc_left_zero_div;
-    result &= (proof.0[4] * acc_gamma + prev_acc.fiat_shamir.acc_right_x) == acc.fiat_shamir.acc_right_x;
-    result &= (proof.0[5] * acc_gamma + prev_acc.fiat_shamir.acc_right_Q_x) == acc.fiat_shamir.acc_right_Q_x;
-    result &= (proof.0[6] * acc_gamma + prev_acc.fiat_shamir.acc_right_zero_div) == acc.fiat_shamir.acc_right_zero_div;
-
-    result &= (flat_A * acc_gamma + prev_acc.fiat_shamir.acc_flat_A) == acc.fiat_shamir.acc_flat_A;
-    result &= (flat_B * acc_gamma + prev_acc.fiat_shamir.acc_flat_B) == acc.fiat_shamir.acc_flat_B;
-    result &= (flat_C * acc_gamma + prev_acc.fiat_shamir.acc_flat_C) == acc.fiat_shamir.acc_flat_C;
-
-    result &= acc.fiat_shamir.acc_flat_B_g2 == prev_acc.fiat_shamir.acc_flat_B_g2 + proof.1[0] * acc_gamma;
-    result &= acc.fiat_shamir.acc_beta_pow_g2 == prev_acc.fiat_shamir.acc_beta_pow_g2
-      && proof.1[1] == beta_pow_g2
-      && beta_pow_g2 == acc.fiat_shamir.acc_beta_pow_g2;
-    result &= acc.mu == prev_acc.mu + acc_gamma;
-
-    result &= prev_acc.acc_errs.acc_left_Q_x + acc.errs.acc_left_Q_x * acc_gamma == acc.acc_errs.acc_left_Q_x;
-    result &= prev_acc.acc_errs.acc_left_x + acc.errs.acc_left_x * acc_gamma == acc.acc_errs.acc_left_x;
-    result &= prev_acc.acc_errs.acc_part_corr1 + acc.errs.acc_part_corr1 * acc_gamma == acc.acc_errs.acc_part_corr1;
-
+    let proof = self.verifier_proof_to_acc(proof);
+    let prev_acc_holder = acc_proof_to_acc(self, prev_acc_proof, false);
+    let acc_holder = acc_proof_to_acc(self, acc_proof, false);
+    result &= self.mira_verify(prev_acc_holder, proof, acc_holder, rng).unwrap();
     Some(result)
   }
 
   fn acc_decide(&self, srs: &SRS, acc_proof: AccProofAffRef) -> Vec<(PairingCheck, PairingOutput<Bn<ark_bn254::Config>>)> {
-    let acc = acc_proof_to_matmul_acc(acc_proof, false).unwrap();
-
-    let acc_flat_A = acc.fiat_shamir.acc_flat_A;
-    let acc_flat_B_g2 = acc.fiat_shamir.acc_flat_B_g2;
-    let acc_left_x = acc.fiat_shamir.acc_left_x;
-    let acc_left_Q_x = acc.fiat_shamir.acc_left_Q_x;
-    let acc_left_zero = acc.fiat_shamir.acc_left_zero;
-    let acc_left_zero_div = acc.fiat_shamir.acc_left_zero_div;
-    let acc_right_x = acc.fiat_shamir.acc_right_x;
-    let acc_right_Q_x = acc.fiat_shamir.acc_right_Q_x;
-    let acc_right_zero_div = acc.fiat_shamir.acc_right_zero_div;
-    let acc_flat_B = acc.fiat_shamir.acc_flat_B;
-    let acc_flat_C = acc.fiat_shamir.acc_flat_C;
-    let beta_pow_g2 = acc.fiat_shamir.acc_beta_pow_g2;
-    let acc_corr = acc.acc_corr;
-    let acc_mu = acc.mu;
-    let errs = &acc.acc_errs;
+    let acc_holder = acc_proof_to_acc(self, acc_proof, false);
+    let [acc_left_x, acc_left_Q_x, acc_left_zero, acc_left_zero_div, acc_right_x, acc_right_Q_x, acc_right_zero_div, acc_corr1, acc_corr2, acc_corr3, acc_corr4, acc_flat_A, acc_flat_B, acc_flat_C] =
+      acc_holder.acc_g1[..]
+    else {
+      panic!("Wrong acc proof format")
+    };
+    let [acc_flat_B_g2, beta_pow_g2] = acc_holder.acc_g2[..] else {
+      panic!("Wrong acc proof format")
+    };
+    let acc_mu = acc_holder.mu;
+    let err_1 = &acc_holder.acc_errs[0];
 
     let mut temp: PairingCheck = vec![];
-    for i in 0..errs.prev_g2s.len() {
-      temp.push((-errs.prev_g1s[i], errs.prev_g2s[i]));
-    }
-    temp.push((-errs.flat_A, errs.acc_flat_B_g2));
-    temp.push((-errs.acc_flat_A, errs.flat_B_g2));
-    temp.push((errs.acc_left_Q_x, (srs.X2A[self.m] - srs.X2A[0]).into()));
-    temp.push((errs.acc_left_x, srs.X2A[0]));
-    temp.push((errs.acc_part_corr1, srs.Y2A));
+    temp.push((err_1.0[0], (srs.X2A[self.m] - srs.X2A[0]).into()));
+    temp.push((err_1.0[1], srs.X2A[0]));
+    temp.push((err_1.0[2], srs.Y2A));
 
-    let err_1 = temp;
     let mut acc_1: PairingCheck = vec![
       (acc_flat_A, acc_flat_B_g2),
       ((-acc_left_x * acc_mu).into(), srs.X2A[0]),
       ((-acc_left_Q_x * acc_mu).into(), (srs.X2A[self.m] - srs.X2A[0]).into()),
-      (-acc_corr[0], srs.Y2A),
+      (-acc_corr1, srs.Y2A),
     ];
-    acc_1.extend(err_1);
+    acc_1.extend(temp);
 
     let acc_2: PairingCheck = vec![(acc_flat_B, srs.X2A[0]), (srs.X1A[0], -acc_flat_B_g2)];
 
     let acc_3: PairingCheck = vec![
       ((acc_left_x - acc_left_zero).into(), srs.X2A[0]),
       (-acc_left_zero_div, srs.X2A[1]),
-      (-acc_corr[1], srs.Y2A),
+      (-acc_corr2, srs.Y2A),
     ];
 
     let acc_4: PairingCheck = vec![
       (acc_flat_C, beta_pow_g2),
       (-acc_right_x, srs.X2A[0]),
       (-acc_right_Q_x, (srs.X2A[self.n] - srs.X2A[0]).into()),
-      (-acc_corr[2], srs.Y2A),
+      (-acc_corr3, srs.Y2A),
     ];
 
     let acc_right_zero: G1Projective = acc_left_zero * (Fr::from(self.m as u32) * Fr::from(self.n as u32).inverse().unwrap());
     let acc_5 = vec![
       ((-acc_right_zero + acc_right_x).into(), srs.X2A[0]),
       (-acc_right_zero_div, srs.X2A[1]),
-      (-acc_corr[3], srs.Y2A),
+      (-acc_corr4, srs.Y2A),
     ];
 
     let pairing_zero = PairingOutput::<Bn<ark_bn254::Config>>::zero();
     vec![
-      (acc_1, pairing_zero),
+      (acc_1, err_1.3[0]),
       (acc_2, pairing_zero),
       (acc_3, pairing_zero),
       (acc_4, pairing_zero),
@@ -944,8 +932,12 @@ impl BasicBlock for MatMulBasicBlock {
   }
 
   fn acc_finalize(&self, _srs: &SRS, acc_proof: AccProofAffRef) -> AccProofAff {
-    let mut acc_holder = acc_proof_to_matmul_acc_holder(acc_proof, false);
+    let mut acc_holder = acc_proof_to_acc(self, acc_proof, false);
+    let err_1 = &acc_holder.acc_errs[0];
+    let acc_err1 = err_1.3[0].clone();
     acc_holder.errs = vec![];
-    acc_to_acc_proof(acc_holder)
+    acc_holder.acc_errs = vec![];
+    let acc_proof = acc_to_acc_proof(acc_holder);
+    (acc_proof.0, acc_proof.1, acc_proof.2, vec![acc_err1])
   }
 }

--- a/src/basic_block/matmul.rs
+++ b/src/basic_block/matmul.rs
@@ -1,9 +1,11 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
 use super::{
   AccProofAff, AccProofAffRef, AccProofProj, AccProofProjRef, BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS,
 };
 use crate::util::{self, acc_proof_to_holder, calc_pow, holder_to_acc_proof, AccHolder, AccProofLayout};
+use crate::{define_acc_err_terms, define_acc_terms};
 use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::bn::Bn;
 use ark_ec::pairing::{Pairing, PairingOutput};
@@ -16,41 +18,75 @@ use ndarray::{arr1, arr2, ArrayD, Ix1, Ix2, IxDyn};
 use rand::{rngs::StdRng, SeedableRng};
 use rayon::iter::ParallelIterator;
 
+define_acc_terms!(
+  MatMulG1Terms,
+  [
+    Left_x,
+    Left_Q_x,
+    Left_zero,
+    Left_zero_div,
+    Right_x,
+    Right_Q_x,
+    Right_zero_div,
+    Corr1,
+    Corr2,
+    Corr3,
+    Corr4,
+    Flat_A,
+    Flat_B,
+    Flat_C
+  ],
+  [Part_corr1, Flat_A_no_blind, Flat_B_no_blind]
+);
+define_acc_terms!(MatMulG2Terms, [Flat_B_g2, Beta_pow_g2], []);
+define_acc_terms!(MatMulFrTerms, [], [Flat_A_r, Flat_B_r]);
+define_acc_err_terms!(MatMulErrG1Terms, [Err_Q, Err_l, Err_C]);
+define_acc_err_terms!(MatMulErrG2Terms, []);
+define_acc_err_terms!(MatMulErrFrTerms, []);
+define_acc_err_terms!(MatMulErrGtTerms, [Err_Gt]);
+
 impl AccProofLayout for MatMulBasicBlock {
+  type AccG1Terms = MatMulG1Terms;
+  type AccG2Terms = MatMulG2Terms;
+  type AccFrTerms = MatMulFrTerms;
+  type ErrG1Terms = MatMulErrG1Terms;
+  type ErrG2Terms = MatMulErrG2Terms;
+  type ErrFrTerms = MatMulErrFrTerms;
+  type ErrGtTerms = MatMulErrGtTerms;
   fn acc_g1_num(&self, is_prover: bool) -> usize {
     if is_prover {
-      17
+      MatMulG1Terms::COUNT
     } else {
-      14
+      MatMulG1Terms::PUBLIC_COUNT
     }
   }
 
   fn acc_g2_num(&self, _is_prover: bool) -> usize {
-    2
+    MatMulG2Terms::COUNT
   }
 
   fn acc_fr_num(&self, is_prover: bool) -> usize {
     if is_prover {
-      2
+      MatMulFrTerms::COUNT
     } else {
-      0
+      MatMulFrTerms::PUBLIC_COUNT
     }
   }
 
   fn err_g1_nums(&self) -> Vec<usize> {
-    vec![3]
+    MatMulErrG1Terms::COUNTS.to_vec()
   }
 
   fn err_g2_nums(&self) -> Vec<usize> {
-    vec![0]
+    MatMulErrG2Terms::COUNTS.to_vec()
   }
 
   fn err_fr_nums(&self) -> Vec<usize> {
-    vec![0]
+    MatMulErrFrTerms::COUNTS.to_vec()
   }
 
   fn err_gt_nums(&self) -> Vec<usize> {
-    vec![1]
+    MatMulErrGtTerms::COUNTS.to_vec()
   }
 
   fn prover_proof_to_acc(&self, proof: (&Vec<G1Projective>, &Vec<G2Projective>, &Vec<Fr>)) -> AccHolder<G1Projective, G2Projective> {
@@ -60,13 +96,13 @@ impl AccProofLayout for MatMulBasicBlock {
       acc_fr: proof.2.clone(),
       mu: Fr::one(),
       errs: vec![(
-        vec![G1Projective::zero(); 3],
+        vec![G1Projective::zero(); MatMulErrG1Terms::COUNTS[0]],
         vec![],
         vec![],
         vec![PairingOutput::<Bn<ark_bn254::Config>>::zero()],
       )],
       acc_errs: vec![(
-        vec![G1Projective::zero(); 3],
+        vec![G1Projective::zero(); MatMulErrG1Terms::COUNTS[0]],
         vec![],
         vec![],
         vec![PairingOutput::<Bn<ark_bn254::Config>>::zero()],
@@ -81,13 +117,13 @@ impl AccProofLayout for MatMulBasicBlock {
       acc_fr: proof.2.clone(),
       mu: Fr::one(),
       errs: vec![(
-        vec![G1Affine::zero(); 3],
+        vec![G1Affine::zero(); MatMulErrG1Terms::COUNTS[0]],
         vec![],
         vec![],
         vec![PairingOutput::<Bn<ark_bn254::Config>>::zero()],
       )],
       acc_errs: vec![(
-        vec![G1Affine::zero(); 3],
+        vec![G1Affine::zero(); MatMulErrG1Terms::COUNTS[0]],
         vec![],
         vec![],
         vec![PairingOutput::<Bn<ark_bn254::Config>>::zero()],
@@ -102,58 +138,94 @@ impl AccProofLayout for MatMulBasicBlock {
     acc_2: AccHolder<G1Projective, G2Projective>,
     rng: &mut StdRng,
   ) -> AccHolder<G1Projective, G2Projective> {
-    let acc_1 = matmul_acc_holder_to_acc(acc_1, true);
-    let acc_2 = matmul_acc_holder_to_acc(acc_2, true);
-
-    let acc_flat_A = acc_1.fiat_shamir.acc_flat_A;
-    let acc_left_x = acc_1.fiat_shamir.acc_left_x;
-    let acc_left_Q_x = acc_1.fiat_shamir.acc_left_Q_x;
-    let acc_mu = acc_1.mu;
-    let acc_part_corr1 = acc_1.prover_only.as_ref().unwrap().acc_part_corr1;
-    let po = acc_1.prover_only.as_ref().unwrap();
-    let acc_flat_A_no_blind = po.acc_flat_A_no_blind;
-    let acc_flat_B_no_blind = po.acc_flat_B_no_blind;
-    let acc_flat_A_r = po.acc_flat_A_r;
-    let acc_flat_B_r = po.acc_flat_B_r;
-    let acc_flat_B_g2 = acc_1.fiat_shamir.acc_flat_B_g2;
-
-    let flat_A = acc_2.fiat_shamir.acc_flat_A;
-    let left_x = acc_2.fiat_shamir.acc_left_x;
-    let left_Q_x = acc_2.fiat_shamir.acc_left_Q_x;
-    let part_corr1 = acc_2.prover_only.as_ref().unwrap().acc_part_corr1;
-    let po = acc_2.prover_only.as_ref().unwrap();
-    let flat_A_no_blind = po.acc_flat_A_no_blind;
-    let flat_B_no_blind = po.acc_flat_B_no_blind;
-    let flat_A_r = po.acc_flat_A_r;
-    let flat_B_r = po.acc_flat_B_r;
-    let flat_B_g2 = acc_2.fiat_shamir.acc_flat_B_g2;
+    let acc_flat_A = acc_1.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A)];
+    let acc_left_x = acc_1.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Left_x)];
+    let acc_left_Q_x = acc_1.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Left_Q_x)];
+    let acc_part_corr1 = acc_1.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Part_corr1)];
+    let acc_flat_A_no_blind = acc_1.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A_no_blind)];
+    let acc_flat_B_no_blind = acc_1.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_B_no_blind)];
+    let acc_flat_A_r = acc_1.acc_fr[MatMulFrTerms::idx(MatMulFrTerms::Flat_A_r)];
+    let acc_flat_B_r = acc_1.acc_fr[MatMulFrTerms::idx(MatMulFrTerms::Flat_B_r)];
+    let acc_flat_B_g2 = acc_1.acc_g2[MatMulG2Terms::idx(MatMulG2Terms::Flat_B_g2)];
+    let acc_beta_pow_g2 = acc_1.acc_g2[MatMulG2Terms::idx(MatMulG2Terms::Beta_pow_g2)];
+    let flat_A = acc_2.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A)];
+    let left_x = acc_2.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Left_x)];
+    let left_Q_x = acc_2.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Left_Q_x)];
+    let part_corr1 = acc_2.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Part_corr1)];
+    let flat_A_no_blind = acc_2.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A_no_blind)];
+    let flat_B_no_blind = acc_2.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_B_no_blind)];
+    let flat_A_r = acc_2.acc_fr[MatMulFrTerms::idx(MatMulFrTerms::Flat_A_r)];
+    let flat_B_r = acc_2.acc_fr[MatMulFrTerms::idx(MatMulFrTerms::Flat_B_r)];
+    let flat_B_g2 = acc_2.acc_g2[MatMulG2Terms::idx(MatMulG2Terms::Flat_B_g2)];
 
     // Compute the error
-    let err = MatMulErrs {
-      acc_left_Q_x: acc_left_Q_x * acc_2.mu + left_Q_x * acc_mu,
-      acc_left_x: acc_left_x * acc_2.mu + left_x * acc_mu,
-      acc_part_corr1: acc_part_corr1 * acc_2.mu
-        + part_corr1 * acc_mu
-        + acc_flat_A_no_blind * flat_B_r
-        + flat_A_no_blind * acc_flat_B_r
-        + acc_flat_B_no_blind * flat_A_r
-        + flat_B_no_blind * acc_flat_A_r
-        + srs.Y1P * (flat_A_r * acc_flat_B_r + flat_B_r * acc_flat_A_r),
-      acc_gt: Bn254::multi_pairing(vec![flat_A, acc_flat_A], vec![acc_flat_B_g2, flat_B_g2]),
+    let err: (Vec<G1Projective>, Vec<G2Projective>, Vec<Fr>, Vec<PairingOutput<Bn<ark_bn254::Config>>>) = (
+      vec![
+        acc_left_Q_x * acc_2.mu + left_Q_x * acc_1.mu,
+        acc_left_x * acc_2.mu + left_x * acc_1.mu,
+        acc_part_corr1 * acc_2.mu
+          + part_corr1 * acc_1.mu
+          + acc_flat_A_no_blind * flat_B_r
+          + flat_A_no_blind * acc_flat_B_r
+          + acc_flat_B_no_blind * flat_A_r
+          + flat_B_no_blind * acc_flat_A_r
+          + srs.Y1P * (flat_A_r * acc_flat_B_r + flat_B_r * acc_flat_A_r),
+      ],
+      vec![],
+      vec![],
+      vec![Bn254::multi_pairing(vec![flat_A, acc_flat_A], vec![acc_flat_B_g2, flat_B_g2])],
+    );
+    let errs = vec![err];
+
+    let mut new_acc_holder = AccHolder {
+      acc_g1: Vec::new(),
+      acc_g2: Vec::new(),
+      acc_fr: Vec::new(),
+      mu: Fr::zero(),
+      errs: Vec::new(),
+      acc_errs: Vec::new(),
     };
 
     // Fiat-Shamir
     let mut bytes = Vec::new();
-    acc_1.fiat_shamir.serialize_uncompressed(&mut bytes).unwrap();
-    acc_2.fiat_shamir.serialize_uncompressed(&mut bytes).unwrap();
-    err.serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g1[11..14].serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g2.serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.acc_g1[11..14].serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.acc_g2.serialize_uncompressed(&mut bytes).unwrap();
+    errs.iter().for_each(|(g1, g2, f, gt)| {
+      g1.serialize_uncompressed(&mut bytes).unwrap();
+      g2.serialize_uncompressed(&mut bytes).unwrap();
+      f.serialize_uncompressed(&mut bytes).unwrap();
+      gt.serialize_uncompressed(&mut bytes).unwrap();
+    });
     util::add_randomness(rng, bytes);
     let acc_gamma = Fr::rand(rng);
+    let acc_gamma_sq = acc_gamma * acc_gamma;
 
-    // Accumulate
-    let new_acc = accumulate(&acc_1, &acc_2, &err, acc_gamma);
+    new_acc_holder.acc_g1 = acc_2.acc_g1.iter().zip(acc_1.acc_g1.iter()).map(|(x, y)| *x * acc_gamma + y).collect();
+    new_acc_holder.acc_g2 = vec![flat_B_g2 * acc_gamma + acc_flat_B_g2, acc_beta_pow_g2];
+    new_acc_holder.acc_fr = acc_2.acc_fr.iter().zip(acc_1.acc_fr.iter()).map(|(x, y)| *x * acc_gamma + y).collect();
+    new_acc_holder.mu = acc_1.mu + acc_gamma * acc_2.mu;
+    new_acc_holder.errs = errs;
 
-    matmul_acc_to_acc_holder(new_acc, true)
+    // Append error terms
+    let (q_group, q_idx) = MatMulErrG1Terms::idx(MatMulErrG1Terms::Err_Q);
+    let (l_group, l_idx) = MatMulErrG1Terms::idx(MatMulErrG1Terms::Err_l);
+    let (c_group, c_idx) = MatMulErrG1Terms::idx(MatMulErrG1Terms::Err_C);
+    let (gt_group, gt_idx) = MatMulErrGtTerms::idx(MatMulErrGtTerms::Err_Gt);
+    let q_term_g1 =
+      acc_1.acc_errs[q_group].0[q_idx] + new_acc_holder.errs[q_group].0[q_idx] * acc_gamma + acc_2.acc_errs[q_group].0[q_idx] * acc_gamma_sq;
+    let l_term_g1 =
+      acc_1.acc_errs[l_group].0[l_idx] + new_acc_holder.errs[l_group].0[l_idx] * acc_gamma + acc_2.acc_errs[l_group].0[l_idx] * acc_gamma_sq;
+    let c_term_g1 =
+      acc_1.acc_errs[c_group].0[c_idx] + new_acc_holder.errs[c_group].0[c_idx] * acc_gamma + acc_2.acc_errs[c_group].0[c_idx] * acc_gamma_sq;
+    let term_gt =
+      acc_1.acc_errs[gt_group].3[gt_idx] + new_acc_holder.errs[gt_group].3[gt_idx] * acc_gamma + acc_2.acc_errs[gt_group].3[gt_idx] * acc_gamma_sq;
+    new_acc_holder.acc_errs = vec![(vec![q_term_g1, l_term_g1, c_term_g1], vec![], vec![], vec![term_gt])];
+
+    new_acc_holder
   }
 
   fn mira_verify(
@@ -163,277 +235,43 @@ impl AccProofLayout for MatMulBasicBlock {
     new_acc: AccHolder<G1Affine, G2Affine>,
     rng: &mut StdRng,
   ) -> Option<bool> {
-    let acc_1 = matmul_acc_holder_to_acc(acc_1, false);
-    let acc_2 = matmul_acc_holder_to_acc(acc_2, false);
-    let new_acc = matmul_acc_holder_to_acc(new_acc, false);
-
     let mut result = true;
 
     // Fiat-Shamir
     let mut bytes = Vec::new();
-    acc_1.fiat_shamir.serialize_uncompressed(&mut bytes).unwrap();
-    acc_2.fiat_shamir.serialize_uncompressed(&mut bytes).unwrap();
-    new_acc.errs.serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g1[11..14].serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g2.serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.acc_g1[11..14].serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.acc_g2.serialize_uncompressed(&mut bytes).unwrap();
+    new_acc.errs.iter().for_each(|(g1, g2, f, gt)| {
+      g1.serialize_uncompressed(&mut bytes).unwrap();
+      g2.serialize_uncompressed(&mut bytes).unwrap();
+      f.serialize_uncompressed(&mut bytes).unwrap();
+      gt.serialize_uncompressed(&mut bytes).unwrap();
+    });
     util::add_randomness(rng, bytes);
     let acc_gamma = Fr::rand(rng);
     let acc_gamma_sq = acc_gamma * acc_gamma;
 
-    result &= (acc_2.fiat_shamir.acc_left_x * acc_gamma + acc_1.fiat_shamir.acc_left_x) == new_acc.fiat_shamir.acc_left_x;
-    result &= (acc_2.fiat_shamir.acc_left_Q_x * acc_gamma + acc_1.fiat_shamir.acc_left_Q_x) == new_acc.fiat_shamir.acc_left_Q_x;
-    result &= (acc_2.fiat_shamir.acc_left_zero * acc_gamma + acc_1.fiat_shamir.acc_left_zero) == new_acc.fiat_shamir.acc_left_zero;
-    result &= (acc_2.fiat_shamir.acc_left_zero_div * acc_gamma + acc_1.fiat_shamir.acc_left_zero_div) == new_acc.fiat_shamir.acc_left_zero_div;
-    result &= (acc_2.fiat_shamir.acc_right_x * acc_gamma + acc_1.fiat_shamir.acc_right_x) == new_acc.fiat_shamir.acc_right_x;
-    result &= (acc_2.fiat_shamir.acc_right_Q_x * acc_gamma + acc_1.fiat_shamir.acc_right_Q_x) == new_acc.fiat_shamir.acc_right_Q_x;
-    result &= (acc_2.fiat_shamir.acc_right_zero_div * acc_gamma + acc_1.fiat_shamir.acc_right_zero_div) == new_acc.fiat_shamir.acc_right_zero_div;
-
-    result &= (acc_2.fiat_shamir.acc_flat_A * acc_gamma + acc_1.fiat_shamir.acc_flat_A) == new_acc.fiat_shamir.acc_flat_A;
-    result &= (acc_2.fiat_shamir.acc_flat_B * acc_gamma + acc_1.fiat_shamir.acc_flat_B) == new_acc.fiat_shamir.acc_flat_B;
-    result &= (acc_2.fiat_shamir.acc_flat_C * acc_gamma + acc_1.fiat_shamir.acc_flat_C) == new_acc.fiat_shamir.acc_flat_C;
-    result &= new_acc.fiat_shamir.acc_flat_B_g2 == acc_1.fiat_shamir.acc_flat_B_g2 + acc_2.fiat_shamir.acc_flat_B_g2 * acc_gamma;
-    result &= new_acc.fiat_shamir.acc_beta_pow_g2 == acc_2.fiat_shamir.acc_beta_pow_g2;
+    acc_2.acc_g1[..7].iter().enumerate().for_each(|(i, x)| {
+      let z = *x * acc_gamma + acc_1.acc_g1[i];
+      result &= new_acc.acc_g1[i] == z;
+    });
+    acc_2.acc_g1[11..14].iter().enumerate().for_each(|(i, x)| {
+      let z = *x * acc_gamma + acc_1.acc_g1[i + 11];
+      result &= new_acc.acc_g1[i + 11] == z;
+    });
+    result &= new_acc.acc_g2[0] == acc_1.acc_g2[0] + acc_2.acc_g2[0] * acc_gamma;
+    result &= new_acc.acc_g2[1] == acc_1.acc_g2[1];
     result &= new_acc.mu == acc_1.mu + acc_gamma * acc_2.mu;
-
-    result &= acc_1.acc_errs.acc_left_Q_x + new_acc.errs.acc_left_Q_x * acc_gamma + acc_2.acc_errs.acc_left_Q_x * acc_gamma_sq
-      == new_acc.acc_errs.acc_left_Q_x;
-    result &=
-      acc_1.acc_errs.acc_left_x + new_acc.errs.acc_left_x * acc_gamma + acc_2.acc_errs.acc_left_x * acc_gamma_sq == new_acc.acc_errs.acc_left_x;
-    result &= acc_1.acc_errs.acc_part_corr1 + new_acc.errs.acc_part_corr1 * acc_gamma + acc_2.acc_errs.acc_part_corr1 * acc_gamma_sq
-      == new_acc.acc_errs.acc_part_corr1;
-    result &= acc_1.acc_errs.acc_gt + new_acc.errs.acc_gt * acc_gamma + acc_2.acc_errs.acc_gt * acc_gamma_sq == new_acc.acc_errs.acc_gt;
+    new_acc.errs[0].0.iter().zip(acc_1.acc_errs[0].0.iter()).enumerate().for_each(|(j, (x, y))| {
+      let z = *y + *x * acc_gamma + acc_2.acc_errs[0].0[j] * acc_gamma_sq;
+      result &= z == new_acc.acc_errs[0].0[j];
+    });
+    result &= acc_1.acc_errs[0].3[0] + new_acc.errs[0].3[0] * acc_gamma + acc_2.acc_errs[0].3[0] * acc_gamma_sq == new_acc.acc_errs[0].3[0];
     Some(result)
-  }
-}
-
-struct MatMulAccProof<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize> {
-  fiat_shamir: MatMulAccFiatShamir<P, Q>,
-  acc_corr: [P; 4],
-  mu: Fr,
-  prover_only: Option<MatMulAccProofProverOnly<P>>,
-  errs: MatMulErrs<P>,
-  acc_errs: MatMulAccErrs<P>,
-}
-
-#[derive(CanonicalSerialize)]
-struct MatMulAccFiatShamir<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize> {
-  acc_left_x: P,
-  acc_left_Q_x: P,
-  acc_left_zero: P,
-  acc_left_zero_div: P,
-  acc_right_x: P,
-  acc_right_Q_x: P,
-  acc_right_zero_div: P,
-  acc_flat_A: P,
-  acc_flat_B: P,
-  acc_flat_C: P,
-  acc_flat_B_g2: Q,
-  acc_beta_pow_g2: Q,
-}
-
-struct MatMulAccProofProverOnly<P: Copy + CanonicalSerialize> {
-  acc_part_corr1: P,
-  acc_flat_A_no_blind: P,
-  acc_flat_B_no_blind: P,
-  acc_flat_A_r: Fr,
-  acc_flat_B_r: Fr,
-}
-
-#[derive(CanonicalSerialize, Clone)]
-struct MatMulErrs<P: Copy + CanonicalSerialize> {
-  acc_left_Q_x: P,
-  acc_left_x: P,
-  acc_part_corr1: P,
-  acc_gt: PairingOutput<Bn<ark_bn254::Config>>,
-}
-
-#[derive(Clone)]
-struct MatMulAccErrs<P: Copy + CanonicalSerialize> {
-  acc_left_Q_x: P,
-  acc_left_x: P,
-  acc_part_corr1: P,
-  acc_gt: PairingOutput<Bn<ark_bn254::Config>>,
-}
-
-fn accumulate(
-  matmul_acc_1: &MatMulAccProof<G1Projective, G2Projective>,
-  matmul_acc_2: &MatMulAccProof<G1Projective, G2Projective>,
-  errs: &MatMulErrs<G1Projective>,
-  acc_gamma: Fr,
-) -> MatMulAccProof<G1Projective, G2Projective> {
-  let new_errs = MatMulErrs {
-    acc_left_Q_x: errs.acc_left_Q_x * acc_gamma,
-    acc_left_x: errs.acc_left_x * acc_gamma,
-    acc_part_corr1: errs.acc_part_corr1 * acc_gamma,
-    acc_gt: errs.acc_gt * acc_gamma,
-  };
-
-  let acc_gamma_sq = acc_gamma * acc_gamma;
-  let acc_errs = MatMulAccErrs {
-    acc_left_Q_x: matmul_acc_1.acc_errs.acc_left_Q_x + new_errs.acc_left_Q_x + matmul_acc_2.acc_errs.acc_left_Q_x * acc_gamma_sq,
-    acc_left_x: matmul_acc_1.acc_errs.acc_left_x + new_errs.acc_left_x + matmul_acc_2.acc_errs.acc_left_x * acc_gamma_sq,
-    acc_part_corr1: matmul_acc_1.acc_errs.acc_part_corr1 + new_errs.acc_part_corr1 + matmul_acc_2.acc_errs.acc_part_corr1 * acc_gamma_sq,
-    acc_gt: matmul_acc_1.acc_errs.acc_gt + new_errs.acc_gt + matmul_acc_2.acc_errs.acc_gt * acc_gamma_sq,
-  };
-
-  // Compute the error
-  let matmul_acc_prover_only_1 = matmul_acc_1.prover_only.as_ref().unwrap();
-  let matmul_acc_prover_only_2 = matmul_acc_2.prover_only.as_ref().unwrap();
-  let new_matmul_acc = MatMulAccProof {
-    fiat_shamir: MatMulAccFiatShamir {
-      acc_left_x: matmul_acc_1.fiat_shamir.acc_left_x + matmul_acc_2.fiat_shamir.acc_left_x * acc_gamma,
-      acc_left_Q_x: matmul_acc_1.fiat_shamir.acc_left_Q_x + matmul_acc_2.fiat_shamir.acc_left_Q_x * acc_gamma,
-      acc_left_zero: matmul_acc_1.fiat_shamir.acc_left_zero + matmul_acc_2.fiat_shamir.acc_left_zero * acc_gamma,
-      acc_left_zero_div: matmul_acc_1.fiat_shamir.acc_left_zero_div + matmul_acc_2.fiat_shamir.acc_left_zero_div * acc_gamma,
-      acc_right_x: matmul_acc_1.fiat_shamir.acc_right_x + matmul_acc_2.fiat_shamir.acc_right_x * acc_gamma,
-      acc_right_Q_x: matmul_acc_1.fiat_shamir.acc_right_Q_x + matmul_acc_2.fiat_shamir.acc_right_Q_x * acc_gamma,
-      acc_right_zero_div: matmul_acc_1.fiat_shamir.acc_right_zero_div + matmul_acc_2.fiat_shamir.acc_right_zero_div * acc_gamma,
-      acc_flat_A: matmul_acc_1.fiat_shamir.acc_flat_A + matmul_acc_2.fiat_shamir.acc_flat_A * acc_gamma,
-      acc_flat_B: matmul_acc_1.fiat_shamir.acc_flat_B + matmul_acc_2.fiat_shamir.acc_flat_B * acc_gamma,
-      acc_flat_C: matmul_acc_1.fiat_shamir.acc_flat_C + matmul_acc_2.fiat_shamir.acc_flat_C * acc_gamma,
-      acc_flat_B_g2: matmul_acc_1.fiat_shamir.acc_flat_B_g2 + matmul_acc_2.fiat_shamir.acc_flat_B_g2 * acc_gamma,
-      acc_beta_pow_g2: matmul_acc_2.fiat_shamir.acc_beta_pow_g2,
-    },
-    acc_corr: [
-      matmul_acc_1.acc_corr[0] + matmul_acc_2.acc_corr[0] * acc_gamma,
-      matmul_acc_1.acc_corr[1] + matmul_acc_2.acc_corr[1] * acc_gamma,
-      matmul_acc_1.acc_corr[2] + matmul_acc_2.acc_corr[2] * acc_gamma,
-      matmul_acc_1.acc_corr[3] + matmul_acc_2.acc_corr[3] * acc_gamma,
-    ],
-    mu: matmul_acc_1.mu + acc_gamma * matmul_acc_2.mu,
-    prover_only: Some(MatMulAccProofProverOnly {
-      acc_part_corr1: matmul_acc_prover_only_1.acc_part_corr1 + matmul_acc_prover_only_2.acc_part_corr1 * acc_gamma,
-      acc_flat_A_no_blind: matmul_acc_prover_only_1.acc_flat_A_no_blind + matmul_acc_prover_only_2.acc_flat_A_no_blind * acc_gamma,
-      acc_flat_B_no_blind: matmul_acc_prover_only_1.acc_flat_B_no_blind + matmul_acc_prover_only_2.acc_flat_B_no_blind * acc_gamma,
-      acc_flat_A_r: matmul_acc_prover_only_1.acc_flat_A_r + matmul_acc_prover_only_2.acc_flat_A_r * acc_gamma,
-      acc_flat_B_r: matmul_acc_prover_only_1.acc_flat_B_r + matmul_acc_prover_only_2.acc_flat_B_r * acc_gamma,
-    }),
-    errs: errs.clone(),
-    acc_errs,
-  };
-
-  new_matmul_acc
-}
-
-fn matmul_acc_holder_to_acc<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(
-  acc_holder: AccHolder<P, Q>,
-  is_prover: bool,
-) -> MatMulAccProof<P, Q> {
-  let acc_proof = MatMulAccProof {
-    fiat_shamir: MatMulAccFiatShamir {
-      acc_left_x: acc_holder.acc_g1[0],
-      acc_left_Q_x: acc_holder.acc_g1[1],
-      acc_left_zero: acc_holder.acc_g1[2],
-      acc_left_zero_div: acc_holder.acc_g1[3],
-      acc_right_x: acc_holder.acc_g1[4],
-      acc_right_Q_x: acc_holder.acc_g1[5],
-      acc_right_zero_div: acc_holder.acc_g1[6],
-      acc_flat_A: acc_holder.acc_g1[11],
-      acc_flat_B: acc_holder.acc_g1[12],
-      acc_flat_C: acc_holder.acc_g1[13],
-      acc_flat_B_g2: acc_holder.acc_g2[0],
-      acc_beta_pow_g2: acc_holder.acc_g2[1],
-    },
-    acc_corr: [acc_holder.acc_g1[7], acc_holder.acc_g1[8], acc_holder.acc_g1[9], acc_holder.acc_g1[10]],
-    mu: acc_holder.mu,
-    prover_only: if is_prover {
-      Some(MatMulAccProofProverOnly {
-        acc_part_corr1: acc_holder.acc_g1[14],
-        acc_flat_A_no_blind: acc_holder.acc_g1[15],
-        acc_flat_B_no_blind: acc_holder.acc_g1[16],
-        acc_flat_A_r: acc_holder.acc_fr[0],
-        acc_flat_B_r: acc_holder.acc_fr[1],
-      })
-    } else {
-      None
-    },
-    errs: MatMulErrs {
-      acc_left_Q_x: acc_holder.errs[0].0[0],
-      acc_left_x: acc_holder.errs[0].0[1],
-      acc_part_corr1: acc_holder.errs[0].0[2],
-      acc_gt: acc_holder.errs[0].3[0],
-    },
-    acc_errs: MatMulAccErrs {
-      acc_left_Q_x: acc_holder.acc_errs[0].0[0],
-      acc_left_x: acc_holder.acc_errs[0].0[1],
-      acc_part_corr1: acc_holder.acc_errs[0].0[2],
-      acc_gt: acc_holder.acc_errs[0].3[0],
-    },
-  };
-  acc_proof
-}
-
-fn matmul_acc_to_acc_holder<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(
-  acc: MatMulAccProof<P, Q>,
-  is_prover: bool,
-) -> AccHolder<P, Q> {
-  let acc_g2 = vec![acc.fiat_shamir.acc_flat_B_g2, acc.fiat_shamir.acc_beta_pow_g2];
-  let mu = acc.mu;
-  let errs = vec![(
-    vec![acc.errs.acc_left_Q_x, acc.errs.acc_left_x, acc.errs.acc_part_corr1],
-    vec![],
-    vec![],
-    vec![acc.errs.acc_gt],
-  )];
-  let acc_errs = vec![(
-    vec![acc.acc_errs.acc_left_Q_x, acc.acc_errs.acc_left_x, acc.acc_errs.acc_part_corr1],
-    vec![],
-    vec![],
-    vec![acc.acc_errs.acc_gt],
-  )];
-  if is_prover {
-    let prover_only = acc.prover_only.unwrap();
-    let acc_g1 = vec![
-      acc.fiat_shamir.acc_left_x,
-      acc.fiat_shamir.acc_left_Q_x,
-      acc.fiat_shamir.acc_left_zero,
-      acc.fiat_shamir.acc_left_zero_div,
-      acc.fiat_shamir.acc_right_x,
-      acc.fiat_shamir.acc_right_Q_x,
-      acc.fiat_shamir.acc_right_zero_div,
-      acc.acc_corr[0],
-      acc.acc_corr[1],
-      acc.acc_corr[2],
-      acc.acc_corr[3],
-      acc.fiat_shamir.acc_flat_A,
-      acc.fiat_shamir.acc_flat_B,
-      acc.fiat_shamir.acc_flat_C,
-      prover_only.acc_part_corr1,
-      prover_only.acc_flat_A_no_blind,
-      prover_only.acc_flat_B_no_blind,
-    ];
-    let acc_fr = vec![prover_only.acc_flat_A_r, prover_only.acc_flat_B_r];
-    AccHolder {
-      acc_g1,
-      acc_g2,
-      acc_fr,
-      mu,
-      errs,
-      acc_errs,
-    }
-  } else {
-    let acc_g1 = vec![
-      acc.fiat_shamir.acc_left_x,
-      acc.fiat_shamir.acc_left_Q_x,
-      acc.fiat_shamir.acc_left_zero,
-      acc.fiat_shamir.acc_left_zero_div,
-      acc.fiat_shamir.acc_right_x,
-      acc.fiat_shamir.acc_right_Q_x,
-      acc.fiat_shamir.acc_right_zero_div,
-      acc.acc_corr[0],
-      acc.acc_corr[1],
-      acc.acc_corr[2],
-      acc.acc_corr[3],
-      acc.fiat_shamir.acc_flat_A,
-      acc.fiat_shamir.acc_flat_B,
-      acc.fiat_shamir.acc_flat_C,
-    ];
-    AccHolder {
-      acc_g1,
-      acc_g2,
-      acc_fr: vec![],
-      mu,
-      errs,
-      acc_errs,
-    }
   }
 }
 
@@ -765,7 +603,7 @@ impl BasicBlock for MatMulBasicBlock {
     if acc_proof.0.len() == 0 && acc_proof.1.len() == 0 && acc_proof.2.len() == 0 {
       return holder_to_acc_proof(proof);
     }
-    let acc_proof = acc_proof_to_acc(self, acc_proof, true);
+    let acc_proof = acc_proof_to_holder(self, acc_proof, true);
     holder_to_acc_proof(self.mira_prove(srs, acc_proof, proof, rng))
   }
 
@@ -775,19 +613,19 @@ impl BasicBlock for MatMulBasicBlock {
     proof: (&Vec<G1Projective>, &Vec<G2Projective>, &Vec<Fr>),
     acc_proof: AccProofProjRef,
   ) -> ((Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>), AccProofAff) {
-    let mut acc_holder = acc_proof_to_acc(self, acc_proof, true);
+    let mut acc_holder = acc_proof_to_holder(self, acc_proof, true);
     // acc_corr1 = acc_part_corr1 * mu + acc_flat_A_no_blind * acc_flat_B_r + acc_flat_B_no_blind * acc_flat_A_r + srs.Y1P * acc_flat_A_r * acc_flat_B_r
-    acc_holder.acc_g1[7] = acc_holder.acc_g1[14] * acc_holder.mu
-      + acc_holder.acc_g1[15] * acc_holder.acc_fr[1]
-      + acc_holder.acc_g1[16] * acc_holder.acc_fr[0]
-      + srs.Y1P * acc_holder.acc_fr[0] * acc_holder.acc_fr[1];
+    acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Corr1)] = acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Part_corr1)] * acc_holder.mu
+      + acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A_no_blind)] * acc_holder.acc_fr[MatMulFrTerms::idx(MatMulFrTerms::Flat_B_r)]
+      + acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_B_no_blind)] * acc_holder.acc_fr[MatMulFrTerms::idx(MatMulFrTerms::Flat_A_r)]
+      + srs.Y1P * acc_holder.acc_fr[MatMulFrTerms::idx(MatMulFrTerms::Flat_A_r)] * acc_holder.acc_fr[MatMulFrTerms::idx(MatMulFrTerms::Flat_B_r)];
     // remove blinding terms from acc proof for the verifier
-    acc_holder.acc_g1 = acc_holder.acc_g1[..acc_holder.acc_g1.len() - 3].to_vec();
+    acc_holder.acc_g1 = acc_holder.acc_g1[..MatMulG1Terms::PUBLIC_COUNT].to_vec();
     acc_holder.acc_fr = vec![];
     let acc_proof = holder_to_acc_proof(acc_holder);
 
     // remove blinding terms from bb proof for the verifier
-    let cqlin_proof = (proof.0[..proof.0.len() - 3].to_vec(), proof.1.to_vec(), vec![]);
+    let cqlin_proof = (proof.0[..MatMulG1Terms::PUBLIC_COUNT].to_vec(), proof.1.to_vec(), vec![]);
 
     (
       (
@@ -867,29 +705,42 @@ impl BasicBlock for MatMulBasicBlock {
       return Some(result);
     }
     let proof = self.verifier_proof_to_acc(proof);
-    let prev_acc_holder = acc_proof_to_acc(self, prev_acc_proof, false);
-    let acc_holder = acc_proof_to_acc(self, acc_proof, false);
+    let prev_acc_holder = acc_proof_to_holder(self, prev_acc_proof, false);
+    let acc_holder = acc_proof_to_holder(self, acc_proof, false);
     result &= self.mira_verify(prev_acc_holder, proof, acc_holder, rng).unwrap();
     Some(result)
   }
 
   fn acc_decide(&self, srs: &SRS, acc_proof: AccProofAffRef) -> Vec<(PairingCheck, PairingOutput<Bn<ark_bn254::Config>>)> {
-    let acc_holder = acc_proof_to_acc(self, acc_proof, false);
-    let [acc_left_x, acc_left_Q_x, acc_left_zero, acc_left_zero_div, acc_right_x, acc_right_Q_x, acc_right_zero_div, acc_corr1, acc_corr2, acc_corr3, acc_corr4, acc_flat_A, acc_flat_B, acc_flat_C] =
-      acc_holder.acc_g1[..]
-    else {
-      panic!("Wrong acc proof format")
-    };
-    let [acc_flat_B_g2, beta_pow_g2] = acc_holder.acc_g2[..] else {
-      panic!("Wrong acc proof format")
-    };
+    let acc_holder = acc_proof_to_holder(self, acc_proof, false);
+    let acc_left_x = acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Left_x)];
+    let acc_left_Q_x = acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Left_Q_x)];
+    let acc_left_zero = acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Left_zero)];
+    let acc_left_zero_div = acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Left_zero_div)];
+    let acc_right_x = acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Right_x)];
+    let acc_right_Q_x = acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Right_Q_x)];
+    let acc_right_zero_div = acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Right_zero_div)];
+    let acc_corr1 = acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Corr1)];
+    let acc_corr2 = acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Corr2)];
+    let acc_corr3 = acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Corr3)];
+    let acc_corr4 = acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Corr4)];
+    let acc_flat_A = acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A)];
+    let acc_flat_B = acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_B)];
+    let acc_flat_C = acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_C)];
+
+    let acc_flat_B_g2 = acc_holder.acc_g2[MatMulG2Terms::idx(MatMulG2Terms::Flat_B_g2)];
+    let beta_pow_g2 = acc_holder.acc_g2[MatMulG2Terms::idx(MatMulG2Terms::Beta_pow_g2)];
+
     let acc_mu = acc_holder.mu;
     let err_1 = &acc_holder.acc_errs[0];
 
     let mut temp: PairingCheck = vec![];
-    temp.push((err_1.0[0], (srs.X2A[self.m] - srs.X2A[0]).into()));
-    temp.push((err_1.0[1], srs.X2A[0]));
-    temp.push((err_1.0[2], srs.Y2A));
+    temp.push((
+      err_1.0[MatMulErrG1Terms::idx(MatMulErrG1Terms::Err_Q).1],
+      (srs.X2A[self.m] - srs.X2A[0]).into(),
+    ));
+    temp.push((err_1.0[MatMulErrG1Terms::idx(MatMulErrG1Terms::Err_l).1], srs.X2A[0]));
+    temp.push((err_1.0[MatMulErrG1Terms::idx(MatMulErrG1Terms::Err_C).1], srs.Y2A));
 
     let mut acc_1: PairingCheck = vec![
       (acc_flat_A, acc_flat_B_g2),
@@ -923,7 +774,7 @@ impl BasicBlock for MatMulBasicBlock {
 
     let pairing_zero = PairingOutput::<Bn<ark_bn254::Config>>::zero();
     vec![
-      (acc_1, err_1.3[0]),
+      (acc_1, err_1.3[MatMulErrGtTerms::idx(MatMulErrGtTerms::Err_Gt).1]),
       (acc_2, pairing_zero),
       (acc_3, pairing_zero),
       (acc_4, pairing_zero),
@@ -932,7 +783,7 @@ impl BasicBlock for MatMulBasicBlock {
   }
 
   fn acc_finalize(&self, _srs: &SRS, acc_proof: AccProofAffRef) -> AccProofAff {
-    let mut acc_holder = acc_proof_to_acc(self, acc_proof, false);
+    let mut acc_holder = acc_proof_to_holder(self, acc_proof, false);
     let err_1 = &acc_holder.acc_errs[0];
     let acc_err1 = err_1.3[0].clone();
     acc_holder.errs = vec![];

--- a/src/basic_block/matmul.rs
+++ b/src/basic_block/matmul.rs
@@ -189,7 +189,9 @@ impl AccProofLayout for MatMulBasicBlock {
     // Fiat-Shamir
     let mut bytes = Vec::new();
     acc_1.acc_g1[..MatMulG1Terms::idx(MatMulG1Terms::Corr1)].serialize_uncompressed(&mut bytes).unwrap();
-    acc_1.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A)..MatMulG1Terms::idx(MatMulG1Terms::Part_corr1)].serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A)..MatMulG1Terms::idx(MatMulG1Terms::Part_corr1)]
+      .serialize_uncompressed(&mut bytes)
+      .unwrap();
     acc_1.acc_g2.serialize_uncompressed(&mut bytes).unwrap();
     acc_2.acc_g1[..MatMulG1Terms::idx(MatMulG1Terms::Corr1)].serialize_uncompressed(&mut bytes).unwrap();
     acc_2.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A)..MatMulG1Terms::idx(MatMulG1Terms::Part_corr1)]
@@ -623,11 +625,12 @@ impl BasicBlock for MatMulBasicBlock {
     acc_proof: AccProofProjRef,
   ) -> ((Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>), AccProofAff) {
     let mut acc_holder = acc_proof_to_holder(self, acc_proof, true);
-    // acc_corr1 = acc_part_corr1 * mu + acc_flat_A_no_blind * acc_flat_B_r + acc_flat_B_no_blind * acc_flat_A_r + srs.Y1P * acc_flat_A_r * acc_flat_B_r
+
     acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Corr1)] = acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Part_corr1)] * acc_holder.mu
       + acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A_no_blind)] * acc_holder.acc_fr[MatMulFrTerms::idx(MatMulFrTerms::Flat_B_r)]
       + acc_holder.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_B_no_blind)] * acc_holder.acc_fr[MatMulFrTerms::idx(MatMulFrTerms::Flat_A_r)]
       + srs.Y1P * acc_holder.acc_fr[MatMulFrTerms::idx(MatMulFrTerms::Flat_A_r)] * acc_holder.acc_fr[MatMulFrTerms::idx(MatMulFrTerms::Flat_B_r)];
+
     // remove blinding terms from acc proof for the verifier
     acc_holder.acc_g1 = acc_holder.acc_g1[..MatMulG1Terms::PUBLIC_COUNT].to_vec();
     acc_holder.acc_fr = vec![];

--- a/src/basic_block/matmul.rs
+++ b/src/basic_block/matmul.rs
@@ -189,9 +189,7 @@ impl AccProofLayout for MatMulBasicBlock {
     // Fiat-Shamir
     let mut bytes = Vec::new();
     acc_1.acc_g1[..MatMulG1Terms::idx(MatMulG1Terms::Corr1)].serialize_uncompressed(&mut bytes).unwrap();
-    acc_1.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A)..MatMulG1Terms::idx(MatMulG1Terms::Part_corr1)]
-      .serialize_uncompressed(&mut bytes)
-      .unwrap();
+    acc_1.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A)..MatMulG1Terms::idx(MatMulG1Terms::Part_corr1)].serialize_uncompressed(&mut bytes).unwrap();
     acc_1.acc_g2.serialize_uncompressed(&mut bytes).unwrap();
     acc_2.acc_g1[..MatMulG1Terms::idx(MatMulG1Terms::Corr1)].serialize_uncompressed(&mut bytes).unwrap();
     acc_2.acc_g1[MatMulG1Terms::idx(MatMulG1Terms::Flat_A)..MatMulG1Terms::idx(MatMulG1Terms::Part_corr1)]

--- a/src/basic_block/permute.rs
+++ b/src/basic_block/permute.rs
@@ -1,9 +1,11 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
+use super::matmul::MatMulG2Terms;
 use super::{
   AccProofAff, AccProofAffRef, AccProofProj, AccProofProjRef, BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS,
 };
 use crate::util::{self, acc_proof_to_holder, calc_pow, holder_to_acc_proof, AccHolder, AccProofLayout};
+use crate::{define_acc_err_terms, define_acc_terms};
 use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::bn::Bn;
 use ark_ec::pairing::{Pairing, PairingOutput};
@@ -15,17 +17,51 @@ use ark_std::{ops::Mul, ops::Sub, One, UniformRand, Zero};
 use ndarray::{Array, ArrayD, Axis};
 use rand::{rngs::StdRng, SeedableRng};
 
+define_acc_terms!(
+  PermuteG1Terms,
+  [
+    Left_x,
+    Left_Q_x,
+    Left_zero,
+    Left_zero_div,
+    Right_x,
+    Right_Q_x,
+    Right_zero_div,
+    Corr1,
+    Corr2,
+    Corr3,
+    Corr4,
+    Flat_L,
+    Flat_R
+  ],
+  []
+);
+define_acc_terms!(PermuteG2Terms, [B_g2, D_g2], []);
+define_acc_terms!(PermuteFrTerms, [], []);
+define_acc_err_terms!(PermuteErrG1Terms);
+define_acc_err_terms!(PermuteErrG2Terms);
+define_acc_err_terms!(PermuteErrFrTerms);
+define_acc_err_terms!(PermuteErrGtTerms);
+
 impl AccProofLayout for PermuteBasicBlock {
+  type AccG1Terms = PermuteG1Terms;
+  type AccG2Terms = PermuteG2Terms;
+  type AccFrTerms = PermuteFrTerms;
+  type ErrG1Terms = PermuteErrG1Terms;
+  type ErrG2Terms = PermuteErrG2Terms;
+  type ErrFrTerms = PermuteErrFrTerms;
+  type ErrGtTerms = PermuteErrGtTerms;
+
   fn acc_g1_num(&self, _is_prover: bool) -> usize {
-    13
+    PermuteG1Terms::COUNT
   }
 
   fn acc_g2_num(&self, _is_prover: bool) -> usize {
-    2
+    PermuteG2Terms::COUNT
   }
 
   fn acc_fr_num(&self, _is_prover: bool) -> usize {
-    0
+    PermuteFrTerms::COUNT
   }
 
   fn prover_proof_to_acc(&self, proof: (&Vec<G1Projective>, &Vec<G2Projective>, &Vec<Fr>)) -> AccHolder<G1Projective, G2Projective> {
@@ -57,8 +93,6 @@ impl AccProofLayout for PermuteBasicBlock {
     acc_2: AccHolder<G1Projective, G2Projective>,
     rng: &mut StdRng,
   ) -> AccHolder<G1Projective, G2Projective> {
-    let [b_g2, d_g2] = acc_2.acc_g2[..] else { panic!("Wrong proof format") };
-
     let mut new_acc_holder = AccHolder {
       acc_g1: Vec::new(),
       acc_g2: Vec::new(),
@@ -68,10 +102,6 @@ impl AccProofLayout for PermuteBasicBlock {
       acc_errs: Vec::new(),
     };
 
-    let [acc_b_g2, acc_d_g2] = acc_1.acc_g2[..] else {
-      panic!("Wrong acc proof format")
-    };
-    let acc_mu = acc_1.mu;
     // Fiat-Shamir
     let mut bytes = Vec::new();
     acc_1.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
@@ -83,7 +113,7 @@ impl AccProofLayout for PermuteBasicBlock {
 
     new_acc_holder.acc_g1 = acc_2.acc_g1.iter().zip(acc_1.acc_g1.iter()).map(|(x, y)| *x * acc_gamma + y).collect();
     new_acc_holder.acc_g2 = acc_1.acc_g2.clone();
-    new_acc_holder.mu = acc_mu + acc_gamma * acc_2.mu;
+    new_acc_holder.mu = acc_1.mu + acc_gamma * acc_2.mu;
     new_acc_holder
   }
 
@@ -527,8 +557,8 @@ impl BasicBlock for PermuteBasicBlock {
     let temp: Vec<_> = (0..n2).map(|i| output[i].g1).collect();
     let flat_R: G1Affine = util::msm::<G1Projective>(&temp, &c).into();
 
-    result &= acc_proof.1[0] == b_g2 && acc_proof.1[1] == d_g2;
-    result &= proof.0[11] == flat_L && proof.0[12] == flat_R;
+    result &= acc_proof.1[PermuteG2Terms::idx(PermuteG2Terms::B_g2)] == b_g2 && acc_proof.1[PermuteG2Terms::idx(PermuteG2Terms::D_g2)] == d_g2;
+    result &= proof.0[PermuteG1Terms::idx(PermuteG1Terms::Flat_L)] == flat_L && proof.0[PermuteG1Terms::idx(PermuteG1Terms::Flat_R)] == flat_R;
     if prev_acc_proof.2.len() == 0 && acc_proof.2[0].is_one() {
       return Some(result);
     }
@@ -543,14 +573,23 @@ impl BasicBlock for PermuteBasicBlock {
   fn acc_decide(&self, srs: &SRS, acc_proof: AccProofAffRef) -> Vec<(PairingCheck, PairingOutput<Bn<ark_bn254::Config>>)> {
     let m2 = self.permutation.1.len();
     let acc_holder = acc_proof_to_holder(self, acc_proof, false);
-    let [acc_left_x, acc_left_Q_x, acc_left_zero, acc_left_zero_div, acc_right_x, acc_right_Q_x, acc_right_zero_div, acc_corr1, acc_corr2, acc_corr3, acc_corr4, acc_flat_L, acc_flat_R] =
-      acc_holder.acc_g1[..]
-    else {
-      panic!("Wrong acc proof format")
-    };
-    let [acc_b_g2, acc_d_g2] = acc_holder.acc_g2[..] else {
-      panic!("Wrong acc proof format")
-    };
+
+    let acc_left_x = acc_holder.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Left_x)];
+    let acc_left_Q_x = acc_holder.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Left_Q_x)];
+    let acc_left_zero = acc_holder.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Left_zero)];
+    let acc_left_zero_div = acc_holder.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Left_zero_div)];
+    let acc_right_x = acc_holder.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Right_x)];
+    let acc_right_Q_x = acc_holder.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Right_Q_x)];
+    let acc_right_zero_div = acc_holder.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Right_zero_div)];
+    let acc_corr1 = acc_holder.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Corr1)];
+    let acc_corr2 = acc_holder.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Corr2)];
+    let acc_corr3 = acc_holder.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Corr3)];
+    let acc_corr4 = acc_holder.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Corr4)];
+    let acc_flat_L = acc_holder.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Flat_L)];
+    let acc_flat_R = acc_holder.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Flat_R)];
+
+    let acc_b_g2 = acc_holder.acc_g2[PermuteG2Terms::idx(PermuteG2Terms::B_g2)];
+    let acc_d_g2 = acc_holder.acc_g2[PermuteG2Terms::idx(PermuteG2Terms::D_g2)];
 
     let acc_1: PairingCheck = vec![
       (acc_flat_L, acc_b_g2),

--- a/src/basic_block/permute.rs
+++ b/src/basic_block/permute.rs
@@ -3,7 +3,7 @@
 use super::{
   AccProofAff, AccProofAffRef, AccProofProj, AccProofProjRef, BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS,
 };
-use crate::util::{self, acc_to_acc_proof, calc_pow, AccHolder};
+use crate::util::{self, acc_proof_to_acc, acc_to_acc_proof, calc_pow, AccHolder, AccProofLayout};
 use ark_bn254::{Bn254, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::bn::Bn;
 use ark_ec::pairing::{Pairing, PairingOutput};
@@ -15,153 +15,104 @@ use ark_std::{ops::Mul, ops::Sub, One, UniformRand, Zero};
 use ndarray::{Array, ArrayD, Axis};
 use rand::{rngs::StdRng, SeedableRng};
 
-// [acc_left_x, acc_left_Q_x, acc_left_zero, acc_left_zero_div, acc_right_x, acc_right_Q_x, acc_right_zero_div, acc_corr1, acc_corr2, acc_corr3, acc_corr4, acc_flat_L, acc_flat_R]
-//acc_b_g2, acc_d_g2
+impl AccProofLayout for PermuteBasicBlock {
+  fn acc_g1_num(&self, _is_prover: bool) -> usize {
+    13
+  }
 
-struct PermuteAccProof<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize> {
-  fiat_shamir: PermuteAccFiatShamir<P, Q>,
-  acc_corr: [P; 4],
-  mu: Fr,
-}
+  fn acc_g2_num(&self, _is_prover: bool) -> usize {
+    2
+  }
 
-#[derive(CanonicalSerialize)]
-struct PermuteAccFiatShamir<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize> {
-  acc_left_x: P,
-  acc_left_Q_x: P,
-  acc_left_zero: P,
-  acc_left_zero_div: P,
-  acc_right_x: P,
-  acc_right_Q_x: P,
-  acc_right_zero_div: P,
-  acc_flat_L: P,
-  acc_flat_R: P,
-  acc_b_g2: Q,
-  acc_d_g2: Q,
-}
+  fn acc_fr_num(&self, _is_prover: bool) -> usize {
+    0
+  }
 
-fn accumulate(
-  permute_acc: &PermuteAccProof<G1Projective, G2Projective>,
-  proof: &(&Vec<G1Projective>, &Vec<G2Projective>, &Vec<Fr>),
-  acc_gamma: Fr,
-) -> PermuteAccProof<G1Projective, G2Projective> {
-  let [left_x, left_Q_x, left_zero, left_zero_div, right_x, right_Q_x, right_zero_div, corr1, corr2, corr3, corr4, flat_L, flat_R] = proof.0[..]
-  else {
-    panic!("Wrong proof format")
-  };
+  fn prover_proof_to_acc(&self, proof: (&Vec<G1Projective>, &Vec<G2Projective>, &Vec<Fr>)) -> AccHolder<G1Projective, G2Projective> {
+    AccHolder {
+      acc_g1: proof.0.clone(),
+      acc_g2: proof.1.clone(),
+      acc_fr: Vec::new(),
+      mu: Fr::one(),
+      errs: Vec::new(),
+      acc_errs: Vec::new(),
+    }
+  }
 
-  // Compute the error
-  let new_matmul_acc = PermuteAccProof {
-    fiat_shamir: PermuteAccFiatShamir {
-      acc_left_x: permute_acc.fiat_shamir.acc_left_x + left_x * acc_gamma,
-      acc_left_Q_x: permute_acc.fiat_shamir.acc_left_Q_x + left_Q_x * acc_gamma,
-      acc_left_zero: permute_acc.fiat_shamir.acc_left_zero + left_zero * acc_gamma,
-      acc_left_zero_div: permute_acc.fiat_shamir.acc_left_zero_div + left_zero_div * acc_gamma,
-      acc_right_x: permute_acc.fiat_shamir.acc_right_x + right_x * acc_gamma,
-      acc_right_Q_x: permute_acc.fiat_shamir.acc_right_Q_x + right_Q_x * acc_gamma,
-      acc_right_zero_div: permute_acc.fiat_shamir.acc_right_zero_div + right_zero_div * acc_gamma,
-      acc_flat_L: permute_acc.fiat_shamir.acc_flat_L + flat_L * acc_gamma,
-      acc_flat_R: permute_acc.fiat_shamir.acc_flat_R + flat_R * acc_gamma,
-      acc_b_g2: permute_acc.fiat_shamir.acc_b_g2,
-      acc_d_g2: permute_acc.fiat_shamir.acc_d_g2,
-    },
-    acc_corr: [
-      permute_acc.acc_corr[0] + corr1 * acc_gamma,
-      permute_acc.acc_corr[1] + corr2 * acc_gamma,
-      permute_acc.acc_corr[2] + corr3 * acc_gamma,
-      permute_acc.acc_corr[3] + corr4 * acc_gamma,
-    ],
-    mu: permute_acc.mu + acc_gamma,
-  };
+  fn verifier_proof_to_acc(&self, proof: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>)) -> AccHolder<G1Affine, G2Affine> {
+    AccHolder {
+      acc_g1: proof.0.clone(),
+      acc_g2: proof.1.clone(),
+      acc_fr: Vec::new(),
+      mu: Fr::one(),
+      errs: Vec::new(),
+      acc_errs: Vec::new(),
+    }
+  }
 
-  new_matmul_acc
-}
+  fn mira_prove(
+    &self,
+    _srs: &SRS,
+    acc_1: AccHolder<G1Projective, G2Projective>,
+    acc_2: AccHolder<G1Projective, G2Projective>,
+    rng: &mut StdRng,
+  ) -> AccHolder<G1Projective, G2Projective> {
+    let [b_g2, d_g2] = acc_2.acc_g2[..] else { panic!("Wrong proof format") };
 
-fn acc_proof_to_permute_acc_holder<P: Copy, Q: Copy>(
-  acc_proof: (&Vec<P>, &Vec<Q>, &Vec<Fr>, &Vec<PairingOutput<Bn<ark_bn254::Config>>>),
-) -> AccHolder<P, Q> {
-  if acc_proof.0.len() == 0 && acc_proof.1.len() == 0 && acc_proof.2.len() == 0 {
-    return AccHolder {
-      acc_g1: vec![],
-      acc_g2: vec![],
-      acc_fr: vec![],
+    let mut new_acc_holder = AccHolder {
+      acc_g1: Vec::new(),
+      acc_g2: Vec::new(),
+      acc_fr: Vec::new(),
       mu: Fr::zero(),
-      errs: vec![],
-      acc_errs: vec![],
+      errs: Vec::new(),
+      acc_errs: Vec::new(),
     };
+
+    let [acc_b_g2, acc_d_g2] = acc_1.acc_g2[..] else {
+      panic!("Wrong acc proof format")
+    };
+    let acc_mu = acc_1.mu;
+    // Fiat-Shamir
+    let mut bytes = Vec::new();
+    acc_1.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g1[11..13].serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.acc_g1[11..13].serialize_uncompressed(&mut bytes).unwrap();
+    util::add_randomness(rng, bytes);
+    let acc_gamma = Fr::rand(rng);
+
+    new_acc_holder.acc_g1 = acc_2.acc_g1.iter().zip(acc_1.acc_g1.iter()).map(|(x, y)| *x * acc_gamma + y).collect();
+    new_acc_holder.acc_g2 = acc_1.acc_g2.clone();
+    new_acc_holder.mu = acc_mu + acc_gamma * acc_2.mu;
+    new_acc_holder
   }
 
-  let acc_g1_num = 13;
+  fn mira_verify(
+    &self,
+    acc_1: AccHolder<G1Affine, G2Affine>,
+    acc_2: AccHolder<G1Affine, G2Affine>,
+    new_acc: AccHolder<G1Affine, G2Affine>,
+    rng: &mut StdRng,
+  ) -> Option<bool> {
+    let mut result = true;
+    // Fiat-Shamir
+    let mut bytes = Vec::new();
+    acc_1.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g1[11..13].serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.acc_g1[11..13].serialize_uncompressed(&mut bytes).unwrap();
+    util::add_randomness(rng, bytes);
+    let acc_gamma = Fr::rand(rng);
 
-  AccHolder {
-    acc_g1: acc_proof.0[..acc_g1_num].to_vec(),
-    acc_g2: acc_proof.1[..2].to_vec(),
-    acc_fr: vec![],
-    mu: acc_proof.2[0],
-    errs: vec![],
-    acc_errs: vec![],
+    acc_2.acc_g1.iter().enumerate().for_each(|(i, x)| {
+      let z = *x * acc_gamma + acc_1.acc_g1[i];
+      result &= new_acc.acc_g1[i] == z;
+    });
+    result &= new_acc.acc_g2[0] == acc_1.acc_g2[0];
+    result &= new_acc.acc_g2[1] == acc_1.acc_g2[1];
+    result &= new_acc.mu == acc_1.mu + acc_gamma * acc_2.mu;
+    Some(result)
   }
-}
-
-fn permute_acc_holder_to_acc<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(acc_holder: AccHolder<P, Q>) -> PermuteAccProof<P, Q> {
-  PermuteAccProof {
-    fiat_shamir: PermuteAccFiatShamir {
-      acc_left_x: acc_holder.acc_g1[0],
-      acc_left_Q_x: acc_holder.acc_g1[1],
-      acc_left_zero: acc_holder.acc_g1[2],
-      acc_left_zero_div: acc_holder.acc_g1[3],
-      acc_right_x: acc_holder.acc_g1[4],
-      acc_right_Q_x: acc_holder.acc_g1[5],
-      acc_right_zero_div: acc_holder.acc_g1[6],
-      acc_flat_L: acc_holder.acc_g1[11],
-      acc_flat_R: acc_holder.acc_g1[12],
-      acc_b_g2: acc_holder.acc_g2[0],
-      acc_d_g2: acc_holder.acc_g2[1],
-    },
-    acc_corr: [acc_holder.acc_g1[7], acc_holder.acc_g1[8], acc_holder.acc_g1[9], acc_holder.acc_g1[10]],
-    mu: acc_holder.mu,
-  }
-}
-
-fn permute_acc_to_acc_holder<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(acc: PermuteAccProof<P, Q>) -> AccHolder<P, Q> {
-  AccHolder {
-    acc_g1: vec![
-      acc.fiat_shamir.acc_left_x,
-      acc.fiat_shamir.acc_left_Q_x,
-      acc.fiat_shamir.acc_left_zero,
-      acc.fiat_shamir.acc_left_zero_div,
-      acc.fiat_shamir.acc_right_x,
-      acc.fiat_shamir.acc_right_Q_x,
-      acc.fiat_shamir.acc_right_zero_div,
-      acc.acc_corr[0],
-      acc.acc_corr[1],
-      acc.acc_corr[2],
-      acc.acc_corr[3],
-      acc.fiat_shamir.acc_flat_L,
-      acc.fiat_shamir.acc_flat_R,
-    ],
-    acc_g2: vec![acc.fiat_shamir.acc_b_g2, acc.fiat_shamir.acc_d_g2],
-    acc_fr: vec![],
-    mu: acc.mu,
-    errs: vec![],
-    acc_errs: vec![],
-  }
-}
-
-fn acc_proof_to_permute_acc<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(
-  acc_proof: (&Vec<P>, &Vec<Q>, &Vec<Fr>, &Vec<PairingOutput<Bn<ark_bn254::Config>>>),
-) -> Option<PermuteAccProof<P, Q>> {
-  if acc_proof.0.len() == 0 && acc_proof.1.len() == 0 && acc_proof.2.len() == 0 {
-    return None;
-  }
-  let acc_holder = acc_proof_to_permute_acc_holder(acc_proof);
-  Some(permute_acc_holder_to_acc(acc_holder))
-}
-
-fn permute_acc_to_acc_proof<P: Copy + CanonicalSerialize, Q: Copy + CanonicalSerialize>(
-  acc: PermuteAccProof<P, Q>,
-) -> (Vec<P>, Vec<Q>, Vec<Fr>, Vec<PairingOutput<Bn<ark_bn254::Config>>>) {
-  let acc_holder = permute_acc_to_acc_holder(acc);
-  acc_to_acc_proof(acc_holder)
 }
 
 #[derive(Debug)]
@@ -341,6 +292,7 @@ impl BasicBlock for PermuteBasicBlock {
     return (proof, proof2, Vec::new());
   }
 
+  #[cfg(not(feature = "fold"))]
   fn verify(
     &self,
     srs: &SRS,
@@ -445,6 +397,27 @@ impl BasicBlock for PermuteBasicBlock {
     checks
   }
 
+  #[cfg(feature = "fold")]
+  fn verify(
+    &self,
+    _srs: &SRS,
+    _model: &ArrayD<DataEnc>,
+    _inputs: &Vec<&ArrayD<DataEnc>>,
+    _outputs: &Vec<&ArrayD<DataEnc>>,
+    _proof: (&Vec<G1Affine>, &Vec<G2Affine>, &Vec<Fr>),
+    rng: &mut StdRng,
+    cache: ProveVerifyCache,
+  ) -> Vec<PairingCheck> {
+    let _alpha = {
+      let mut cache = cache.lock().unwrap();
+      let CacheValues::RLCRandom(alpha) = cache.entry("permute_alpha".to_owned()).or_insert_with(|| CacheValues::RLCRandom(Fr::rand(rng))) else {
+        panic!("Cache type error")
+      };
+      alpha.clone()
+    };
+    vec![]
+  }
+
   fn acc_prove(
     &self,
     srs: &SRS,
@@ -456,25 +429,12 @@ impl BasicBlock for PermuteBasicBlock {
     rng: &mut StdRng,
     _cache: ProveVerifyCache,
   ) -> AccProofProj {
-    let [b_g2, d_g2] = proof.1[..] else { panic!("Wrong proof format") };
-
-    let permute_acc = acc_proof_to_permute_acc(acc_proof).unwrap();
-
-    let [acc_b_g2, acc_d_g2] = [permute_acc.fiat_shamir.acc_b_g2, permute_acc.fiat_shamir.acc_d_g2];
-    assert!(b_g2 == acc_b_g2 && d_g2 == acc_d_g2);
-
-    // Compute the error (but we skip it because permuteBB has no error)
-
-    // Fiat-Shamir
-    let mut bytes = Vec::new();
-    permute_acc.fiat_shamir.serialize_uncompressed(&mut bytes).unwrap();
-    proof.0[..7].serialize_uncompressed(&mut bytes).unwrap();
-    proof.0[11..13].serialize_uncompressed(&mut bytes).unwrap();
-    util::add_randomness(rng, bytes);
-    let acc_gamma = Fr::rand(rng);
-
-    let new_permute_acc = accumulate(&permute_acc, &proof, acc_gamma);
-    permute_acc_to_acc_proof(new_permute_acc)
+    let proof = self.prover_proof_to_acc(proof);
+    if acc_proof.0.len() == 0 && acc_proof.1.len() == 0 && acc_proof.2.len() == 0 {
+      return acc_to_acc_proof(proof);
+    }
+    let acc_proof = acc_proof_to_acc(self, acc_proof, true);
+    acc_to_acc_proof(self.mira_prove(srs, acc_proof, proof, rng))
   }
 
   fn acc_clean(
@@ -483,16 +443,19 @@ impl BasicBlock for PermuteBasicBlock {
     proof: (&Vec<G1Projective>, &Vec<G2Projective>, &Vec<Fr>),
     acc_proof: AccProofProjRef,
   ) -> ((Vec<G1Affine>, Vec<G2Affine>, Vec<Fr>), AccProofAff) {
-    // remove unnecessary terms from bb proof for the verifier
-    let cqlin_proof_g1 = proof.0[..11].to_vec();
-
+    let cqlin_proof_g1 = proof.0.to_vec();
+    let cqlin_proof_g2 = proof.1.to_vec();
     (
-      (cqlin_proof_g1.iter().map(|x| (*x).into()).collect(), vec![], vec![]),
+      (
+        cqlin_proof_g1.iter().map(|x| (*x).into()).collect(),
+        cqlin_proof_g2.iter().map(|x| (*x).into()).collect(),
+        vec![],
+      ),
       (
         acc_proof.0.iter().map(|x| (*x).into()).collect(),
         acc_proof.1.iter().map(|x| (*x).into()).collect(),
         acc_proof.2.to_vec(),
-        vec![],
+        acc_proof.3.iter().map(|x| *x).collect(),
       ),
     )
   }
@@ -564,67 +527,30 @@ impl BasicBlock for PermuteBasicBlock {
     let temp: Vec<_> = (0..n2).map(|i| output[i].g1).collect();
     let flat_R: G1Affine = util::msm::<G1Projective>(&temp, &c).into();
 
-    let proof0_11_13 = vec![flat_L, flat_R];
-
-    let prev_acc = acc_proof_to_permute_acc(prev_acc_proof);
-    let acc = acc_proof_to_permute_acc(acc_proof).unwrap();
-
-    if prev_acc.is_none() || (prev_acc.as_ref().unwrap().mu.is_zero() && acc.mu.is_one()) {
-      // skip verifying RLC because no RLC was done in acc_init.
-      // Fiat-shamir
-      let mut bytes = Vec::new();
-      proof.0[..7].serialize_uncompressed(&mut bytes).unwrap();
-      proof0_11_13.serialize_uncompressed(&mut bytes).unwrap();
-      util::add_randomness(rng, bytes);
-      let _acc_gamma = Fr::rand(rng);
+    result &= acc_proof.1[0] == b_g2 && acc_proof.1[1] == d_g2;
+    result &= proof.0[11] == flat_L && proof.0[12] == flat_R;
+    if prev_acc_proof.2.len() == 0 && acc_proof.2[0].is_one() {
       return Some(result);
     }
 
-    // Fiat-Shamir
-    let mut bytes = Vec::new();
-    let prev_acc = prev_acc.unwrap();
-    prev_acc.fiat_shamir.serialize_uncompressed(&mut bytes).unwrap();
-    proof.0[..7].serialize_uncompressed(&mut bytes).unwrap();
-    proof0_11_13.serialize_uncompressed(&mut bytes).unwrap();
-    util::add_randomness(rng, bytes);
-    let acc_gamma = Fr::rand(rng);
-
-    result &= acc.fiat_shamir.acc_left_x == proof.0[0] * acc_gamma + prev_acc.fiat_shamir.acc_left_x;
-    result &= acc.fiat_shamir.acc_left_Q_x == proof.0[1] * acc_gamma + prev_acc.fiat_shamir.acc_left_Q_x;
-    result &= acc.fiat_shamir.acc_left_zero == proof.0[2] * acc_gamma + prev_acc.fiat_shamir.acc_left_zero;
-    result &= acc.fiat_shamir.acc_left_zero_div == proof.0[3] * acc_gamma + prev_acc.fiat_shamir.acc_left_zero_div;
-    result &= acc.fiat_shamir.acc_right_x == proof.0[4] * acc_gamma + prev_acc.fiat_shamir.acc_right_x;
-    result &= acc.fiat_shamir.acc_right_Q_x == proof.0[5] * acc_gamma + prev_acc.fiat_shamir.acc_right_Q_x;
-    result &= acc.fiat_shamir.acc_right_zero_div == proof.0[6] * acc_gamma + prev_acc.fiat_shamir.acc_right_zero_div;
-
-    result &= acc.fiat_shamir.acc_flat_L == flat_L * acc_gamma + prev_acc.fiat_shamir.acc_flat_L;
-    result &= acc.fiat_shamir.acc_flat_R == flat_R * acc_gamma + prev_acc.fiat_shamir.acc_flat_R;
-
-    result &= acc.fiat_shamir.acc_b_g2 == prev_acc.fiat_shamir.acc_b_g2 && b_g2 == acc.fiat_shamir.acc_b_g2;
-    result &= acc.fiat_shamir.acc_d_g2 == prev_acc.fiat_shamir.acc_d_g2 && d_g2 == acc.fiat_shamir.acc_d_g2;
-    result &= acc.mu == prev_acc.mu + acc_gamma;
+    let proof = self.verifier_proof_to_acc(proof);
+    let prev_acc_holder = acc_proof_to_acc(self, prev_acc_proof, true);
+    let acc_holder = acc_proof_to_acc(self, acc_proof, true);
+    result &= self.mira_verify(prev_acc_holder, proof, acc_holder, rng).unwrap();
     Some(result)
   }
 
   fn acc_decide(&self, srs: &SRS, acc_proof: AccProofAffRef) -> Vec<(PairingCheck, PairingOutput<Bn<ark_bn254::Config>>)> {
     let m2 = self.permutation.1.len();
-    let acc_holder = acc_proof_to_permute_acc(acc_proof).unwrap();
-
-    let acc_left_x = acc_holder.fiat_shamir.acc_left_x;
-    let acc_left_Q_x = acc_holder.fiat_shamir.acc_left_Q_x;
-    let acc_left_zero = acc_holder.fiat_shamir.acc_left_zero;
-    let acc_left_zero_div = acc_holder.fiat_shamir.acc_left_zero_div;
-    let acc_right_x = acc_holder.fiat_shamir.acc_right_x;
-    let acc_right_Q_x = acc_holder.fiat_shamir.acc_right_Q_x;
-    let acc_right_zero_div = acc_holder.fiat_shamir.acc_right_zero_div;
-    let acc_corr1 = acc_holder.acc_corr[0];
-    let acc_corr2 = acc_holder.acc_corr[1];
-    let acc_corr3 = acc_holder.acc_corr[2];
-    let acc_corr4 = acc_holder.acc_corr[3];
-    let acc_flat_L = acc_holder.fiat_shamir.acc_flat_L;
-    let acc_flat_R = acc_holder.fiat_shamir.acc_flat_R;
-    let acc_b_g2 = acc_holder.fiat_shamir.acc_b_g2;
-    let acc_d_g2 = acc_holder.fiat_shamir.acc_d_g2;
+    let acc_holder = acc_proof_to_acc(self, acc_proof, false);
+    let [acc_left_x, acc_left_Q_x, acc_left_zero, acc_left_zero_div, acc_right_x, acc_right_Q_x, acc_right_zero_div, acc_corr1, acc_corr2, acc_corr3, acc_corr4, acc_flat_L, acc_flat_R] =
+      acc_holder.acc_g1[..]
+    else {
+      panic!("Wrong acc proof format")
+    };
+    let [acc_b_g2, acc_d_g2] = acc_holder.acc_g2[..] else {
+      panic!("Wrong acc proof format")
+    };
 
     let acc_1: PairingCheck = vec![
       (acc_flat_L, acc_b_g2),

--- a/src/basic_block/permute.rs
+++ b/src/basic_block/permute.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
 use super::matmul::MatMulG2Terms;
 use super::{
   AccProofAff, AccProofAffRef, AccProofProj, AccProofProjRef, BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS,
@@ -104,10 +105,14 @@ impl AccProofLayout for PermuteBasicBlock {
 
     // Fiat-Shamir
     let mut bytes = Vec::new();
-    acc_1.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
-    acc_1.acc_g1[11..13].serialize_uncompressed(&mut bytes).unwrap();
-    acc_2.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
-    acc_2.acc_g1[11..13].serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g1[..PermuteG1Terms::idx(PermuteG1Terms::Corr1)].serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Flat_L)..PermuteG1Terms::idx(PermuteG1Terms::Flat_R) + 1]
+      .serialize_uncompressed(&mut bytes)
+      .unwrap();
+    acc_2.acc_g1[..PermuteG1Terms::idx(PermuteG1Terms::Corr1)].serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Flat_L)..PermuteG1Terms::idx(PermuteG1Terms::Flat_R) + 1]
+      .serialize_uncompressed(&mut bytes)
+      .unwrap();
     util::add_randomness(rng, bytes);
     let acc_gamma = Fr::rand(rng);
 
@@ -127,10 +132,14 @@ impl AccProofLayout for PermuteBasicBlock {
     let mut result = true;
     // Fiat-Shamir
     let mut bytes = Vec::new();
-    acc_1.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
-    acc_1.acc_g1[11..13].serialize_uncompressed(&mut bytes).unwrap();
-    acc_2.acc_g1[..7].serialize_uncompressed(&mut bytes).unwrap();
-    acc_2.acc_g1[11..13].serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g1[..PermuteG1Terms::idx(PermuteG1Terms::Corr1)].serialize_uncompressed(&mut bytes).unwrap();
+    acc_1.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Flat_L)..PermuteG1Terms::idx(PermuteG1Terms::Flat_R) + 1]
+      .serialize_uncompressed(&mut bytes)
+      .unwrap();
+    acc_2.acc_g1[..PermuteG1Terms::idx(PermuteG1Terms::Corr1)].serialize_uncompressed(&mut bytes).unwrap();
+    acc_2.acc_g1[PermuteG1Terms::idx(PermuteG1Terms::Flat_L)..PermuteG1Terms::idx(PermuteG1Terms::Flat_R) + 1]
+      .serialize_uncompressed(&mut bytes)
+      .unwrap();
     util::add_randomness(rng, bytes);
     let acc_gamma = Fr::rand(rng);
 

--- a/src/basic_block/permute.rs
+++ b/src/basic_block/permute.rs
@@ -1,7 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
-use super::matmul::MatMulG2Terms;
 use super::{
   AccProofAff, AccProofAffRef, AccProofProj, AccProofProjRef, BasicBlock, CacheValues, Data, DataEnc, PairingCheck, ProveVerifyCache, SRS,
 };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -247,6 +247,16 @@ fn testBasicBlocks() {
     &vec![&a],
   );
   let a = ArrayD::from_shape_fn(IxDyn(&[l, m]), |_| Fr::rand(&mut rng));
+  testBasicBlock(MatMulBasicBlock { m, n }, srs, &empty, &vec![&a, &b]);
+  testBasicBlock(
+    RepeaterBasicBlock {
+      basic_block: Box::new(MatMulBasicBlock { m, n }),
+      N: 2,
+    },
+    srs,
+    &empty,
+    &vec![&a, &b],
+  );
   testBasicBlock(CQLinBasicBlock { setup: c.clone() }, srs, &c, &vec![&a]);
   testBasicBlock(
     RepeaterBasicBlock {
@@ -260,7 +270,9 @@ fn testBasicBlocks() {
   let p1 = (vec![0], (0..l * m).collect::<Vec<_>>()); // Concatenate columns
   let p2 = (vec![0], (0..l * m).map(|i| (i % m) * l + (i / m)).collect::<Vec<_>>()); // Concatenate rows
   let p3 = ((0..m).map(|i| i * l).collect::<Vec<_>>(), (0..l).collect::<Vec<_>>()); // Transpose
-
+  testBasicBlock(PermuteBasicBlock { permutation: p1, n: l, m: m }, srs, &empty, &vec![&a]);
+  testBasicBlock(PermuteBasicBlock { permutation: p2, n: l, m: m }, srs, &empty, &vec![&a]);
+  testBasicBlock(PermuteBasicBlock { permutation: p3, n: l, m: m }, srs, &empty, &vec![&a]);
   let min = 1.;
   let max = 8.;
   testBasicBlock(ClipBasicBlock { min, max }, srs, &empty, &vec![&a]);


### PR DESCRIPTION
As title stated.

After discussing with @liliatangxy today, we decide to merge the PRs in the following order to prevent the master branch from being broken. 
1. Add MatMul and Permute into `mira_para` (which is to merge this PR into PR #162)
2. Add CQ and CQ2 into `mira_para`
3. Add Repeater into `mira_para`
4. Merge `mira_para` into `master`
